### PR TITLE
[releng][oomph] Setup model rewritten

### DIFF
--- a/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
+++ b/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
@@ -16,748 +16,328 @@
     name="capella"
     label="Capella">
   <setupTask
-      xsi:type="setup:VariableTask"
-      name="polarsys.git.remoteURIs"
-      label="Polarsys Git Repository">
-    <choice
-        value="http://git.polarsys.org/gitroot/@{remoteURI}.git"
-        label="HTTP (read-only, anonymous, direct)"/>
-    <choice
-        value="ssh://${git.user.id|username}@git.polarsys.org/gitroot/@{remoteURI}.git"
-        label="SSH (read-write, direct)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <choice
-        value="git://git.polarsys.org/gitroot/@{remoteURI}"
-        label="Git (read-only, anonymous, direct)"/>
-    <description>Choose from the available Git URIs</description>
-  </setupTask>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="polarsys.gerrit.remoteURIs"
-      label="Polarsys Gerrit Repository">
-    <choice
-        value="https://git.polarsys.org/r/@{remoteURI}"
-        label="HTTPS (read-only, anonymous, Gerrit)"/>
-    <choice
-        value="ssh://${git.user.id|username}@git.polarsys.org:29418/@{remoteURI}"
-        label="SSH (read-write, Gerrit)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <choice
-        value="https://${git.user.id|username}@git.polarsys.org/r/@{remoteURI}"
-        label="HTTPS (read-write, Gerrit)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <description>Choose from the available remote Gerrit URIs</description>
-  </setupTask>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="polarsys.git.gerrit.remoteURIs"
-      label="Polarsys Gerrit or Git Repository">
-    <annotation
-        source="http://www.eclipse.org/oomph/setup/InheritedChoices">
-      <detail
-          key="inherit">
-        <value>polarsys.gerrit.remoteURIs polarsys.git.remoteURIs</value>
-      </detail>
-    </annotation>
-    <choice
-        value="https://git.polarsys.org/r/@{remoteURI}"
-        label="HTTPS (read-only, anonymous, Gerrit)"/>
-    <choice
-        value="ssh://${git.user.id|username}@git.polarsys.org:29418/@{remoteURI}"
-        label="SSH (read-write, Gerrit)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <choice
-        value="https://${git.user.id|username}@git.polarsys.org/r/@{remoteURI}"
-        label="HTTPS (read-write, Gerrit)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <choice
-        value="http://git.polarsys.org/gitroot/@{remoteURI}.git"
-        label="HTTP (read-only, anonymous, direct)"/>
-    <choice
-        value="ssh://${git.user.id|username}@git.polarsys.org/gitroot/@{remoteURI}.git"
-        label="SSH (read-write, direct)">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/MatchChoice"/>
-    </choice>
-    <choice
-        value="git://git.polarsys.org/gitroot/@{remoteURI}"
-        label="Git (read-only, anonymous, direct)"/>
-    <description>Choose from the available Gerrit or Git URIs</description>
-  </setupTask>
-  <project name="Capella Base">
+      xsi:type="setup:CompoundTask"
+      name="Global Variables">
     <setupTask
-        xsi:type="setup:CompoundTask"
-        name="User Preferences">
+        xsi:type="setup:VariableTask"
+        name="bugzilla.id"
+        defaultValue="anonymous"
+        label="Eclipse user email for Bugzilla/Jenkins/Jiro">
+      <description>The email associated with the Eclipse Bugzilla/Jenkins/Jiro account</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        type="PASSWORD"
+        name="eclipse.user.password"
+        label="Eclipse password for Bugzilla/Jenkins/Jiro">
       <annotation
-          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+          source="http://www.eclipse.org/oomph/setup/PasswordVerification">
         <detail
-            key="/instance/org.eclipse.jdt.ui/formatter_profile">
-          <value>record</value>
+            key="type">
+          <value>form</value>
         </detail>
         <detail
-            key="/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.formatterprofiles">
-          <value>record</value>
+            key="form.url">
+          <value>https://accounts.eclipse.org/</value>
         </detail>
         <detail
-            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.copyrightTemplate">
-          <value>record</value>
+            key="form.parameters">
+          <value>name pass op form_id</value>
         </detail>
         <detail
-            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.replaceAllExisting">
-          <value>record</value>
+            key="form.secure.parameters">
+          <value>pass</value>
+        </detail>
+        <detail
+            key="form.filter">
+          <value>name=anonymous\&amp;.*</value>
+        </detail>
+        <detail
+            key="form.parameter.name">
+          <value>$${bugzilla.id}</value>
+        </detail>
+        <detail
+            key="form.parameter.pass">
+          <value>$${value}</value>
+        </detail>
+        <detail
+            key="form.parameter.op">
+          <value>Sign in</value>
+        </detail>
+        <detail
+            key="form.parameter.form_id">
+          <value>user_login</value>
+        </detail>
+        <detail
+            key="form.verification.matches">
+          <value>&lt;https://www.eclipse.org/user/.*>; rel=&quot;canonical&quot;.*</value>
+        </detail>
+        <detail
+            key="form.ok">
+          <value>Valid password for $${form.parameter.name} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.info">
+          <value>Validate the password for $${form.parameter.name} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.warning">
+          <value>Unable to validate the password for $${form.parameter.name} because $${form.url} is unreachable.</value>
+        </detail>
+        <detail
+            key="form.error">
+          <value>Invalid password for $${form.parameter.name} at $${form.url}.</value>
         </detail>
       </annotation>
