### PR TITLE
M2 Annotations for XMLPiviot/Orchestra Connector

### DIFF
--- a/m2/plugins/org.polarsys.capella.core.data.def/model/CompositeStructure.ecore
+++ b/m2/plugins/org.polarsys.capella.core.data.def/model/CompositeStructure.ecore
@@ -537,7 +537,6 @@
         <details key="constraints" value="none"/>
         <details key="comment/notes" value="none"/>
       </eAnnotations>
-      <eAnnotations source="http://www.polarsys.org/capella/semantic"/>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="realizedComponents" upperBound="-1"
         eType="#//Component" changeable="false" volatile="true" transient="true" derived="true">

--- a/m2/plugins/org.polarsys.capella.core.data.def/model/LogicalArchitecture.ecore
+++ b/m2/plugins/org.polarsys.capella.core.data.def/model/LogicalArchitecture.ecore
@@ -515,9 +515,7 @@
         <details key="constraints" value="none"/>
         <details key="comment/notes" value="none"/>
       </eAnnotations>
-      <eAnnotations source="http://www.polarsys.org/capella/semantic">
-        <details key="excludefrom" value="xmlpivot"/>
-      </eAnnotations>
+      <eAnnotations source="http://www.polarsys.org/capella/semantic"/>
       <eAnnotations source="http://www.polarsys.org/capella/derived">
         <details key="viatra.variant" value="alias"/>
         <details key="viatra.expression" value="realizedComponents"/>


### PR DESCRIPTION
So these 2 affect xml pivot and also the connector. It's not required urgently, but we should consider this before 5.0, as I had to hardcode some hacks into xmlpivot as workarounds.

I didn't generate java code though... should I, or can you do it?