### PR TITLE
- Fix duplicate queries problem

### DIFF
--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/META-INF/MANIFEST.MF
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.edit.ui,
  org.polarsys.capella.common.ui.services,
  org.polarsys.capella.common.ui.toolkit,
- org.polarsys.kitalpha.emde.ui
+ org.polarsys.kitalpha.emde.ui,
+ org.apache.commons.lang
 Export-Package: org.polarsys.capella.common.ui.toolkit.browser,
  org.polarsys.capella.common.ui.toolkit.browser.action,
  org.polarsys.capella.common.ui.toolkit.browser.category,

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/CategoryImpl.java
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/CategoryImpl.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
+import org.eclipse.emf.ecore.EObject;
 import org.polarsys.capella.common.ui.toolkit.browser.internal.TypeHelper;
 import org.polarsys.capella.common.ui.toolkit.browser.query.QueryAdapter;
 
@@ -27,7 +30,7 @@ public class CategoryImpl implements ICategory {
   protected String id;
 
   protected String name;
-
+  
   /**
    * Qualified Name of type for which the category is enabled.
    */
@@ -141,5 +144,20 @@ public class CategoryImpl implements ICategory {
   public String getCategoryId() {
     return this.id;
   }
+  
+  @Override
+  public String getTypeFullyQualifiedName() {
+    return this.typeQualifiedName;
+  }
+  
+  @Override
+  public boolean overrides(ICategory otherCategory, EObject current) {
+    return this.getName().equals(otherCategory.getName())
+        && TypeHelper.getInstance().isSubtype(this.typeQualifiedName, otherCategory.getTypeFullyQualifiedName(), current);
+  }
 
+  @Override
+  public String getSymbolicName() {
+    return StringUtils.uncapitalize(WordUtils.capitalizeFully(this.name.toLowerCase()).replaceAll("\\s+", ""));
+  }
 }

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/CategoryRegistry.java
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/CategoryRegistry.java
@@ -76,7 +76,19 @@ public class CategoryRegistry {
         categories.add(category);
       }
     }
+    removeOverriddenCategories(categories, currentElement);
     return categories;
+  }
+
+  /**
+   * Remove categories overridden by at least one another category in the same input set of categories
+   * 
+   * @param categories
+   */
+  private void removeOverriddenCategories(Set<ICategory> categories, EObject current) {
+    Set<ICategory> overriddenCategories = categories.stream()
+        .filter(x -> categories.stream().anyMatch(y -> y != x && y.overrides(x, current))).collect(Collectors.toSet());
+    categories.removeAll(overriddenCategories);
   }
 
   /**

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/ICategory.java
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/category/ICategory.java
@@ -14,6 +14,7 @@ package org.polarsys.capella.common.ui.toolkit.browser.category;
 
 import java.util.List;
 
+import org.eclipse.emf.ecore.EObject;
 
 /**
  * Represents a category of elements in the tree viewer dedicated to semantic browsing.
@@ -115,4 +116,23 @@ public interface ICategory {
    * @return the category identifier.
    */
   public String getCategoryId();
+  
+  /**
+   * @return the type fully qualified name
+   */
+  public String getTypeFullyQualifiedName();
+  
+  /**
+   * 
+   * @param otherCategory
+   * @param current
+   * @return whether this category overrides another category in the context of current object
+   */
+  public boolean overrides(ICategory otherCategory, EObject current);
+  
+  /**
+   * 
+   * @return the symbolic name for the category (e.g. used in Capella interpreter)
+   */
+  public String getSymbolicName();
 }

--- a/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/internal/TypeHelper.java
+++ b/common/plugins/org.polarsys.capella.common.ui.toolkit.browser/src/org/polarsys/capella/common/ui/toolkit/browser/internal/TypeHelper.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.polarsys.capella.common.ui.toolkit.browser.internal;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.ClassUtils;
+import org.eclipse.emf.ecore.EObject;
+
 /**
  * 
  */
@@ -64,6 +70,25 @@ public class TypeHelper {
     for (int i = 0; i < interfaces.length; i++) {
       if (isSubtype(interfaces[i], type))
         return true;
+    }
+    return false;
+  }
+  
+  /**
+   * Check in the super interface hierarchy of a given object, classFQN1 is a sub-type of classFQN2
+   * 
+   * @param classFQN1
+   * @param classFQN2
+   * @param current
+   * @return
+   */
+  @SuppressWarnings("unchecked")
+  public boolean isSubtype(String classFQN1, String classFQN2, EObject current) {
+    Class<? extends EObject> clazz = current.getClass();
+    Map<String, Class> name2Interface = (Map<String, Class>) ClassUtils.getAllInterfaces(clazz).stream()
+        .collect(Collectors.toMap(i -> ((Class) i).getName(), i -> i));
+    if (name2Interface.containsKey(classFQN1) && name2Interface.containsKey(classFQN2)) {
+      return name2Interface.get(classFQN2).isAssignableFrom(name2Interface.get(classFQN1));
     }
     return false;
   }

--- a/core/plugins/org.polarsys.capella.core.diagram.helpers/src/org/polarsys/capella/core/diagram/helpers/TitleBlockHelper.java
+++ b/core/plugins/org.polarsys.capella.core.diagram.helpers/src/org/polarsys/capella/core/diagram/helpers/TitleBlockHelper.java
@@ -42,13 +42,11 @@ import org.eclipse.sirius.viewpoint.description.DAnnotation;
 import org.eclipse.sirius.viewpoint.description.DescriptionFactory;
 import org.eclipse.sirius.viewpoint.description.RepresentationElementMapping;
 import org.eclipse.swt.widgets.Text;