-      <setupTask
-          xsi:type="setup:CompoundTask"
-          name="org.eclipse.core.resources">
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.core.resources/encoding"
-            value="UTF-8"/>
-      </setupTask>
-      <setupTask
-          xsi:type="setup:CompoundTask"
-          name="org.eclipse.core.runtime">
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.core.runtime/line.separator"
-            value="&#xD;&#xA;"/>
-      </setupTask>
-      <setupTask
-          xsi:type="setup:CompoundTask"
-          name="org.eclipse.jdt.ui">
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.jdt.ui/formatter_profile"
-            value="_Capella"/>
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.formatterprofiles"
-            value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?>&#xA;&lt;profiles version=&quot;12&quot;>&#xA;&lt;profile kind=&quot;CodeFormatterProfile&quot; name=&quot;Capella&quot; version=&quot;12&quot;>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_ellipsis&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_after_imports&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_javadoc_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indentation.size&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.disabling_tag&quot; value=&quot;@formatter:off&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.continuation_indentation&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_enum_constants&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_imports&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_after_package&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_binary_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.indent_root_tags&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.enabling_tag&quot; value=&quot;@formatter:on&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.problem.enumIdentifier&quot; value=&quot;error&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_statements_compare_to_block&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.line_length&quot; value=&quot;120&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.use_on_off_tags&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_method_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_binary_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_block&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_lambda_body&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.compact_else_if&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.problem.assertIdentifier&quot; value=&quot;error&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_binary_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_unary_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_ellipsis&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_line_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.align_type_members_on_columns&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_assignment&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_conditional_expression&quot; value=&quot;80&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_block_in_case&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_header&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode&quot; value=&quot;enabled&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_method_declaration&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.join_wrapped_lines&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines&quot; value=&quot;2147483647&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_resources_in_try&quot; value=&quot;80&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.source&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.tabulation.size&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_source_code&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_field&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_method&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.codegen.targetPlatform&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_switch&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_html&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_compact_if&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_empty_lines&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_unary_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_label&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_member_type&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_block_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_statements_compare_to_body&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_multiple_fields&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_array_initializer&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_before_binary_operator&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.compliance&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_enum_constant&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_package&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.join_lines_in_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.indent_parameter_description&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.tabulation.char&quot; value=&quot;space&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_between_import_groups&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.lineSplit&quot; value=&quot;120&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;/profile>&#xA;&lt;/profiles>&#xA;"/>
-      </setupTask>
-      <setupTask
-          xsi:type="setup:CompoundTask"
-          name="org.eclipse.releng.tools">
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.copyrightTemplate"
-            value="Copyright (c) $${date} THALES GLOBAL SERVICES.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html&#xA;  &#xA;Contributors:&#xA;   Thales - initial API and implementation"/>
-        <setupTask
-            xsi:type="setup:PreferenceTask"
-            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.replaceAllExisting"
-            value="false"/>
-      </setupTask>
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/PasswordVerification">
+        <detail
+            key="type">
+          <value>form</value>
+        </detail>
+        <detail
+            key="form.url">
+          <value>https://git.eclipse.org/r/login/</value>
+        </detail>
+        <detail
+            key="form.parameters">
+          <value>username password submit</value>
+        </detail>
+        <detail
+            key="form.secure.parameters">
+          <value>password</value>
+        </detail>
+        <detail
+            key="form.filter">
+          <value>username=anonymous\&amp;.*</value>
+        </detail>
+        <detail
+            key="form.parameter.username">
+          <value>$${bugzilla.id}</value>
+        </detail>
+        <detail
+            key="form.parameter.password">
+          <value>$${value}</value>
+        </detail>
+        <detail
+            key="form.parameter.submit">
+          <value>Sign In</value>
+        </detail>
+        <detail
+            key="form.verification.url">
+          <value>https://git.eclipse.org/r/accounts/$${git.user.id|username}</value>
+        </detail>
+        <detail
+            key="form.verification.matches">
+          <value>.*&quot;email&quot;: &quot;$${form.parameter.username}&quot;.*</value>
+        </detail>
+        <detail
+            key="form.ok">
+          <value>Valid password for account $${git.user.id} of $${form.parameter.username} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.info">
+          <value>Validate the password for account $${git.user.id} of $${form.parameter.username} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.warning">
+          <value>Unable to validate the password for account $${git.user.id} of $${form.parameter.username} because $${form.url} is unreachable.</value>
+        </detail>
+        <detail
+            key="form.error">
+          <value>Invalid password for account $${git.user.id} of $${form.parameter.username} at $${form.url}.</value>
+        </detail>
+      </annotation>
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/PasswordVerification">
+        <detail
+            key="type">
+          <value>form-post</value>
+        </detail>
+        <detail
+            key="form.url">
+          <value>https://accounts.eclipse.org/</value>
+        </detail>
+        <detail
+            key="form.filter">
+          <value>anonymous</value>
+        </detail>
+        <detail
+            key="form.user">
+          <value>$${bugzilla.id}</value>
+        </detail>
+        <detail
+            key="form.password">
+          <value>$${value}</value>
+        </detail>
+        <detail
+            key="form.response.location.matches">
+          <value>https://accounts.eclipse.org/users/$${git.user.id}</value>
+        </detail>
+        <detail
+            key="form.ok">
+          <value>Valid password for account $${git.user.id} of $${form.user} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.info">
+          <value>Validate the password for account $${git.user.id} of $${form.user} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.warning">
+          <value>Unable to validate the password for account $${git.user.id} of $${form.user} because $${form.url} is unreachable.</value>
+        </detail>
+        <detail
+            key="form.error">
+          <value>Invalid password for account $${git.user.id} of $${form.user} at $${form.url}.</value>
+        </detail>
+      </annotation>
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/PasswordVerification">
+        <detail
+            key="type">
+          <value>form-post</value>
+        </detail>
+        <detail
+            key="form.url">
+          <value>https://accounts.eclipse.org/</value>
+        </detail>
+        <detail
+            key="form.filter">
+          <value>anonymous</value>
+        </detail>
+        <detail
+            key="form.user">
+          <value>$${bugzilla.id}</value>
+        </detail>
+        <detail
+            key="form.password">
+          <value>$${value}</value>
+        </detail>
+        <detail
+            key="form.response.location.matches">
+          <value>https://accounts.eclipse.org/users/.*</value>
+        </detail>
+        <detail
+            key="form.ok">
+          <value>Valid password for $${form.user} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.info">
+          <value>Validate the password for $${form.user} at $${form.url}.</value>
+        </detail>
+        <detail
+            key="form.warning">
+          <value>Unable to validate the password for $${form.user} because $${form.url} is unreachable.</value>
+        </detail>
+        <detail
+            key="form.error">
+          <value>Invalid password for $${form.user} at $${form.url}.</value>
+        </detail>
+      </annotation>
     </setupTask>
