### PR TITLE
[553820] Move preferences customization to sirius.customization

### DIFF
--- a/common/plugins/org.polarsys.capella.common.platform.sirius.customization/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.customization/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.sirius.common,
  org.eclipse.sirius.diagram.ui,
  org.polarsys.capella.shared.id.handler,
- org.eclipse.sirius.common.ui
+ org.eclipse.sirius.common.ui,
+ org.eclipse.gmf.runtime.notation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.polarsys.capella.common.platform.sirius.customisation,

--- a/common/plugins/org.polarsys.capella.common.platform.sirius.customization/src/org/polarsys/capella/common/platform/sirius/customisation/SiriusCustomizationPlugin.java
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.customization/src/org/polarsys/capella/common/platform/sirius/customisation/SiriusCustomizationPlugin.java
@@ -17,10 +17,14 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.gmf.runtime.notation.JumpLinkStatus;
+import org.eclipse.gmf.runtime.notation.JumpLinkType;
 import org.eclipse.sirius.business.api.preferences.SiriusPreferencesKeys;
 import org.eclipse.sirius.common.tools.api.constant.CommonPreferencesConstants;
 import org.eclipse.sirius.common.tools.api.util.ReflectionHelper;
 import org.eclipse.sirius.common.ui.SiriusTransPlugin;
+import org.eclipse.sirius.diagram.DiagramPlugin;
+import org.eclipse.sirius.diagram.tools.api.preferences.SiriusDiagramCorePreferences;
 import org.eclipse.sirius.ui.business.api.preferences.SiriusUIPreferencesKeys;
 import org.eclipse.sirius.viewpoint.provider.SiriusEditPlugin;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
