### PR TITLE
[test] Avoid NPE thrown by test framework in runtime.

### DIFF
--- a/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/headless/selector/TestSessionManagerListener.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/headless/selector/TestSessionManagerListener.java
@@ -14,13 +14,15 @@ import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionListener;
 import org.eclipse.sirius.business.api.session.SessionManagerListener;
 import org.eclipse.sirius.business.api.session.danalysis.DAnalysisSession;
+import org.eclipse.ui.PlatformUI;
 
 public class TestSessionManagerListener extends SessionManagerListener.Stub {
 
   @Override
   public void notify(Session updated, int notification) {
     super.notify(updated, notification);
-    if (notification == SessionListener.OPENED) {
+    boolean enableHeadless = (PlatformUI.getTestableObject().getTestHarness() != null);
+    if (notification == SessionListener.OPENED && enableHeadless) {
       ((DAnalysisSession) updated).setAnalysisSelector(HeadlessCapellaAnalysisSelector.INSTANCE);
     }
   }


### PR DESCRIPTION
When the org.polarsys.capella.test.diagram.common.ju is present and
opened in dev environment, NPE are thrown on representation creation as:
- the HeadlessCapellaAnalysisSelector is installed by the
TestSessionManagerListener on every created sessions.
- excepted for some specific tests, the selectedUri is never set


Change-Id: I17a28ce1fd3383780aeb575d4ae7f7634b0c8688
Signed-off-by: Maxime Porhel <maxime.porhel@obeo.fr>
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>