### PR TITLE
[563327] In scenario initialization Guard are not referenced on operands

### DIFF
--- a/core/plugins/org.polarsys.capella.core.projection.scenario/src/org/polarsys/capella/core/projection/scenario/uml2/rules/Rule_InteractionOperand.java
+++ b/core/plugins/org.polarsys.capella.core.projection.scenario/src/org/polarsys/capella/core/projection/scenario/uml2/rules/Rule_InteractionOperand.java
@@ -49,6 +49,8 @@ public class Rule_InteractionOperand extends Rule_CapellaElement {
 
     AttachmentHelper.getInstance(context_p).attachTracedElements(element_p, result_p, InteractionPackage.Literals.INTERACTION_FRAGMENT__COVERED_INSTANCE_ROLES,
         context_p);
+    AttachmentHelper.getInstance(context_p).attachTracedElements(element_p, result_p, InteractionPackage.Literals.INTERACTION_OPERAND__GUARD,
+        context_p);
   }
   
   @Override

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.melodymodeller
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/model/CreateRule_Scenario/CreateRule_Scenario.melodymodeller
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_1.4.0-->
+<!--Capella_Version_1.4.1-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/1.4.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/1.4.0"
@@ -5056,7 +5056,8 @@
             <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
                 id="02ed717d-e0fc-4df6-a0e5-b482e956d94a" name="FE1412" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872"/>
             <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:InteractionOperand"
-                id="efee6369-502a-480b-b937-aed808ac7097" name="IO1413" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872">
+                id="efee6369-502a-480b-b937-aed808ac7097" name="IO1413" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872"
+                guard="#57e74bf6-fe24-4a49-9d16-2180742f42db">
               <ownedConstraints xsi:type="org.polarsys.capella.core.data.capellacore:Constraint"
                   id="57e74bf6-fe24-4a49-9d16-2180742f42db" name="" constrainedElements="#efee6369-502a-480b-b937-aed808ac7097">
                 <ownedSpecification xsi:type="org.polarsys.capella.core.data.information.datavalue:OpaqueExpression"
@@ -5079,7 +5080,8 @@
             <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
                 id="352a6ea8-be2e-4b7c-a244-7d0c0f0f192a" name="FE1415" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872"/>
             <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:InteractionOperand"
-                id="8540a655-115c-4f3f-b57f-2df182b23ee7" name="IO1416" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872">
+                id="8540a655-115c-4f3f-b57f-2df182b23ee7" name="IO1416" coveredInstanceRoles="#6846e53f-bac2-471d-8392-4317716d9872"
+                guard="#846ae807-e60c-4e66-b0ce-201848a779c4">
               <ownedConstraints xsi:type="org.polarsys.capella.core.data.capellacore:Constraint"
                   id="846ae807-e60c-4e66-b0ce-201848a779c4" name="" constrainedElements="#8540a655-115c-4f3f-b57f-2df182b23ee7">
                 <ownedSpecification xsi:type="org.polarsys.capella.core.data.information.datavalue:OpaqueExpression"

--- a/tests/plugins/org.polarsys.capella.test.transition.ju/src/org/polarsys/capella/test/transition/ju/transitions/CreateRule_ScenarioUml2_01.java
+++ b/tests/plugins/org.polarsys.capella.test.transition.ju/src/org/polarsys/capella/test/transition/ju/transitions/CreateRule_ScenarioUml2_01.java
@@ -21,6 +21,7 @@ import org.eclipse.osgi.util.NLS;
 import org.polarsys.capella.common.data.modellingcore.AbstractNamedElement;
 import org.polarsys.capella.common.helpers.EObjectLabelProviderHelper;
 import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.data.interaction.InteractionOperand;
 import org.polarsys.capella.core.data.interaction.Scenario;
 import org.polarsys.capella.core.data.interaction.ScenarioKind;
 import org.polarsys.capella.core.transition.system.topdown.constants.ITopDownConstants;
@@ -154,9 +155,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1111, scenario);
     mustBeTransitionedAndReference(fe1112, scenario);
     mustBeTransitionedAndReference(io1113, scenario);
+    hasGuard(io1113, scenario);
     mustBeTransitionedAndReference(fe1114, scenario);
     mustBeTransitionedAndReference(fe1115, scenario);
     mustBeTransitionedAndReference(io1116, scenario);
+    hasGuard(io1116, scenario);
     mustBeTransitionedAndReference(SF1117, scenario);
     mustBeTransitionedAndReference(io1118, scenario);
     mustBeTransitionedAndReference(SF1119, scenario);