@@ -92,38 +96,61 @@ public class SiriusCustomizationPlugin extends AbstractUIPlugin {
 
   private void customizeSiriusDefaultPreferences() {
     // ----------------
+    
     // Preference customization for plugin "org.eclipse.sirius"
-    IEclipsePreferences defaultScope = DefaultScope.INSTANCE.getNode(org.eclipse.sirius.viewpoint.SiriusPlugin.ID);
+    IEclipsePreferences siriusPreferences = DefaultScope.INSTANCE.getNode(org.eclipse.sirius.viewpoint.SiriusPlugin.ID);
+    
     // Allow by default aird fragment with no representation creation
-    defaultScope.putBoolean(SiriusPreferencesKeys.PREF_EMPTY_AIRD_FRAGMENT_ON_CONTROL.name(), true);
+    siriusPreferences.putBoolean(SiriusPreferencesKeys.PREF_EMPTY_AIRD_FRAGMENT_ON_CONTROL.name(), true);
 
     // Re-apply command line customizations
-    applyCommandLineCustomizations(defaultScope);
+    applyCommandLineCustomizations(siriusPreferences);
 
     // ----------------
+    
     // Preference customization for plugin "org.eclipse.sirius.common.ui"
-    defaultScope = DefaultScope.INSTANCE.getNode(SiriusTransPlugin.PLUGIN_ID);
+    IEclipsePreferences transPreferences = DefaultScope.INSTANCE.getNode(SiriusTransPlugin.PLUGIN_ID);
+    
     // Disable Sirius Pre-commit listener behavior since Capella has the same one.
-    defaultScope.putBoolean(CommonPreferencesConstants.PREF_DEFENSIVE_EDIT_VALIDATION, false);
+    transPreferences.putBoolean(CommonPreferencesConstants.PREF_DEFENSIVE_EDIT_VALIDATION, false);
 
     // Re-apply command line customizations
-    applyCommandLineCustomizations(defaultScope);
+    applyCommandLineCustomizations(transPreferences);
 
     // ----------------
+    
     // Preference customization for plugin "org.eclipse.sirius.ui"
-    defaultScope = DefaultScope.INSTANCE.getNode(SiriusEditPlugin.ID);
+    IEclipsePreferences editPreferences = DefaultScope.INSTANCE.getNode(SiriusEditPlugin.ID);
     // Required since Sirius 5.1 since default behavior is not welcome
-    defaultScope.putBoolean(SiriusUIPreferencesKeys.PREF_SAVE_WHEN_NO_EDITOR.name(), false);
-    defaultScope.putBoolean(SiriusUIPreferencesKeys.PREF_RELOAD_ON_LAST_EDITOR_CLOSE.name(), false);
+    editPreferences.putBoolean(SiriusUIPreferencesKeys.PREF_SAVE_WHEN_NO_EDITOR.name(), false);
+    editPreferences.putBoolean(SiriusUIPreferencesKeys.PREF_RELOAD_ON_LAST_EDITOR_CLOSE.name(), false);
 
     // Set the default Sirius scale option (20%).
-    defaultScope.putInt(SiriusUIPreferencesKeys.PREF_SCALE_LEVEL_DIAGRAMS_ON_EXPORT.name(), 2);
+    editPreferences.putInt(SiriusUIPreferencesKeys.PREF_SCALE_LEVEL_DIAGRAMS_ON_EXPORT.name(), 2);
 
     // Don't use colors from odesign in diagram palettes
-    defaultScope.putBoolean(SiriusUIPreferencesKeys.PREF_DISPLAY_VSM_USER_FIXED_COLOR_IN_PALETTE.name(), false);
+    editPreferences.putBoolean(SiriusUIPreferencesKeys.PREF_DISPLAY_VSM_USER_FIXED_COLOR_IN_PALETTE.name(), false);
 
     // Re-apply command line customizations
-    applyCommandLineCustomizations(defaultScope);
+    applyCommandLineCustomizations(editPreferences);
+
+    // ----------------
+
+    // Preference customization for plugin "org.eclipse.sirius.diagram"
+    IEclipsePreferences diagramPreferences = DefaultScope.INSTANCE.getNode(DiagramPlugin.ID);
+
+    // By default override the Jump Link properties default values
+    diagramPreferences.putBoolean(SiriusDiagramCorePreferences.PREF_JUMP_LINK_ENABLE_OVERRIDE, true);
+    
+    // Set the jump link status as "Above"
+    diagramPreferences.putInt(SiriusDiagramCorePreferences.PREF_JUMP_LINK_STATUS, JumpLinkStatus.ABOVE);
+    
+    // Set the jump link type as "Tunnel"
+    diagramPreferences.putInt(SiriusDiagramCorePreferences.PREF_JUMP_LINK_TYPE, JumpLinkType.TUNNEL);
+    
+    // Re-apply command line customizations
+    applyCommandLineCustomizations(diagramPreferences);
+    
   }
 
   /**

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/META-INF/MANIFEST.MF
@@ -27,6 +27,5 @@ Require-Bundle: org.eclipse.ui,
  org.polarsys.capella.core.application,
  org.polarsys.capella.common.platform.sirius.customization,
  org.eclipse.sirius.diagram,
- org.polarsys.capella.common.tools.report.appenders.usage,
- org.eclipse.gmf.runtime.notation;bundle-version="1.10.0"
+ org.polarsys.capella.common.tools.report.appenders.usage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/src/org/polarsys/capella/core/platform/sirius/ui/PerspectivePlugin.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/src/org/polarsys/capella/core/platform/sirius/ui/PerspectivePlugin.java
@@ -11,14 +11,6 @@
 
 package org.polarsys.capella.core.platform.sirius.ui;
 
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.preferences.DefaultScope;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.gmf.runtime.notation.JumpLinkStatus;
-import org.eclipse.gmf.runtime.notation.JumpLinkType;
-import org.eclipse.sirius.diagram.DiagramPlugin;
-import org.eclipse.sirius.diagram.tools.api.preferences.SiriusDiagramCorePreferences;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -43,18 +35,6 @@ public class PerspectivePlugin extends AbstractUIPlugin {
   public void start(BundleContext context_p) throws Exception {
     super.start(context_p);
     __plugin = this;
-    try {
-      IEclipsePreferences diagramCoreDefaultPreferences = DefaultScope.INSTANCE.getNode(DiagramPlugin.ID);
-
-      // By default override the Jump Link properties default values
-      diagramCoreDefaultPreferences.putBoolean(SiriusDiagramCorePreferences.PREF_JUMP_LINK_ENABLE_OVERRIDE, true);
-      // Set the jump link status as "Above"
-      diagramCoreDefaultPreferences.putInt(SiriusDiagramCorePreferences.PREF_JUMP_LINK_STATUS, JumpLinkStatus.ABOVE);
-      // Set the jump link type as "Tunnel"
-      diagramCoreDefaultPreferences.putInt(SiriusDiagramCorePreferences.PREF_JUMP_LINK_TYPE, JumpLinkType.TUNNEL);
-    } catch (Exception e) {
-      getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, e.getMessage(), e));
-    }
   }
 
   /**


### PR DESCRIPTION
All sirius preferences are located into sirius.customization plugin

Change-Id: I4f6a3be5805e8ff3a0648a7573a3d16f1becce09
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>