-    <setupTask
-        xsi:type="setup:EclipseIniTask"
-        option="-Xmx"
-        value="2048m"
-        vm="true">
-      <description>Set the heap space needed to work with the projects of ${scope.project.label}</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup:ResourceCreationTask"
-        excludedTriggers="STARTUP MANUAL"
-        content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xD;&#xA;&lt;section name=&quot;Workbench&quot;>&#xD;&#xA;&#x9;&lt;section name=&quot;org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart&quot;>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;true&quot; key=&quot;group_libraries&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;false&quot; key=&quot;linkWithEditor&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;layout&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;rootMode&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;packageExplorer configured=&amp;quot;true&amp;quot; group_libraries=&amp;quot;1&amp;quot; layout=&amp;quot;2&amp;quot; linkWithEditor=&amp;quot;0&amp;quot; rootMode=&amp;quot;2&amp;quot; sortWorkingSets=&amp;quot;false&amp;quot; workingSetName=&amp;quot;&amp;quot;&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;workingSet editPageId=&amp;quot;org.eclipse.jdt.internal.ui.OthersWorkingSet&amp;quot; factoryID=&amp;quot;org.eclipse.ui.internal.WorkingSetFactory&amp;quot; id=&amp;quot;1382792884467_1&amp;quot; label=&amp;quot;Other Projects&amp;quot; name=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;activeWorkingSet workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;allWorkingSets workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/packageExplorer&amp;gt;&quot; key=&quot;memento&quot;/>&#xD;&#xA;&#x9;&lt;/section>&#xD;&#xA;&lt;/section>&#xD;&#xA;"
-        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml"
-        encoding="UTF-8">
-      <description>Initialize JDT's package explorer to show working sets as its root objects</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.p2:P2Task">
-      <requirement
-          name="org.eclipse.sirius.specifier.feature.group"/>
-      <requirement
-          name="org.eclipse.emf.sdk.feature.group"/>
-      <requirement
-          name="org.eclipse.releng.tools.feature.group"/>
-      <repository
-          url="http://download.eclipse.org/releases/neon"/>
-      <repository
-          url="http://download.eclipse.org/eclipse/updates/4.6"/>
-      <repository
-          url="http://download.eclipse.org/releases/photon"/>
-      <repository
-          url="http://download.eclipse.org/releases/mars"/>
-      <repository
-          url="http://download.eclipse.org/sirius/updates/releases/6.0.2/photon"/>
-      <repository
-          url="http://download.eclipse.org/sirius/updates/releases/6.2.1/2019-06"/>
-      <repository
-          url="http://download.eclipse.org/releases/2019-06"/>
-      <repository
-          url="http://download.eclipse.org/releases/2019-09"/>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.targlets:TargletTask"
-        filter="(!(eclipse.target.platform=Mars))">
-      <targlet
-          name="Eclipse Modeling Base"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.sdk.feature.group"/>
-        <requirement
-            name="org.eclipse.platform.feature.group"/>
-        <requirement
-            name="org.eclipse.emf.sdk.feature.group"/>
-        <requirement
-            name="org.eclipse.emf.transaction.feature.group"/>
-        <requirement
-            name="org.eclipse.equinox.executable.feature.group"/>
-        <requirement
-            name="com.ibm.icu"/>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.eclipse.org/releases/neon"/>
-        </repositoryList>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/releases/oxygen"/>
-        </repositoryList>
-        <repositoryList
-            name="Mars">
-          <repository
-              url="http://download.eclipse.org/releases/mars"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.eclipse.org/releases/2019-06"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Sirius"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.sirius.doc.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.runtime.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.runtime.aql.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.runtime.ide.ui.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.interpreter.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.acceleo.ui.interpreter.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.aql.feature.group"/>
-        <requirement
-            name="org.eclipse.acceleo.query.feature.group"/>
-        <requirement
-            name="org.eclipse.sirius.runtime.ide.ui.acceleo.feature.group"/>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="https://download.eclipse.org/sirius/updates/releases/5.1.4/neon"/>
-        </repositoryList>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/sirius/updates/releases/6.1.3/oxygen"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200320-102312/2019-06/"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Diffmerge"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.emf.diffmerge.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.emf.diffmerge.sirius.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.emf.diffmerge.gmf.feature.feature.group"/>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.9.0/emf-diffmerge-site"/>
-        </repositoryList>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.11.2/emf-diffmerge-site"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.11.2/emf-diffmerge-site"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Patterns"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.emf.diffmerge.patterns.sdk.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.feature.group"/>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.9.0/edm-patterns-site"/>
-        </repositoryList>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.11.0/edm-patterns-site"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.eclipse.org/diffmerge/releases/0.11.0/edm-patterns-site"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Amalgam"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.amalgam.explorer.activity.feature.group"/>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.10.1-S20190510/capella"/>
-        </repositoryList>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.9.0-S20180528/capella"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.11.0-S20191007/capella"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Sirius Legacy">
-        <requirement
-            name="org.eclipse.sirius.query.legacy.feature.feature.group"/>
-        <repositoryList
-            name="">
-          <repository
-              url="http://download.eclipse.org/sirius/updates/legacy/1.1.0"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Nebula">
-        <requirement
-            name="org.eclipse.nebula.widgets.richtext.feature.feature.group"/>
-        <repositoryList>
-          <repository
-              url="http://download.eclipse.org/nebula/releases/1.2.0"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Eclipse License"
-          activeRepositoryList="">
-        <requirement
-            name="org.eclipse.license.feature.group"/>
-        <repositoryList
-            name="">
-          <repository
-              url="http://download.eclipse.org/cbi/updates/license"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Orbit 2013">
-        <requirement
-            name="org.apache.log4j"
-            versionRange="[1.2.15.v201012070815,1.2.15.v201012070815]"/>
-        <requirement
-            name="org.apache.commons.lang"
-            versionRange="[2.4.0.v201005080502,2.4.0.v201005080502]"/>
-        <requirement
-            name="org.apache.commons.net"
-            versionRange="[3.2.0.v201305141515,3.2.0.v201305141515]"/>
-        <requirement
-            name="org.jsoup"
-            versionRange="[1.7.2.v201304221138,1.7.2.v201304221138]"/>
-        <repositoryList
-            name="">
-          <repository
-              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20130827064939/repository"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Orbit 2014">
-        <requirement
-            name="com.google.guava"
-            versionRange="[15.0.0.v201403281430,15.0.0.v201403281430]"/>
-        <repositoryList
-            name="">
-          <repository
-              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Capella Features"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.polarsys.capella.core.advance.feature.feature.group"/>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.rcp.site"/>
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.egf.site"/>
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.richtext.site"/>
-        </repositoryList>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.rcp.site"/>
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.egf.site"/>
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.richtext.site"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.4.x/org.polarsys.capella.rcp.site"/>
-          <repository
-              url="http://download.polarsys.org/capella/core/updates/nightly/1.4.x/org.polarsys.capella.egf.site"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="Kitalpha"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.polarsys.kitalpha.ad.runtime.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.cadence.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.common.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.emde.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.emde.ui.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.common.commands.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.common.scrutiny.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.common.share.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.detachment.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.model.detachment.ui.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.patterns.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.report.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.report.ui.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.transposer.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.richtext.widget.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.richtext.widget.doc.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.richtext.widget.ext.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.emde.sdk.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.kitalpha.doc.feature.feature.group"/>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.3.x/239/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.core.updatesite/target/repository"/>
-          <repository
-              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.3.x/239/artifact/releng/plugins/org.polarsys.kitalpha.releng.sdk.updatesite/target/repository"/>
-          <repository
-              url="http://download.eclipse.org/egf/updates/1.6.0/oxygen"/>
-        </repositoryList>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.core.updatesite/target/repository"/>
-          <repository
-              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.updatesite/target/repository"/>
-          <repository
-              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.sdk.updatesite/target/repository"/>
-          <repository
-              url="http://download.eclipse.org/egf/updates/1.5.1/neon"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="https://download.eclipse.org/kitalpha/updates/stable/runtimecore/1.4.0RC4"/>
-          <repository
-              url="https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.0RC4"/>
-          <repository
-              url="http://download.eclipse.org/egf/updates/1.6.1/2019-06"/>
-        </repositoryList>
-      </targlet>
-      <targlet
-          name="GMF"
-          activeRepositoryList="${eclipse.target.platform}">
-        <requirement
-            name="org.eclipse.gmf.feature.group"/>
-        <repositoryList
-            name="Neon">
-          <repository
-              url="http://download.eclipse.org/releases/neon"/>
-        </repositoryList>
-        <repositoryList
-            name="Oxygen">
-          <repository
-              url="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S201805221301"/>
-          <repository
-              url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S201806010809"/>
-        </repositoryList>
-        <repositoryList
-            name="Mars">
-          <repository
-              url="http://download.eclipse.org/releases/mars"/>
-        </repositoryList>
-        <repositoryList
-            name="2019-06">
-          <repository
-              url="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S202003100829"/>
-          <repository
-              url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202003121028"/>
-        </repositoryList>
-      </targlet>
-      <description>This defines the targets for 1.2.x and master. The filter below is defined to exclude this targlet from v1.1.x which is isolated in its own stream since its tp differs quite a bit.</description>
-    </setupTask>
-    <stream
-        name="master"
-        label="">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="2019-06"
-          defaultValue="2019-06"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="jdt:JRETask"
-          version="JavaSE-1.8"
-          location="${jre.location-1.8}">
-        <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label} 1.2.x+</description>
-      </setupTask>
-      <setupTask
-          xsi:type="setup.targlets:TargletTask">
-        <targlet
-            name="Kitalpha-1.4.x">
-          <requirement
-              name="org.polarsys.kitalpha.massactions.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.ui.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.feature.group"/>
-        </targlet>
-      </setupTask>
-      <description>Capella master development</description>
-    </stream>
-    <stream
-        name="v1.3.x"
-        label="">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Oxygen"
-          defaultValue="Oxygen"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="jdt:JRETask"
-          version="JavaSE-1.8"
-          location="${jre.location-1.8}">
-        <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label} 1.2.x+</description>
-      </setupTask>
-      <setupTask
-          xsi:type="setup.targlets:TargletTask">
-        <targlet
-            name="Kitalpha-1.3.x">
-          <requirement
-              name="org.polarsys.kitalpha.massactions.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.ui.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.feature.group"/>
-        </targlet>
-      </setupTask>
-      <description>Capella v1.3.x development</description>
-    </stream>
-    <stream
-        name="v1.2.x"
-        label="">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Neon"
-          defaultValue="Neon"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="jdt:JRETask"
-          version="JavaSE-1.8"
-          location="${jre.location-1.8}">
-        <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label} 1.2.x+</description>
-      </setupTask>
-      <description>Capella v1.2.x development</description>
-    </stream>
-    <stream
-        name="v1.1.x"
-        label="">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Mars"
-          defaultValue="Mars"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="setup.targlets:TargletTask">
-        <targlet
-            name="Capella Dependencies"
-            activeRepositoryList="">
-          <annotation
-              source="http:/www.eclipse.org/oomph/targlets/TargetDefinitionGenerator">
-            <detail
-                key="location">
-              <value>${java.io.tmpdir/Capella.target}</value>
-            </detail>
-            <detail
-                key="extraUnits">
-              <value>org.eclipse.equinox.executable.feature.group</value>
-            </detail>
-            <detail
-                key="singleLocation">
-              <value>true</value>
-            </detail>
-            <detail
-                key="includeAllPlatforms">
-              <value>false</value>
-            </detail>
-            <detail
-                key="includeSource">
-              <value>true</value>
-            </detail>
-          </annotation>
-          <requirement
-              name="org.eclipse.sdk.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.sdk.feature.group"/>
-          <requirement
-              name="org.eclipse.gef.sdk.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.transaction.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.validation.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.workspace.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.validation.ocl.feature.group"/>
-          <requirement
-              name="org.eclipse.gmf.feature.group"/>
-          <requirement
-              name="org.eclipse.sirius.query.legacy.feature.feature.group"/>
-          <requirement
-              name="org.eclipse.sirius.runtime.feature.group"/>
-          <requirement
-              name="org.eclipse.sirius.runtime.ide.ui.feature.group"/>
-          <requirement
-              name="org.eclipse.sirius.doc.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.emde.ui.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.emde.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.model.detachment.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.feature.group"/>
-          <requirement
-              name="org.polarsys.kitalpha.patterns.feature.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.diffmerge.sdk.feature.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.diffmerge.patterns.sdk.feature.feature.group"/>
-          <requirement
-              name="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.feature.group"/>
-          <requirement
-              name="org.eclipse.amalgam.explorer.activity.feature.group"/>
-          <requirement
-              name="org.eclipse.amalgam.explorer.contextual.feature.group"/>
-          <requirement
-              name="org.eclipse.amalgam.explorer.contextual.core.feature.group"/>
-          <requirement
-              name="org.eclipse.amalgam.explorer.contextual.sirius.feature.group"/>
-          <repositoryList
-              name="Mars">
-            <repository
-                url="http://download.eclipse.org/sirius/updates/stable/4.1.9-S20180222-100510/mars/"/>
-            <repository
-                url="http://download.eclipse.org/sirius/updates/legacy/1.1.0"/>
-            <repository
-                url="http://download.eclipse.org/diffmerge/releases/0.7.0/emf-diffmerge-site"/>
-            <repository
-                url="http://download.eclipse.org/diffmerge/releases/0.7.1/edm-patterns-site"/>
-            <repository
-                url="https://hudson.polarsys.org/kitalpha/job/kitalpha-v1.1.x/713/artifact/result/publish/kitalpha_runtime/site.p2"/>
-            <repository
-                url="https://hudson.polarsys.org/kitalpha/job/kitalpha-v1.1.x/713/artifact/result/publish/kitalpha_sdk/site.p2"/>
-            <repository
-                url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.8.0.S20180308/mars"/>
-            <repository
-                url="http://download.eclipse.org/tools/orbit/downloads/drops/R20130827064939/repository"/>
-            <repository
-                url="http://download.eclipse.org/releases/mars"/>
-            <repository
-                url="http://download.eclipse.org/cbi/updates/license"/>
-          </repositoryList>
-        </targlet>
-        <description>Target for Capella 1.1.x, before tycho</description>
-      </setupTask>
-      <setupTask
-          xsi:type="jdt:JRETask"
-          version="JavaSE-1.7"
-          location="${jre.location-1.7}">
-        <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label} 1.1.x</description>
-      </setupTask>
-    </stream>
-    <description>Minimum setup, containing preferences and target platform. Users should always select this.</description>
-  </project>
+  </setupTask>
+  <setupTask
+      xsi:type="jdt:JRETask"
+      version="JavaSE-1.8"
+      location="${jre.location-1.8}">
+    <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label} 1.2.x+</description>
+  </setupTask>
   <project name="Capella Developer"
       logicalProjectContainer="/">
     <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.capella"