-import org.polarsys.capella.common.data.modellingcore.AbstractNamedElement;
 import org.polarsys.capella.common.helpers.EObjectLabelProviderHelper;
 import org.polarsys.capella.common.ui.toolkit.browser.category.CategoryRegistry;
 import org.polarsys.capella.common.ui.toolkit.browser.category.ICategory;
+import org.polarsys.capella.core.model.handler.helpers.CapellaAdapterHelper;
 import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
-
-import com.google.common.base.CaseFormat;
 
 /**
  * Various helpers for {@link DAnnotation} annotations on {@link Title Blocks} elements.
@@ -445,6 +443,7 @@ public class TitleBlockHelper {
 
   public static void getServicesProposals(Text textField, EObject target) {
     KeyStroke keyStroke;
+    EObject resolvedTarget = CapellaAdapterHelper.resolveDescriptorOrBusinessObject(target);
     try {
       keyStroke = KeyStroke.getInstance("Ctrl+Space");
       IContentProposalProvider provider = new IContentProposalProvider() {
@@ -454,15 +453,14 @@ public class TitleBlockHelper {
           IInterpreter vpInterpreter = CompoundInterpreter.INSTANCE.getInterpreterForExpression(contents);
 
           List<IContentProposal> proposalsList = new ArrayList<IContentProposal>();
-          ContentInstanceContext contentContext = new ContentInstanceContext(target, contents, position);
-
+          ContentInstanceContext contentContext = new ContentInstanceContext(resolvedTarget, contents, position);
           if (contents.contains(CAPELLA_PREFIX)) {
+            
             // get all the categories for target and match the command name from category with the command in TitleBlock
-            Set<ICategory> categories = CategoryRegistry.getInstance().gatherCategories(target);
+            Set<ICategory> categories = CategoryRegistry.getInstance().gatherCategories(resolvedTarget);
 
             for (ICategory category : categories) {
-              String proposalContent = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL,
-                  category.getName().trim().replaceAll(" ", "_"));
+              String proposalContent = category.getSymbolicName();
               if (proposalContent.toLowerCase().startsWith(contents.replaceFirst(CAPELLA_PREFIX, "").toLowerCase())) {
                 proposalsList
                     .add(new org.eclipse.jface.fieldassist.ContentProposal(proposalContent, proposalContent, null));

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaInterpreter.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaInterpreter.java
@@ -32,6 +32,7 @@ import org.eclipse.sirius.ecore.extender.business.api.accessor.ModelAccessor;
 import org.polarsys.capella.common.ui.toolkit.browser.category.CategoryRegistry;
 import org.polarsys.capella.common.ui.toolkit.browser.category.ICategory;
 import org.polarsys.capella.core.diagram.helpers.TitleBlockHelper;
+import org.polarsys.capella.core.model.handler.helpers.CapellaAdapterHelper;
 
 import com.google.common.base.CaseFormat;
 
@@ -73,12 +74,13 @@ public class CapellaInterpreter implements IInterpreterProvider, IInterpreter, T
   @Override
   public Object evaluate(EObject target, String expression) throws EvaluationException {
     Object result = null;
-    if (target != null && expression != null && expression.startsWith(PREFIX)) {
+    EObject resolvedTarget = CapellaAdapterHelper.resolveDescriptorOrBusinessObject(target);
+    if (resolvedTarget != null && expression != null && expression.startsWith(PREFIX)) {
       // extract the capella command
       String command = expression.substring(PREFIX.length(), expression.length()).trim();
 
       // get all the categories for target and match the command name from category with the command in TitleBlock
-      Set<ICategory> categories = CategoryRegistry.getInstance().gatherCategories(target).stream()
+      Set<ICategory> categories = CategoryRegistry.getInstance().gatherCategories(resolvedTarget).stream()
           .filter(category -> CaseFormat.UPPER_UNDERSCORE
               .to(CaseFormat.LOWER_CAMEL, category.getName().trim().replaceAll(" ", "_")).equals(command))
           .collect(Collectors.toSet());
@@ -87,7 +89,7 @@ public class CapellaInterpreter implements IInterpreterProvider, IInterpreter, T
         ICategory category = categories.iterator().next();
         if (category != null) {
           // execute the command
-          result = category.compute(target);
+          result = category.compute(resolvedTarget);
         }
       }
       else {

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/TitleBlockServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/TitleBlockServices.java
@@ -771,7 +771,8 @@ public class TitleBlockServices {
     } else {
       // we want to show/hide one or more Title Blocks in the diagram
       for (DDiagramElement aContainer : diagram.getDiagramElements()) {
-        if ((aContainer.getTarget() instanceof DAnnotation)) {
+        if ((aContainer.getTarget() instanceof DAnnotation)
+            && TitleBlockHelper.isTitleBlock((DAnnotation) aContainer.getTarget())) {
           DAnnotation annotation = (DAnnotation) aContainer.getTarget();
           if (annotation.getSource() != null)
             existingTitleBlocks.put(annotation, aContainer);


### PR DESCRIPTION
- Query evaluation should depend on object resolution (e.g. part/type in
mono-part mode)
- Query symbolic name is defined from SB code

Change-Id: Ie66aa419def26c9ee44ebd9bed41ca2af8e022be
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>