### PR TITLE
[559825] fix NPE thrown when executing a commandline with"-forceoutputfoldercreation" argument but without "-outputfolder" argument

### DIFF
--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/AbstractCommandLine.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/AbstractCommandLine.java
@@ -139,7 +139,7 @@ public class AbstractCommandLine implements ICommandLine {
     }
 
     // create outputfolder if necessary
-    if (argHelper.isCreateFolder()) {
+    if (argHelper.isCreateFolder() && argHelper.getOutputFolder() != null) {
       createOutputFolder(argHelper.getOutputFolder());
     }
     if (!projectVersionIsCompliant()) {


### PR DESCRIPTION

Change-Id: Iadacdf6baf2c5da7b9eb308c07fe149ffe383d89
Signed-off-by: Jeremy Aubry <jaubry@obeo.fr>