### PR TITLE
[561365] Richtext can lost the last modification when switching tab

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
@@ -114,11 +114,12 @@ public abstract class ElementDescriptionGroup {
       if (lastSave == null && this.owner == owner && this.feature == feature) {
         setDataValue(owner, feature, editorText);
 
-      } else if (lastSave == Boolean.TRUE) {
+      } else if (Boolean.TRUE.equals(lastSave)) {
         // Usecase:
         // On two opened diagrams with description tab opened, Change description of element, keep edition focus, then
         // switch tab to other diagram.
         // Last save may be lost by the previous if.
+
         setDataValue(owner, feature, editorText);
         lastSave = Boolean.FALSE;
       }
@@ -225,6 +226,7 @@ public abstract class ElementDescriptionGroup {
         /**
          * @see java.lang.Runnable#run()
          */
+        @Override
         public void run() {
           command.run();
         }
@@ -363,6 +365,7 @@ public abstract class ElementDescriptionGroup {
   protected void setDataValue(final EObject object, final EStructuralFeature feature, final Object value) {
     if (NotificationHelper.isNotificationRequired(object, feature, value)) {
       AbstractReadWriteCommand command = new AbstractReadWriteCommand() {
+        @Override
         public void run() {
           object.eSet(feature, value);
         }

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
@@ -88,6 +88,12 @@ public abstract class ElementDescriptionGroup {
 
     EStructuralFeature feature;
 
+    // Does the saveStrategy has to perform the last save before its disposal.
+    // If null, the last save is not yet there.
+    // If true, the last save has to be done
+    // If false, the last save has been done and another save is not welcome as the given owner may have changed
+    Boolean lastSave = null;
+
     public SavingStrategy() {
     }
 
@@ -101,11 +107,29 @@ public abstract class ElementDescriptionGroup {
       // Due to async 'lost focus' event, the given owner in parameter can be the next one and not the intended one
 
       // Usecase:
-      // On ProjectExplorer, select an element. Change its description, then choose another element in explorer.
+      // On ProjectExplorer, select an element. Change its description, keep edition focus, then choose another element
+      // in explorer.
       // Save is called twice, one in loadData/within bind method with previous element, then another one in lostFocus
       // with new one but with old text.
-      if (this.owner == owner && this.feature == feature) {
+      if (lastSave == null && this.owner == owner && this.feature == feature) {
         setDataValue(owner, feature, editorText);
+
+      } else if (lastSave == Boolean.TRUE) {
+        // Usecase:
+        // On two opened diagrams with description tab opened, Change description of element, keep edition focus, then
+        // switch tab to other diagram.
+        // Last save may be lost by the previous if.
+        setDataValue(owner, feature, editorText);
+        lastSave = Boolean.FALSE;
+      }
+    }
+
+    /**
+     * Mark the save strategy to ensure that last save of the editor will be performed
+     */
+    public void ensureLastSave() {
+      if (lastSave == null) {
+        lastSave = Boolean.TRUE;
       }
     }
   }
@@ -156,6 +180,7 @@ public abstract class ElementDescriptionGroup {
     if (updateDescriptionEditability(semanticElement, semanticFeature)) {
       try {
         if (semanticElement != null && semanticFeature != null) {
+          ((SavingStrategy) descriptionTextField.getSaveStrategy()).ensureLastSave();
           descriptionTextField.bind(semanticElement, semanticFeature);
           descriptionTextField.setSaveStrategy(new SavingStrategy(semanticElement, semanticFeature));
         }
@@ -306,6 +331,7 @@ public abstract class ElementDescriptionGroup {
           }
 
           // We setSaveStrategy after the bind, as bind also do a saveContent on previous element.
+          ((SavingStrategy) descriptionTextField.getSaveStrategy()).ensureLastSave();
           descriptionTextField.bind(semanticElement, semanticFeature);
           descriptionTextField.setSaveStrategy(new SavingStrategy(semanticElement, semanticFeature));
 

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/CapellaDescriptionPropertySection.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/CapellaDescriptionPropertySection.java
@@ -19,9 +19,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
@@ -75,27 +73,28 @@ public class CapellaDescriptionPropertySection extends DescriptionPropertySectio
   }
 
   DelayedSetDescription job = new DelayedSetDescription("Load Description");
-  
+
   /**
    * Avoid consecutive loads if the selection is quickly changed
    */
   private class DelayedSetDescription extends UIJob {
 
     EObject current = null;
-    
+
     public DelayedSetDescription(String name) {
       super(name);
       setSystem(true);
     }
 
+    @Override
     public boolean belongsTo(Object family) {
-      return family == DelayedSetDescription.class.getSimpleName();
-    };
-    
+      return DelayedSetDescription.class.getSimpleName().equals(family);
+    }
+
     @Override
     public IStatus runInUIThread(IProgressMonitor monitor) {
       EObject element = current;
-      
+
       // On loading data, add the instance to the map.
       if (null != descriptionGroup) {
         descriptionGroup.loadData(element);
@@ -114,6 +113,7 @@ public class CapellaDescriptionPropertySection extends DescriptionPropertySectio
   public void loadData(EObject descriptorOrCapellaElement) {
     super.loadData(descriptorOrCapellaElement);
     mapDescriptionSectionToEObject.put(CapellaDescriptionPropertySection.this, descriptorOrCapellaElement);
+
     job.current = descriptorOrCapellaElement;
     job.schedule(100);
   }
@@ -129,11 +129,8 @@ public class CapellaDescriptionPropertySection extends DescriptionPropertySectio
       EObject elt = CapellaAdapterHelper
           .resolveDescriptorOrBusinessObject(((StructuredSelection) selection).getFirstElement());
 
-      if (elt instanceof CapellaElement) {
-        loadData((CapellaElement) elt);
-
-      } else if (elt instanceof DRepresentationDescriptor) {
-        loadData((DRepresentationDescriptor) elt);
+      if (elt instanceof CapellaElement || elt instanceof DRepresentationDescriptor) {
+        loadData(elt);
       }
     }
   }

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -60,7 +60,7 @@ location sirius "https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200
 	org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group
 }
 
-location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1.202005231334/" {	
+location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1.202005251251/" {	
 	org.polarsys.kitalpha.ad.runtime.feature.feature.group
 	org.polarsys.kitalpha.cadence.feature.feature.group
 	org.polarsys.kitalpha.common.feature.feature.group
@@ -87,7 +87,7 @@ location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/upd
 	org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group
 	org.polarsys.kitalpha.transposer.feature.feature.group
 }
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1.202005231334/" {
+location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1.202005251251/" {
 	org.polarsys.kitalpha.doc.feature.feature.group
 	org.polarsys.kitalpha.emde.sdk.feature.feature.group
 }

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -60,7 +60,7 @@ location sirius "https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200
 	org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group
 }
 
-location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1DEV0" {	
+location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1.202005231334/" {	
 	org.polarsys.kitalpha.ad.runtime.feature.feature.group
 	org.polarsys.kitalpha.cadence.feature.feature.group
 	org.polarsys.kitalpha.common.feature.feature.group
@@ -87,7 +87,7 @@ location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/upd
 	org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group
 	org.polarsys.kitalpha.transposer.feature.feature.group
 }
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1DEV0" {
+location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1.202005231334/" {
 	org.polarsys.kitalpha.doc.feature.feature.group
 	org.polarsys.kitalpha.emde.sdk.feature.feature.group
 }


### PR DESCRIPTION
When two diagrams are opened and displaying description tab, if user
changes description of the first then switch to other diagram editor
while keeping focus on description, he may lost its description

Bug: 561365
Change-Id: I3139f3b9add7b981cb3d8fa5a5192c6bb973ac86
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>