### PR TITLE
[558032] Avoid exceptions when insert columns/rows of diagram title

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/preferences/TitleBlockPreferenceField.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/preferences/TitleBlockPreferenceField.java
@@ -151,10 +151,12 @@ public class TitleBlockPreferenceField extends FieldEditor {
   }
 
   private void disposeColumns() {
+    v.getTable().setRedraw(false);
     TableColumn[] columns = v.getTable().getColumns();
     for (TableColumn tc : columns) {
       tc.dispose();
     }
+    v.getTable().setRedraw(true);
   }
 
   private void refreshTableInsertColumns(int index) {


### PR DESCRIPTION
blocks in the preference page

Bug: 558032
Change-Id: I3d3bc514cc492485adeeb6b33d2ac9caceb6a946
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>