### PR TITLE
Search behavior fixes

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchConstants.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchConstants.java
@@ -12,7 +12,7 @@ package org.polarsys.capella.core.ui.search;
 
 public class CapellaSearchConstants {
   public static final String CapellaSearchEmptyString = "";
-  public static final String CapellaReplaceQuery_Validation_Replacement_Null="The replacement must not be null";
+  public static final String CapellaReplaceQuery_Validation_Replacement_Null = "The replacement must not be null";
   public static final String CapellaSearchDialog_ShowIn_NotFound_Message = "The selected element is not present in the search result for pattern '%s'";
   public static final String CapellaSearchDialog_Title = "Capella Search";
   public static final String CapellaAttribute_Description = "Description";
@@ -21,9 +21,10 @@ public class CapellaSearchConstants {
   public static final String CapellaSearchPage_Checkbox_CaseSensitive_Label = "Case sensitive";
   public static final String CapellaSearchPage_Checkbox_Regex_Label = "Regular expression";
   public static final String CapellaSearchPage_Checkbox_WholeWord_Label = "Whole word";
-  public static final String CapellaSearchPage_Combo_Pattern_Label_Regex_Disabled = "Containing text (* = any string, ? = any character, \\\\ = escape for literals: * ? \\\\\\\\):";
+  public static final String CapellaSearchPage_Combo_Pattern_Label_Regex_Disabled = "Containing text (* = any string, ? = any character, \\ = escape for literals: * ? \\):";
   public static final String CapellaSearchPage_Combo_Pattern_Label_Regex_Enabled = "Containing text (Regular expression):";
   public static final String CapellaSearchPage_Validation_Message_OK = "";
+  public static final String CapellaSearchPage_Validation_Message_Whole_Word_Same_Time_Regex = "The 'Whole word' option is unsupported together with 'Regular expression'";
   public static final String CapellaSearchPage_Validation_Message_Pattern_Empty = "Search pattern must not be empty";
   public static final String CapellaSearchPage_Validation_Message_Project_Selection = "At least one project must be selected";
   public static final String CapellaSearchPage_Validation_Message_SearchAttribute_Selection = "At least one attribute must be selected";
@@ -48,7 +49,7 @@ public class CapellaSearchConstants {
   public static final String Filters_Label = "Filters";
   public static final String Abstract_Label = "Abstract";
   public static final String Semantic_Label = "Semantic";
-  public static final String SearchFor_Label = "Search For (* = any string, ? = any character, \\\\\\\\ = escape for literals: * ? \\\\\\\\)";
+  public static final String SearchFor_Label = "Search for (* = any string, ? = any character, \\ = escape for literals: * ? \\)";
   public static final String ModelElements_Key = "Model Elements";
   public static final String DiagramElements_Key = "Diagram Elements";
   public static final String Diagram_Label = "Diagram";

--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchSettings.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchSettings.java
@@ -38,7 +38,7 @@ public class CapellaSearchSettings {
   private boolean isAbstractChecked = false;
   private boolean isSemanticChecked = true;
   private int scope;
-  
+
   public void addObjectToSearch(Object objectToSearch) {
     objectsToSearch.add(objectToSearch);
   }
@@ -118,23 +118,28 @@ public class CapellaSearchSettings {
   public void setSemanticChecked(boolean isSemanticChecked) {
     this.isSemanticChecked = isSemanticChecked;
   }
-  
+
   public void setScope(int scope) {
     this.scope = scope;
   }
-  
+
   public int getScope() {
     return this.scope;
   }
 
-  // method used to check the search settings (that we entered text, selected at least one mettaclass or attribute etc) 
+  // method used to check the search settings (that we entered text, selected at least one mettaclass or attribute etc)
   public IStatus validate() {
     if (textPattern == null || textPattern.isEmpty()) {
       return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
           CapellaSearchConstants.CapellaSearchPage_Validation_Message_Pattern_Empty);
     }
-    
+
     if (isRegExSearch) {
+      if (isWholeWord) {
+        return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
+            CapellaSearchConstants.CapellaSearchPage_Validation_Message_Whole_Word_Same_Time_Regex);
+      }
+
       try {
         CapellaSearchSettings.createPattern(textPattern, isCaseSensitive, isRegExSearch, isWholeWord);
       } catch (PatternSyntaxException e) {
@@ -147,7 +152,8 @@ public class CapellaSearchSettings {
           CapellaSearchConstants.CapellaSearchPage_Validation_Message_SearchMetaClass_Selection);
     }
 
-    if (searchAttributeItems.isEmpty() && !searchMetaClassItems.stream().anyMatch(SearchForNoteItem.class::isInstance)) {
+    if (searchAttributeItems.isEmpty()
+        && !searchMetaClassItems.stream().anyMatch(SearchForNoteItem.class::isInstance)) {
       return new Status(IStatus.ERROR, Activator.PLUGIN_ID,
           CapellaSearchConstants.CapellaSearchPage_Validation_Message_SearchAttribute_Selection);
     }
@@ -157,7 +163,7 @@ public class CapellaSearchSettings {
 
   public static Pattern createPattern(String textPattern, boolean isCaseSensitive, boolean isRegExSearch,
       boolean isWholeWord) {
-    return PatternConstructor.createPattern(textPattern, isRegExSearch, false, isCaseSensitive, isWholeWord);
+    return PatternConstructor.createPattern(textPattern, isRegExSearch, true, isCaseSensitive, isWholeWord);
   }
 
   public Pattern createPattern() {
@@ -192,20 +198,21 @@ public class CapellaSearchSettings {
         : !this.searchAttributeItems.equals(that.searchAttributeItems)) {
       return false;
     }
-    
+
     if (this.searchMetaClassItems == null ? that.searchMetaClassItems != null
         : !this.searchMetaClassItems.equals(that.searchMetaClassItems)) {
       return false;
     }
 
-    if (this.objectsToSearch == null ? that.objectsToSearch != null : !this.objectsToSearch.equals(that.objectsToSearch)) {
+    if (this.objectsToSearch == null ? that.objectsToSearch != null
+        : !this.objectsToSearch.equals(that.objectsToSearch)) {
       return false;
     }
-    
+
     if (this.scope != that.scope) {
       return false;
     }
-    
+
     return true;
   }
 


### PR DESCRIPTION
- Fixed AssertionFailedException when "Whole word" and "Regular
expression" options are used together
-- A message informing the user is displayed and the search is not
performed

- Fixed regex information in both text box and class filter
- Fixed search queries that use the String Matcher format
-- The String matcher is not as powerful as regex but allows the use of
\* for any string, \? for a character etc.

Change-Id: I2ebf69f58c97de9453f42bfe84dbde49dccbd586
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>