### PR TITLE
[563340] Clean code of SiriusSessionFactory.createSession

### DIFF
--- a/common/plugins/org.polarsys.capella.common.platform.sirius.ted/src/org/polarsys/capella/common/platform/sirius/ted/SiriusSessionFactory.java
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.ted/src/org/polarsys/capella/common/platform/sirius/ted/SiriusSessionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c) 2008, 2020 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -57,7 +57,7 @@ public class SiriusSessionFactory extends SessionFactoryImpl implements SessionF
       public Collection<Resource> getSemanticResources() {
         Collection<Resource> semanticResources = new ArrayList<Resource>(super.getSemanticResources());
         semanticResources.addAll(
-            new DerivedResourcesHelper().getDerivedSemanticResources(transactionalEditingDomain, semanticResources));
+            new DerivedResourcesHelper().getDerivedSemanticResources(this.getTransactionalEditingDomain(), semanticResources));
         return Collections.unmodifiableCollection(semanticResources);
       }
     };

--- a/common/plugins/org.polarsys.capella.common.platform.sirius.ted/src/org/polarsys/capella/common/platform/sirius/ted/SiriusSessionFactory.java
+++ b/common/plugins/org.polarsys.capella.common.platform.sirius.ted/src/org/polarsys/capella/common/platform/sirius/ted/SiriusSessionFactory.java
@@ -56,8 +56,8 @@ public class SiriusSessionFactory extends SessionFactoryImpl implements SessionF
       @Override
       public Collection<Resource> getSemanticResources() {
         Collection<Resource> semanticResources = new ArrayList<Resource>(super.getSemanticResources());
-        semanticResources.addAll(
-            new DerivedResourcesHelper().getDerivedSemanticResources(this.getTransactionalEditingDomain(), semanticResources));
+        semanticResources.addAll(new DerivedResourcesHelper()
+            .getDerivedSemanticResources(this.getTransactionalEditingDomain(), semanticResources));
         return Collections.unmodifiableCollection(semanticResources);
       }
     };
@@ -100,10 +100,12 @@ public class SiriusSessionFactory extends SessionFactoryImpl implements SessionF
         Collection<Resource> nonDerivedSemanticResources) {
       Collection<Resource> derivedSemanticResources = new ArrayList<Resource>();
 
-      for (IDerivedSemanticResourceProvider provider : getAllDerivedSemanticResourceProviders()) {
-        for (Resource resource : provider.getDerivedSemanticResources(editingDomain)) {
-          if (!nonDerivedSemanticResources.contains(resource) && !derivedSemanticResources.contains(resource)) {
-            derivedSemanticResources.add(resource);
+      if (editingDomain != null) {
+        for (IDerivedSemanticResourceProvider provider : getAllDerivedSemanticResourceProviders()) {
+          for (Resource resource : provider.getDerivedSemanticResources(editingDomain)) {
+            if (!nonDerivedSemanticResources.contains(resource) && !derivedSemanticResources.contains(resource)) {
+              derivedSemanticResources.add(resource);
+            }
           }
         }
       }
@@ -137,11 +139,11 @@ public class SiriusSessionFactory extends SessionFactoryImpl implements SessionF
   public static class SessionMetadataHelper {
 
     static Boolean loaded = Boolean.FALSE;
-    
+
     static IMetadataProvider provider = null;
 
     public IMetadataProvider getProvider() {
-      
+
       if (loaded == Boolean.FALSE) {
         for (IConfigurationElement configurationElement : ExtensionPointHelper
             .getConfigurationElements(PlatformSiriusTedActivator.getDefault().getPluginId(), "metadataProvider")) {


### PR DESCRIPTION
This commit avoids to use the final parameter transactionalEditingDomain
that had the same name as the field transactionalEditingDomain of DASI.
This causes the creation, at compilation time, of a
val$transactionalEditingDomain in the DASI. This "new field" is not set
to null in DASI.close and can cause a memory leak.

Bug: 563340
Change-Id: I72d27ff022bbdc52534a7ff5b4fb95bf30665363
Signed-off-by: Laurent Redor <laurent.redor@obeo.fr>