### PR TITLE
Left panel class tree should be collapsed

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchConstants.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchConstants.java
@@ -46,10 +46,10 @@ public class CapellaSearchConstants {
   public static final String SelectAllButton_Name = "Select All";
   public static final String DeselectAllButton_Name = "Deselect All";
   public static final String RestoreDefaultsButton_Name = "Restore Defaults";
-  public static final String Filters_Label = "Active filters";
+  public static final String Filters_Label = "Active filters (matching items will be hidden)";
   public static final String Abstract_Label = "Abstract elements";
   public static final String Semantic_Label = "Non Semantic elements";
-  public static final String SearchFor_Label = "Search for (* = any string, ? = any character, \\ = escape for literals: * ? \\)";
+  public static final String SearchFor_Label = "Search for (* = any string, ? = any character, \\ = escape for literals: * ? \\):";
   public static final String ModelElements_Key = "Model Elements";
   public static final String DiagramElements_Key = "Diagram Elements";
   public static final String Diagram_Label = "Diagram";

--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/AbstractCapellaSearchForContainerArea.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/AbstractCapellaSearchForContainerArea.java
@@ -75,7 +75,7 @@ public abstract class AbstractCapellaSearchForContainerArea {
 
     filteredTree.getViewer().setInput("");
 
-    ((CheckboxTreeViewer) filteredTree.getViewer()).expandAll();
+    filteredTree.getViewer().expandAll();
     filteredTree.getViewer().getTree().setLayout(new GridLayout());
 
     GridData chechboxTreeViewerGridData = new GridData(GridData.FILL_BOTH);

--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/CapellaLeftSearchForContainerArea.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/CapellaLeftSearchForContainerArea.java
@@ -184,6 +184,9 @@ public class CapellaLeftSearchForContainerArea extends AbstractCapellaSearchForC
   @Override
   protected void createContentArea() {
     super.createContentArea();
+
+    filteredTree.getViewer().collapseAll();
+
     // Map of fix categories and their index
     Map<String, Integer> fixedCategories = new HashMap<>();
     fixedCategories.put(CapellaSearchConstants.ModelElements_Key, 0);


### PR DESCRIPTION
- Collapse the left panel class tree by default
- Add 'matching items will be hidden' note for the class filters

Change-Id: I8aa407e16b7b9a33db21412df8ccea7a0bbe42dd
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>