### PR TITLE
[554358] Remove Editing domain and transactions references

### DIFF
--- a/common/plugins/org.polarsys.capella.common.ef/src/org/polarsys/capella/common/ef/ExecutionManager.java
+++ b/common/plugins/org.polarsys.capella.common.ef/src/org/polarsys/capella/common/ef/ExecutionManager.java
@@ -169,4 +169,12 @@ public class ExecutionManager {
     }
     return null;
   }
+
+  /**
+   * Dispose the {@link ExecutionManager}. {@link ExecutionManager#dispose()} should be called after the dispose of the
+   * {@link TransactionalEditingDomain}.
+   */
+  public void dispose() {
+    this._editingDomain = null;
+  }
 }

--- a/common/plugins/org.polarsys.capella.common.ef/src/org/polarsys/capella/common/ef/ExecutionManagerRegistry.java
+++ b/common/plugins/org.polarsys.capella.common.ef/src/org/polarsys/capella/common/ef/ExecutionManagerRegistry.java
@@ -77,6 +77,7 @@ public class ExecutionManagerRegistry {
   public void removeManager(ExecutionManager executionManager) {
     if ((executionManager != null) && (executionManager.getEditingDomain() != null)) {
       _managers.remove(executionManager.getEditingDomain());
+      executionManager.dispose();
     }
   }
 


### PR DESCRIPTION
- Removes the cross referencer and clear adapters from resourceSet
resources in the editing domain dispose
- Allows to dispose the execution manager

Change-Id: Ic3e622ad8fb3932a87dc527f3af6ab353514f09b
Signed-off-by: Guillaume Coutable <guillaume.coutable@obeo.fr>