@@ -164,6 +167,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitioned(iu112, scenario);
     mustBeTransitioned(cf113, scenario);
     mustBeTransitioned(cf114, scenario);
+  }
+
+  private void hasGuard(String id, EObject container) {
+    InteractionOperand target = (InteractionOperand) super.mustBeTransitionedAndReference(id, container);
+    assertTrue(target.getGuard() != null);
   }
 
   @Override
@@ -184,9 +192,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1211, scenario);
     mustBeTransitionedAndReference(fe1212, scenario);
     mustBeTransitionedAndReference(io1213, scenario);
+    hasGuard(io1213, scenario);
     mustBeTransitionedAndReference(fe1214, scenario);
     mustBeTransitionedAndReference(fe1215, scenario);
     mustBeTransitionedAndReference(io1216, scenario);
+    hasGuard(io1216, scenario);
     mustBeTransitionedAndReference(SF1217, scenario);
     mustBeTransitionedAndReference(io1218, scenario);
     mustBeTransitionedAndReference(SF1219, scenario);
@@ -206,9 +216,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1311, scenario);
     mustBeTransitionedAndReference(fe1312, scenario);
     mustBeTransitionedAndReference(io1313, scenario);
+    hasGuard(io1113, scenario);
     mustBeTransitionedAndReference(fe1314, scenario);
     mustBeTransitionedAndReference(fe1315, scenario);
     mustBeTransitionedAndReference(io1316, scenario);
+    hasGuard(io1316, scenario);
     mustBeTransitionedAndReference(SF1317, scenario);
     mustBeTransitionedAndReference(io1318, scenario);
     mustBeTransitionedAndReference(SF1319, scenario);
@@ -228,9 +240,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1411, scenario);
     mustBeTransitionedAndReference(FE1412, scenario);
     mustBeTransitionedAndReference(IO1413, scenario);
+    hasGuard(IO1413, scenario);
     mustBeTransitionedAndReference(FE1414, scenario);
     mustBeTransitionedAndReference(FE1415, scenario);
     mustBeTransitionedAndReference(IO1416, scenario);
+    hasGuard(IO1416, scenario);
     mustBeTransitionedAndReference(SF1417, scenario);
     mustBeTransitionedAndReference(IO1418, scenario);
     mustBeTransitionedAndReference(SF1419, scenario);
@@ -253,9 +267,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1111, scenario);
     mustBeTransitionedAndReference(fe1112, scenario);
     mustBeTransitionedAndReference(io1113, scenario);
+    hasGuard(io1113, scenario);
     mustBeTransitionedAndReference(fe1114, scenario);
     mustBeTransitionedAndReference(fe1115, scenario);
     mustBeTransitionedAndReference(io1116, scenario);
+    hasGuard(io1116, scenario);
     mustBeTransitionedAndReference(SF1117, scenario);
     mustBeTransitionedAndReference(io1118, scenario);
     mustBeTransitionedAndReference(SF1119, scenario);
@@ -274,9 +290,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1211, scenario);
     mustBeTransitionedAndReference(fe1212, scenario);
     mustBeTransitionedAndReference(io1213, scenario);
+    hasGuard(io1213, scenario);
     mustBeTransitionedAndReference(fe1214, scenario);
     mustBeTransitionedAndReference(fe1215, scenario);
     mustBeTransitionedAndReference(io1216, scenario);
+    hasGuard(io1216, scenario);
     mustBeTransitionedAndReference(SF1217, scenario);
     mustBeTransitionedAndReference(io1218, scenario);
     mustBeTransitionedAndReference(SF1219, scenario);
@@ -296,9 +314,11 @@ public class CreateRule_ScenarioUml2_01 extends TopDownTransitionTestCase {
     mustBeTransitionedAndReference(SF1311, scenario);
     mustBeTransitionedAndReference(fe1312, scenario);
     mustBeTransitionedAndReference(io1313, scenario);
+    hasGuard(io1313, scenario);
     mustBeTransitionedAndReference(fe1314, scenario);
     mustBeTransitionedAndReference(fe1315, scenario);
     mustBeTransitionedAndReference(io1316, scenario);
+    hasGuard(io1316, scenario);
     mustBeTransitionedAndReference(SF1317, scenario);
     mustBeTransitionedAndReference(io1318, scenario);
     mustBeTransitionedAndReference(SF1319, scenario);


### PR DESCRIPTION
Bug: 563327
Change-Id: I840fe8289432ec51bc54a953241bd48830b06c0f
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>