-        remoteURI="capella/capella.git">
+        remoteURI="eclipse/capella">
       <annotation
           source="http://www.eclipse.org/oomph/setup/InducedChoices">
         <detail
             key="inherit">
-          <value>polarsys.git.gerrit.remoteURIs</value>
+          <value>github.remoteURIs</value>
         </detail>
         <detail
             key="label">
-          <value>${scope.project.label} repository</value>
+          <value>${scope.project.label} Github repository</value>
+        </detail>
+        <detail
+            key="target">
+          <value>remoteURI</value>
+        </detail>
+      </annotation>
+      <configSections
+          name="core">
+        <properties
+            key="autocrlf"
+            value="false"/>
+      </configSections>
+      <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.addon-xhtml"
+        remoteURI="eclipse/capella-xhtml-docgen">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/InducedChoices">
+        <detail
+            key="inherit">
+          <value>github.remoteURIs</value>
+        </detail>
+        <detail
+            key="label">
+          <value>${scope.project.label} Github repository</value>
+        </detail>
+        <detail
+            key="target">
+          <value>remoteURI</value>
+        </detail>
+      </annotation>
+      <configSections
+          name="core">
+        <properties
+            key="autocrlf"
+            value="false"/>
+      </configSections>
+      <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.addon-basicvp"
+        remoteURI="eclipse/capella-basic-vp">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/InducedChoices">
+        <detail
+            key="inherit">
+          <value>github.remoteURIs</value>
+        </detail>
+        <detail
+            key="label">
+          <value>${scope.project.label} Github repository</value>
+        </detail>
+        <detail
+            key="target">
+          <value>remoteURI</value>
+        </detail>
+      </annotation>
+      <configSections
+          name="core">
+        <properties
+            key="autocrlf"
+            value="false"/>
+      </configSections>
+      <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="git:GitCloneTask"
+        id="git.clone.addon-ssstransition"
+        remoteURI="eclipse/capella-sss-transition">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/InducedChoices">
+        <detail
+            key="inherit">
+          <value>github.remoteURIs</value>
+        </detail>
+        <detail
+            key="label">
+          <value>${scope.project.label} Github repository</value>
         </detail>
         <detail
             key="target">
