### PR TITLE
[558032] Store Title Block on DRepresentationDescriptor instead of DRepresentation

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.core.properties/src/org/polarsys/capella/core/data/core/properties/fields/TitleBlockBasicElementGroup.java
+++ b/core/plugins/org.polarsys.capella.core.data.core.properties/src/org/polarsys/capella/core/data/core/properties/fields/TitleBlockBasicElementGroup.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.sirius.business.api.dialect.command.RefreshRepresentationsCommand;
 import org.eclipse.sirius.common.tools.api.interpreter.EvaluationException;
 import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.sirius.viewpoint.description.DAnnotation;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
@@ -141,7 +142,7 @@ public class TitleBlockBasicElementGroup extends AbstractSemanticField {
   }
   
   private void updateTitleBlock(EObject object, String nameValue, String contentField) {
-    DDiagram diagram = (DDiagram) object.eContainer();
+    DRepresentationDescriptor descriptor = (DRepresentationDescriptor) object.eContainer();
     AbstractReadWriteCommand command = new AbstractReadWriteCommand() {
       @Override
       public void run() {
@@ -155,7 +156,7 @@ public class TitleBlockBasicElementGroup extends AbstractSemanticField {
         }
         
         RefreshRepresentationsCommand refreshCommand = new RefreshRepresentationsCommand(
-            TransactionUtil.getEditingDomain(diagram), new NullProgressMonitor(), diagram);
+            TransactionUtil.getEditingDomain(descriptor), new NullProgressMonitor(), descriptor.getRepresentation());
         refreshCommand.execute();
       }
     };
@@ -168,8 +169,7 @@ public class TitleBlockBasicElementGroup extends AbstractSemanticField {
     EObject container = titleBlockCell.eContainer();
     if (container instanceof DDiagram) {
       DDiagram diagram = (DDiagram) container;
-      DAnnotation titleBlock = TitleBlockHelper.getParentTitleBlock(titleBlockCell, diagram);
-
+      DAnnotation titleBlock = TitleBlockHelper.getParentTitleBlock(titleBlockCell);
       Object evaluateResult = TitleBlockHelper.getResultOfExpression(RepresentationHelper.getRepresentationDescriptor((DDiagram) diagram),
           contentTextField.getText(), titleBlock);
       if (evaluateResult instanceof EvaluationException) {

--- a/core/plugins/org.polarsys.capella.core.diagram.helpers/src/org/polarsys/capella/core/diagram/helpers/RepresentationAnnotationHelper.java
+++ b/core/plugins/org.polarsys.capella.core.diagram.helpers/src/org/polarsys/capella/core/diagram/helpers/RepresentationAnnotationHelper.java
@@ -17,7 +17,6 @@ import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.sirius.viewpoint.description.DAnnotation;
 import org.polarsys.capella.common.mdsofa.common.constant.ICommonConstants;
 import org.polarsys.capella.core.data.capellacore.EnumerationPropertyLiteral;
-import org.polarsys.capella.core.diagram.helpers.DAnnotationHelper;
 
 /**
  * Define DRepresentation annotation helpers.

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/providers/TitleBlockItemProvider.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/providers/TitleBlockItemProvider.java
@@ -12,14 +12,8 @@
  *******************************************************************************/
 package org.polarsys.capella.core.sirius.analysis.providers;
 
-import java.util.Collection;
-
 import org.eclipse.emf.common.notify.AdapterFactory;
-import org.eclipse.emf.ecore.EStructuralFeature.Setting;
-import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.viewpoint.description.DAnnotation;
-import org.eclipse.sirius.viewpoint.description.DescriptionPackage;
 import org.eclipse.sirius.viewpoint.description.provider.DAnnotationItemProvider;
 import org.polarsys.capella.core.diagram.helpers.TitleBlockHelper;
 
@@ -40,13 +34,9 @@ public class TitleBlockItemProvider extends DAnnotationItemProvider {
 
     } else if (TitleBlockHelper.isTitleBlockCell(annotation) || TitleBlockHelper.isTitleBlockLine(annotation)
         || TitleBlockHelper.isContentTitleBlock(annotation)) {
-      Session session = SessionManager.INSTANCE.getSession(annotation);
-      if (session != null) {
-        Collection<Setting> referencer = session.getSemanticCrossReferencer().getInverseReferences(annotation,
-            DescriptionPackage.Literals.DANNOTATION__REFERENCES, false);
-        if (!referencer.isEmpty()) {
-          return referencer.iterator().next().getEObject();
-        }
+      DAnnotation parent = TitleBlockHelper.getParentAnnotation(annotation);
+      if (parent != null) {
+        return parent;
       }
     }
     return super.getParent(object);

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/providers/TitleBlockItemProviderDecorator.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/providers/TitleBlockItemProviderDecorator.java
@@ -12,18 +12,12 @@
  *******************************************************************************/
 package org.polarsys.capella.core.sirius.analysis.providers;
 
-import java.net.URL;
-
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
 import org.eclipse.emf.edit.provider.IItemPropertySource;
 import org.eclipse.emf.edit.provider.IStructuredItemContentProvider;
 import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.sirius.viewpoint.description.DAnnotation;
 import org.polarsys.capella.core.data.gen.edit.decorators.ItemProviderAdapterDecorator;
 import org.polarsys.capella.core.diagram.helpers.TitleBlockHelper;

--- a/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/step/tools/titleblocks/InsertRemoveTitleBlockTool.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/step/tools/titleblocks/InsertRemoveTitleBlockTool.java
@@ -26,7 +26,9 @@ import java.util.Optional;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.sirius.viewpoint.description.DAnnotation;
+import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
 import org.polarsys.capella.core.sirius.analysis.DiagramServices;
 import org.polarsys.capella.core.sirius.analysis.actions.extensions.AbstractExternalJavaAction;
 import org.polarsys.capella.test.diagram.common.ju.context.DiagramContext;
@@ -43,7 +45,8 @@ public class InsertRemoveTitleBlockTool extends InsertRemoveTool {
 
   private DAnnotation getAnnotation(String uid) {
     DDiagram diagram = getDiagramContext().getDiagram();
-    Optional<DAnnotation> op = diagram.getEAnnotations().stream().filter(x -> x.getUid().equals(uid)).findFirst();
+    DRepresentationDescriptor descriptor = RepresentationHelper.getRepresentationDescriptor(diagram);
+    Optional<DAnnotation> op = descriptor.getEAnnotations().stream().filter(x -> x.getUid().equals(uid)).findFirst();
 
     if (op.isPresent()) {
       return op.get();


### PR DESCRIPTION
It avoids to add SRM resources to DAnalysis Semantic Resources when
DRepresentation are stored on SRM resources

Bug: 558032
Change-Id: I5b51ee6fb2a36ffd41c784c56f5731e1a6223e89
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>