### PR TITLE
[releng] Update Sirius version to 6.4.0-S20200716-044517 based on 2020-06

### DIFF
--- a/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
+++ b/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
@@ -357,7 +357,7 @@
           <repository
               url="http://download.eclipse.org/egf/updates/1.6.1/2019-06"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/releases/6.3.2/2019-06"/>
+              url="https://download.eclipse.org/sirius/updates/stable/6.4.0-S20200716-044517/2020-06/"/>
           <repository
               url="https://download.eclipse.org/diffmerge/releases/0.12.0/emf-diffmerge-site"/>
           <repository

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/releases/6.3.2/2019-06/targets/modules/gmf-runtime-1.13.tpd"
+include "https://download.eclipse.org/sirius/updates/stable/6.4.0-S20200716-044517/2020-06/targets/modules/gmf-runtime-1.13.tpd"
 
 with source, requirements
 
@@ -41,7 +41,7 @@ location eclipse "http://download.eclipse.org/releases/2019-06" {
 	org.eclipse.mylyn.help.ui
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/releases/6.3.2/2019-06/" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/6.4.0-S20200716-044517/2020-06/" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
There is no code change compared to 6.3.2 but only the bump to 6.4.0 and
the build done on 2020-06 platform

Change-Id: I98b50d35920b49d0d4a99bc135bc67f0bd653ed7
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>