@@ -775,32 +355,228 @@
     <setupTask
         xsi:type="setup.targlets:TargletTask">
       <targlet
-          name="Capella Sourcelocator Targlet"
-          activeRepositoryList="">
+          name="Capella source code, excluding test model projects and ext/ sources"
+          activeRepositoryList=""
+          includeBinaryEquivalents="false">
+        <requirement
+            name="*"/>
         <sourceLocator
             rootFolder="${git.clone.capella.location}"
-            locateNestedProjects="true"/>
+            locateNestedProjects="true">
+          <excludedPath>ext/viatra/</excludedPath>
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:OrPredicate">
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.library.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.project.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.core.preferences.project.nature.configNature"/>
+            </operand>
+          </predicate>
+        </sourceLocator>
+        <sourceLocator
+            rootFolder="${git.clone.addon-xhtml.location}"
+            locateNestedProjects="true">
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:OrPredicate">
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.library.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.project.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.core.preferences.project.nature.configNature"/>
+            </operand>
+          </predicate>
+        </sourceLocator>
+        <sourceLocator
+            rootFolder="${git.clone.addon-basicvp.location}"
+            locateNestedProjects="true">
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:OrPredicate">
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.library.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.project.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.core.preferences.project.nature.configNature"/>
+            </operand>
+          </predicate>
+        </sourceLocator>
+        <sourceLocator
+            rootFolder="${git.clone.addon-ssstransition.location}"
+            locateNestedProjects="true">
+          <predicate
+              xsi:type="predicates:NotPredicate">
+            <operand
+                xsi:type="predicates:OrPredicate">
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.library.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.project.nature"/>
+              <operand
+                  xsi:type="predicates:NaturePredicate"
+                  nature="org.polarsys.capella.core.preferences.project.nature.configNature"/>
+            </operand>
+          </predicate>
+        </sourceLocator>
       </targlet>
       <targlet
-          name="Capella Tests">
-        <requirement
-            name="org.polarsys.capella.test.feature.feature.group"/>
+          name="Common dependencies">
+        <repositoryList
+            name="">
+          <repository
+              url="http://download.eclipse.org/nebula/releases/1.2.0"/>
+          <repository
+              url="http://download.eclipse.org/sirius/updates/legacy/1.1.0"/>
+          <repository
+              url="http://download.eclipse.org/cbi/updates/license"/>
+          <repository
+              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20130827064939/repository"/>
+          <repository
+              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository"/>
+        </repositoryList>
       </targlet>
       <targlet
-          name="Capella M2 Definitions">
-        <requirement
-            name="org.polarsys.capella.core.model.definition.feature.feature.group"/>
+          name="Branch Dependencies"
+          activeRepositoryList="${scope.project.stream.name}">
+        <repositoryList
+            name="v1.2.x">
+          <repository
+              url="http://download.eclipse.org/releases/neon"/>
+          <repository
+              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.core.updatesite/target/repository"/>
+          <repository
+              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.updatesite/target/repository"/>
+          <repository
+              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.2.x/88/artifact/releng/plugins/org.polarsys.kitalpha.releng.sdk.updatesite/target/repository"/>
+          <repository
+              url="http://download.eclipse.org/egf/updates/1.5.1/neon"/>
+          <repository
+              url="https://download.eclipse.org/sirius/updates/releases/5.1.4/neon"/>
+          <repository
+              url="http://download.eclipse.org/diffmerge/releases/0.9.0/emf-diffmerge-site"/>
+          <repository
+              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.9.0-S20180528/capella"/>
+        </repositoryList>
+        <repositoryList
+            name="v1.3.x">
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S201805221301"/>
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S201806010809"/>
+          <repository
+              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.3.x/239/artifact/releng/plugins/org.polarsys.kitalpha.releng.runtime.core.updatesite/target/repository"/>
+          <repository
+              url="https://ci.polarsys.org/kitalpha/job/Kitalpha-v1.3.x/239/artifact/releng/plugins/org.polarsys.kitalpha.releng.sdk.updatesite/target/repository"/>
+          <repository
+              url="http://download.eclipse.org/egf/updates/1.6.0/oxygen"/>
+          <repository
+              url="http://download.eclipse.org/releases/oxygen"/>
+          <repository
+              url="http://download.eclipse.org/sirius/updates/releases/6.1.3/oxygen"/>
+          <repository
+              url="http://download.eclipse.org/diffmerge/releases/0.11.2/emf-diffmerge-site"/>
+          <repository
+              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.10.1-S20190510/capella"/>
+        </repositoryList>
+        <repositoryList
+            name="v1.4.x">
+          <repository
+              url="http://download.eclipse.org/releases/2019-06"/>
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202003121028"/>
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S202003100829"/>
+          <repository
+              url="https://download.eclipse.org/kitalpha/updates/stable/runtimecore/1.4.0.202001100637"/>
+          <repository
+              url="https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.0.202001100637"/>
+          <repository
+              url="http://download.eclipse.org/egf/updates/1.6.1/2019-06"/>
+          <repository
+              url="https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200320-102312/2019-06/"/>
+          <repository
+              url="http://download.eclipse.org/diffmerge/releases/0.12.0/emf-diffmerge-site"/>
+          <repository
+              url="https://download.eclipse.org/diffmerge/releases/0.12.0/edm-patterns-site"/>
+          <repository
+              url="http://download.eclipse.org/modeling/amalgam/updates/stable/1.11.0-S20191007/capella"/>
+        </repositoryList>
+        <repositoryList
+            name="master">
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S202003100829"/>
+          <repository
+              url="http://download.eclipse.org/releases/2019-06"/>
+          <repository
+              url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202003121028"/>
+          <repository
+              url="https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1DEV0"/>
+          <repository
+              url="https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1DEV0"/>
+          <repository
+              url="http://download.eclipse.org/egf/updates/1.6.1/2019-06"/>
+          <repository
+              url="https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200320-102312/2019-06/"/>
+          <repository
+              url="https://download.eclipse.org/diffmerge/releases/0.12.0/emf-diffmerge-site"/>
+          <repository
+              url="https://download.eclipse.org/modeling/amalgam/updates/stable/1.11.0-S20191007/capella"/>
+        </repositoryList>
       </targlet>
       <targlet
-          name="Capella Releng and Code Generators">
-        <requirement
-            name="org.polarsys.capella.core.egf.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.rcp.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.core.data.def"/>
-        <requirement
-            name="org.polarsys.capella.common.data.def"/>
+          name="Latest Capella Build"
+          activeRepositoryList="${scope.project.stream.name}">
+        <repositoryList
+            name="v1.2.x">
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.rcp.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.egf.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.2.x/org.polarsys.capella.richtext.site"/>
+        </repositoryList>
+        <repositoryList
+            name="v1.3.x">
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.rcp.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.egf.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.3.x/org.polarsys.capella.richtext.site"/>
+        </repositoryList>
+        <repositoryList
+            name="v1.4.x">
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.4.x/org.polarsys.capella.rcp.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/1.4.x/org.polarsys.capella.egf.site"/>
+        </repositoryList>
+        <repositoryList
+            name="master">
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/master/org.polarsys.capella.rcp.site"/>
+          <repository
+              url="http://download.polarsys.org/capella/core/updates/nightly/master/org.polarsys.capella.egf.site"/>
+        </repositoryList>
       </targlet>
     </setupTask>
     <setupTask
@@ -832,7 +608,7 @@
               pattern=".*\.validation(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.9"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Tests']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -847,7 +623,7 @@
               pattern=".*\.properties(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -862,7 +638,7 @@
               pattern=".*\.quickfix(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -877,7 +653,7 @@
               pattern=".*\.transition(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.9"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Tests']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -892,7 +668,7 @@
               pattern=".*\.sirius(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -907,7 +683,7 @@
               pattern=".*/common/.*"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.2 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.3 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.0 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.7 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.5 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.4 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.1 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.9 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.11"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Properties'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Quickfix'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Metamodel'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Core'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Sirius'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Transition'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Validation'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Tests'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Doc']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -922,7 +698,7 @@
               pattern=".*/core/.*"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.0 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.2 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.3 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.5 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.4 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.1 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.9 //@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.11"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Metamodel'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Properties'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Quickfix'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Sirius'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Transition'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Validation'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Tests'] //@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Doc']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -949,7 +725,7 @@
               pattern=".*\.test(\..*)?"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
@@ -967,7 +743,7 @@
               project="org.polarsys.capella.common"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -979,17 +755,38 @@
               pattern=".*/doc/.*"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.2/@workingSets.8"/>
+              excludedWorkingSet="//@projects[name='Capella%20Developer']/@setupTasks.5/@workingSets[name='Capella%20Features']"/>
           <operand
               xsi:type="predicates:RepositoryPredicate"
               project="org.polarsys.capella.common"/>
         </predicate>
       </workingSet>
+      <workingSet
+          name="Capella Addon XHTML Docgen">
+        <predicate
+            xsi:type="predicates:AndPredicate">
+          <operand
+              xsi:type="predicates:NamePredicate"
+              pattern="org\.polarsys\.capella\.docgen(\..*)?"/>
+        </predicate>
+      </workingSet>
+      <workingSet
+          name="Capella Basic Addons">
+        <predicate
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.polarsys.capella.basic.mass.viewpoint.site"/>
+      </workingSet>
+      <workingSet
+          name="Capella Addon System2Subsystem Transition">
+        <predicate
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.polarsys.capella.transition.system2subsystem.site"/>
+      </workingSet>
       <description>The dynamic working sets for ${scope.project.label}</description>
     </setupTask>
     <setupTask
         xsi:type="mylyn:MylynQueriesTask"
-        repositoryURL="https://bugs.polarsys.org"
+        repositoryURL="https://bugs.eclipse.org/bugs"
         userID="${bugzilla.id}"
         password="${eclipse.user.password}">
       <query
@@ -998,12 +795,120 @@
       <query
           summary="Closed Capella Bugs"
           url="/buglist.cgi?bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;component=Capella%20Studio&amp;component=Core&amp;component=Detachment&amp;component=Diagram&amp;component=Diff-Merge&amp;component=Documentation&amp;component=Forum&amp;component=General&amp;component=Library&amp;component=ModelValidation&amp;component=Patterns&amp;component=Properties&amp;component=Rec-Rpl&amp;component=Releng&amp;component=Transition&amp;component=UI&amp;component=Website&amp;list_id=21077&amp;product=Capella&amp;query_format=advanced&amp;resolution=---"/>
+      <query
+          summary="Open Capella Addon Bugs"
+          url="/buglist.cgi?bug_status=UNCONFIRMED&amp;bug_status=CONFIRMED&amp;bug_status=IN_PROGRESS&amp;classification=Polarsys&amp;component=GenDoc HTML&amp;component=Mass VP&amp;component=Perfo VP&amp;component=Price VP&amp;component=System2Subsystem&amp;component=XML Pivot&amp;product=Capella&amp;query_format=advanced"/>
+      <query
+          summary="Closed Capella Addon Bugs"
+          url="/buglist.cgi?bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;classification=Polarsys&amp;component=GenDoc HTML&amp;component=Mass VP&amp;component=Perfo VP&amp;component=Price VP&amp;component=System2Subsystem&amp;component=XML Pivot&amp;product=Capella&amp;query_format=advanced"/>
     </setupTask>
     <setupTask
         xsi:type="setup:ResourceCopyTask"
         disabled="true"
         sourceURL="${java.io.tmpdir|uri}/Capella.target"
         targetURL="${git.clone.capella.location|uri}/releng/plugins/org.polarsys.capella.core.releng/oomph/Capella.target"/>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+        <detail
+            key="/instance/org.eclipse.jdt.ui/formatter_profile">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.formatterprofiles">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.copyrightTemplate">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.replaceAllExisting">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.epp.mpc.ui/org.eclipse.epp.mpc.naturelookup">
+          <value>record</value>
+        </detail>
+      </annotation>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.core.resources">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.core.resources/encoding"
+            value="UTF-8"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.core.runtime">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.core.runtime/line.separator"
+            value="&#xD;&#xA;"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.epp.mpc.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.epp.mpc.ui/org.eclipse.epp.mpc.naturelookup"
+            value="false"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.jdt.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.jdt.ui/formatter_profile"
+            value="_Capella"/>
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.jdt.ui/org.eclipse.jdt.ui.formatterprofiles"
+            value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?>&#xA;&lt;profiles version=&quot;12&quot;>&#xA;&lt;profile kind=&quot;CodeFormatterProfile&quot; name=&quot;Capella&quot; version=&quot;12&quot;>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_ellipsis&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_after_imports&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_javadoc_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indentation.size&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.disabling_tag&quot; value=&quot;@formatter:off&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.continuation_indentation&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_enum_constants&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_imports&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_after_package&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_binary_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.indent_root_tags&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.enabling_tag&quot; value=&quot;@formatter:on&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.problem.enumIdentifier&quot; value=&quot;error&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_statements_compare_to_block&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.line_length&quot; value=&quot;120&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.use_on_off_tags&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_method_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_binary_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_block&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_lambda_body&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.compact_else_if&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.problem.assertIdentifier&quot; value=&quot;error&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_binary_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_unary_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_ellipsis&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_line_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.align_type_members_on_columns&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_assignment&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_conditional_expression&quot; value=&quot;80&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_block_in_case&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_header&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode&quot; value=&quot;enabled&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_method_declaration&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.join_wrapped_lines&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines&quot; value=&quot;2147483647&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_resources_in_try&quot; value=&quot;80&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.source&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.tabulation.size&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_source_code&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_field&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer&quot; value=&quot;2&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_method&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.codegen.targetPlatform&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_switch&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_html&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_compact_if&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_empty_lines&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_unary_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_label&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_member_type&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.format_block_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_statements_compare_to_body&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_multiple_fields&quot; value=&quot;16&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_array_initializer&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_before_binary_operator&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.compiler.compliance&quot; value=&quot;1.8&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_enum_constant&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.brace_position_for_type_declaration&quot; value=&quot;end_of_line&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_before_package&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header&quot; value=&quot;0&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.join_lines_in_comments&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.comment.indent_parameter_description&quot; value=&quot;true&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.tabulation.char&quot; value=&quot;space&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.blank_lines_between_import_groups&quot; value=&quot;1&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.lineSplit&quot; value=&quot;120&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation&quot; value=&quot;do not insert&quot;/>&#xD;&#xA;&lt;setting id=&quot;org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch&quot; value=&quot;insert&quot;/>&#xD;&#xA;&lt;/profile>&#xA;&lt;/profiles>&#xA;"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.releng.tools">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.copyrightTemplate"
+            value="Copyright (c) $${date} THALES GLOBAL SERVICES.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html&#xA;  &#xA;Contributors:&#xA;   Thales - initial API and implementation"/>
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.releng.tools/org.eclipse.releng.tools.replaceAllExisting"
+            value="false"/>
+      </setupTask>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        excludedTriggers="STARTUP MANUAL"
+        content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xD;&#xA;&lt;section name=&quot;Workbench&quot;>&#xD;&#xA;&#x9;&lt;section name=&quot;org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart&quot;>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;true&quot; key=&quot;group_libraries&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;false&quot; key=&quot;linkWithEditor&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;layout&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;2&quot; key=&quot;rootMode&quot;/>&#xD;&#xA;&#x9;&#x9;&lt;item value=&quot;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;packageExplorer configured=&amp;quot;true&amp;quot; group_libraries=&amp;quot;1&amp;quot; layout=&amp;quot;2&amp;quot; linkWithEditor=&amp;quot;0&amp;quot; rootMode=&amp;quot;2&amp;quot; sortWorkingSets=&amp;quot;false&amp;quot; workingSetName=&amp;quot;&amp;quot;&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;workingSet editPageId=&amp;quot;org.eclipse.jdt.internal.ui.OthersWorkingSet&amp;quot; factoryID=&amp;quot;org.eclipse.ui.internal.WorkingSetFactory&amp;quot; id=&amp;quot;1382792884467_1&amp;quot; label=&amp;quot;Other Projects&amp;quot; name=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;activeWorkingSet workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;allWorkingSets workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/packageExplorer&amp;gt;&quot; key=&quot;memento&quot;/>&#xD;&#xA;&#x9;&lt;/section>&#xD;&#xA;&lt;/section>&#xD;&#xA;"
+        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml"
+        encoding="UTF-8">
+      <description>Initialize JDT's package explorer to show working sets as its root objects</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup.p2:P2Task">
+      <requirement
+          name="org.eclipse.sirius.specifier.feature.group"/>
+      <requirement
+          name="org.eclipse.emf.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.releng.tools.feature.group"/>
+      <repository
+          url="http://download.eclipse.org/sirius/updates/releases/6.3.0/2019-06"/>
+      <repository
+          url="http://download.eclipse.org/releases/2019-06"/>
+      <repository
+          url="http://download.eclipse.org/releases/2019-09"/>
+      <repository
+          url="http://download.eclipse.org/releases/2020-03"/>
+      <repository
+          url="http://download.eclipse.org/eclipse/updates/4.15"/>
+    </setupTask>
     <stream
         name="master">
       <setupTask
@@ -1015,10 +920,19 @@
       <setupTask
           xsi:type="setup:EclipseIniTask"
           option="-Doomph.redirection.capella="
-          value="https://git.polarsys.org/c/capella/capella.git/plain/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup->${git.clone.capella.location|uri}/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup"
+          value="https://raw.githubusercontent.com/eclipse/capella/master/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup->${git.clone.capella.location|uri}/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup"
           vm="true">
         <description>Redirect to local setup file allows testing changes before pushing them back to git. Disabled atm because does not work with branches other than master.</description>
       </setupTask>
+    </stream>
+    <stream
+        name="v1.4.x">
+      <setupTask
+          xsi:type="setup:VariableTask"
+          name="eclipse.target.platform"
+          value="2019-06"
+          defaultValue="2019-06"
+          storageURI="scope://Workspace"/>
     </stream>
     <stream
         name="v1.3.x">
@@ -1038,257 +952,22 @@
           defaultValue="Neon"
           storageURI="scope://Workspace"/>
     </stream>
-    <stream
-        name="v1.1.x">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Mars"
-          defaultValue="Mars"
-          storageURI="scope://Workspace"/>
-    </stream>
-    <description>Select this if you want to make changes to the capella source code</description>
-  </project>
-  <project name="Capella Addon Developer">
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="git.clone.addon-xhtml"
-        remoteURI="capella/capella-xhtml-docgen.git">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>polarsys.git.gerrit.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>${scope.project.label} repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <configSections
-          name="core">
-        <properties
-            key="autocrlf"
-            value="false"/>
-      </configSections>
-      <description>${scope.project.label}</description>
-    </setupTask>
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="git.clone.addon-basicvp"
-        remoteURI="capella/capella-basic-vp.git">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>polarsys.git.gerrit.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>${scope.project.label} repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <configSections
-          name="core">
-        <properties
-            key="autocrlf"
-            value="false"/>
-      </configSections>
-      <description>${scope.project.label}</description>
-    </setupTask>
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="git.clone.addon-ssstransition"
-        remoteURI="capella/capella-sss-transition.git">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>polarsys.git.gerrit.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>${scope.project.label} repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <configSections
-          name="core">
-        <properties
-            key="autocrlf"
-            value="false"/>
-      </configSections>
-      <description>${scope.project.label}</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.targlets:TargletTask">
-      <targlet
-          name="Capella Addons Source Code">
-        <requirement
-            name="org.polarsys.capella.docgen.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.docgen.package.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.vp.mass.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.vp.perfo.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.vp.price.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.transition.system2subsystem.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.transition.system2subsystem.tests.ju"/>
-        <sourceLocator
-            rootFolder="${git.clone.addon-xhtml.location}"
-            locateNestedProjects="true"/>
-        <sourceLocator
-            rootFolder="${git.clone.addon-basicvp.location}"
-            locateNestedProjects="true"/>
-        <sourceLocator
-            rootFolder="${git.clone.addon-ssstransition.location}"
-            locateNestedProjects="true"/>
-      </targlet>
-      <targlet
-          name="Capella Addons Test Dependencies">
-        <requirement
-            name="org.eclipse.jgit"/>
-      </targlet>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
-      <workingSet
-          name="Capella XHTML Docgen">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern="org\.polarsys\.capella\.docgen(\..*)?"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="Capella Basic VP - Price">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern="org\.polarsys\.capella\.vp\.price(\..*)?"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="Capella Basic VP - Perfo">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern="org\.polarsys\.capella\.vp\.perfo(\..*)?"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="Capella Basic VP - Mass">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern="org\.polarsys\.capella\.vp\.mass(\..*)?"/>
-        </predicate>
-      </workingSet>
-      <workingSet
-          name="Capella System2Subsystem Transition">
-        <predicate
-            xsi:type="predicates:AndPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern="org\.polarsys\.capella\.transition\.system2subsystem(\..*)?"/>
-        </predicate>
-      </workingSet>
-    </setupTask>
-    <setupTask
-        xsi:type="mylyn:MylynQueriesTask"
-        repositoryURL="https://bugs.polarsys.org"
-        userID="${bugzilla.id}"
-        password="${eclipse.user.password}">
-      <query
-          summary="Open Capella Addon Bugs"
-          url="/buglist.cgi?bug_status=UNCONFIRMED&amp;bug_status=CONFIRMED&amp;bug_status=IN_PROGRESS&amp;classification=Polarsys&amp;component=GenDoc HTML&amp;component=Mass VP&amp;component=Perfo VP&amp;component=Price VP&amp;component=System2Subsystem&amp;component=XML Pivot&amp;product=Capella&amp;query_format=advanced"/>
-      <query
-          summary="Closed Capella Addon Bugs"
-          url="/buglist.cgi?bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;classification=Polarsys&amp;component=GenDoc HTML&amp;component=Mass VP&amp;component=Perfo VP&amp;component=Price VP&amp;component=System2Subsystem&amp;component=XML Pivot&amp;product=Capella&amp;query_format=advanced"/>
-    </setupTask>
-    <stream
-        name="master">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="2019-06"
-          defaultValue="2019-06"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="basic-vp-branch"
-          value="master"/>
-    </stream>
-    <stream
-        name="v1.3.x">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Oxygen"
-          defaultValue="Neon"
-          storageURI="scope://Workspace"/>
-    </stream>
-    <stream
-        name="v1.2.x">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Neon"
-          defaultValue="Neon"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="basic-vp-branch"
-          value="master"/>
-    </stream>
-    <stream
-        name="v1.1.x">
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="eclipse.target.platform"
-          value="Mars"
-          defaultValue="Mars"
-          storageURI="scope://Workspace"/>
-      <setupTask
-          xsi:type="setup:VariableTask"
-          name="basic-vp-branch"
-          value="v1.1.x"/>
-    </stream>
-    <description>Select this if you want to make changes to the capella addons source code</description>
+    <description>Development IDE for Capella and Addons</description>
   </project>
   <project name="Capella Tools Developer">
     <setupTask
         xsi:type="git:GitCloneTask"
         id="git.clone.tools"
-        remoteURI="capella/capella-tools.git">
+        remoteURI="eclipse/capella-tools">
       <annotation
           source="http://www.eclipse.org/oomph/setup/InducedChoices">
         <detail
             key="inherit">
-          <value>polarsys.git.gerrit.remoteURIs</value>
+          <value>github.remoteURIs</value>
         </detail>
         <detail
             key="label">
-          <value>${scope.project.label} repository</value>
+          <value>${scope.project.label} Github repository</value>
         </detail>
         <detail
             key="target">
@@ -1308,11 +987,7 @@
       <targlet
           name="Capella Tools Source Code">
         <requirement
-            name="org.polarsys.capella.groovy.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.model2ecore.feature.feature.group"/>
-        <requirement
-            name="org.polarsys.capella.ocl.requester.feature.feature.group"/>
+            name="*"/>
         <sourceLocator
             rootFolder="${git.clone.tools.location}"
             locateNestedProjects="true"/>
@@ -1320,22 +995,25 @@
       <targlet
           name="Capella Groovy Dependencies"
           activeRepositoryList="${scope.project.stream.name}">
-        <requirement
-            name="org.codehaus.groovy.eclipse.feature.feature.group"/>
         <repositoryList
             name="master">
           <repository
-              url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.12/"/>
+              url="http://dist.springsource.org/release/GRECLIPSE/e4.12/"/>
+        </repositoryList>
+        <repositoryList
+            name="v1.4.x">
+          <repository
+              url="http://dist.springsource.org/release/GRECLIPSE/e4.12/"/>
         </repositoryList>
         <repositoryList
             name="v1.3.x">
           <repository
-              url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/"/>
+              url="http://dist.springsource.org/release/GRECLIPSE/e4.7/"/>
         </repositoryList>
         <repositoryList
             name="v1.2.x">
           <repository
-              url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/"/>
+              url="http://dist.springsource.org/release/GRECLIPSE/e4.6/"/>
         </repositoryList>
       </targlet>
     </setupTask>
@@ -1373,23 +1051,28 @@
         xsi:type="setup.p2:P2Task">
       <requirement
           name="org.codehaus.groovy.eclipse.feature.feature.group"/>
+      <requirement
+          name="org.codehaus.groovy25.feature.feature.group"/>
       <repository
-          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/"/>
+          url="https://dist.springsource.org/release/GRECLIPSE/e4.12"/>
       <repository
-          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.8/"/>
+          url="https://dist.springsource.org/release/GRECLIPSE/e4.13"/>
       <repository
-          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.9/"/>
+          url="https://dist.springsource.org/release/GRECLIPSE/e4.14"/>
       <repository
-          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.10/"/>
-      <repository
-          url="https://dist.springsource.org/release/GRECLIPSE/e4.11/"/>
-      <repository
-          url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.12/"/>
-      <repository
-          url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.13/"/>
+          url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.15"/>
     </setupTask>
     <stream
         name="master">
+      <setupTask
+          xsi:type="setup:VariableTask"
+          name="eclipse.target.platform"
+          value="2019-06"
+          defaultValue="2019-06"
+          storageURI="scope://Workspace"/>
+    </stream>
+    <stream
+        name="v1.4.x">
       <setupTask
           xsi:type="setup:VariableTask"
           name="eclipse.target.platform"
@@ -1415,10 +1098,10 @@
           defaultValue="Neon"
           storageURI="scope://Workspace"/>
     </stream>
-    <description>Select this if you want to make changes to the capella tools source code</description>
+    <description>Extends Capella Developer IDE with groovy, capella ocl requestor and other tools to the workspace</description>
   </project>
   <logicalProjectContainer
       xsi:type="setup:ProjectCatalog"
-      href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>
+      href="index:/org.eclipse.setup#//@projectCatalogs[name='com.github']"/>
   <description></description>
 </setup:Project>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/.project
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/ReuseOfComponentsModel/ReuseOfComponentsModel/.project
@@ -7,5 +7,6 @@
 	<buildSpec>
 	</buildSpec>
 	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
 	</natures>
 </projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/.project
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/DiffMergeSourceV1Prj/.project
@@ -7,5 +7,6 @@
 	<buildSpec>
 	</buildSpec>
 	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
 	</natures>
 </projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/.project
+++ b/tests/plugins/org.polarsys.capella.test.table/model/SF-OA/.project
@@ -7,5 +7,6 @@
 	<buildSpec>
 	</buildSpec>
 	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
 	</natures>
 </projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/.project
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/.project
@@ -7,5 +7,6 @@
 	<buildSpec>
 	</buildSpec>
 	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
* Simplify and adapt capella.setup for the following:
- Use github repositories
- Addons are now downloaded for all Capella Developers
- Target platform calculation much simpler now, only repo
  urls are needed
- Users of the current model should ditch their current installs
  and reinstall with the new setup

* Some test projects had missing natures
- This is important, because capella nature is used
  to identify test projects, which shouldn't be imported
  into the workspace

Signed-off-by: Felix Dorner <felix.dorner@gmail.com>