### PR TITLE
[test] Avoid the installation of the test DAnalysisSelector

### DIFF
--- a/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/headless/selector/TestSessionManagerListener.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.common.ju/src/org/polarsys/capella/test/diagram/common/ju/headless/selector/TestSessionManagerListener.java
@@ -20,12 +20,14 @@ import org.eclipse.ui.PlatformUI;
 
 public class TestSessionManagerListener extends SessionManagerListener.Stub {
 
-  @Override
-  public void notify(Session updated, int notification) {
-    super.notify(updated, notification);
-    boolean enableHeadless = (PlatformUI.getTestableObject().getTestHarness() != null);
-    if (notification == SessionListener.OPENED && enableHeadless) {
-      ((DAnalysisSession) updated).setAnalysisSelector(HeadlessCapellaAnalysisSelector.INSTANCE);
-    }
-  }
+	@Override
+	public void notify(Session updated, int notification) {
+		if (!Boolean.getBoolean("capella.tests.disablecustomdanalysisselector")) {
+			super.notify(updated, notification);
+			boolean enableHeadless = (PlatformUI.getTestableObject().getTestHarness() != null);
+			if (notification == SessionListener.OPENED && enableHeadless) {
+				((DAnalysisSession) updated).setAnalysisSelector(HeadlessCapellaAnalysisSelector.INSTANCE);
+			}
+		}
+	}
 }


### PR DESCRIPTION
The org.polarsys.capella.test.diagram.common.ju plugin declares a
TestSessionManagerListener which will inject a test DAnalysisSelector in 
the Sirius Session.
It is sometimes painful when working in a development context because it
changes the runtime behavior and breaks a lot of tests.

This commit allows to deactivate the TestSessionManagerListener using
the system property "capella.tests.disablecustomdanalysisselector".

Change-Id: I07290b600abfa0836c8c21ec4b2faa3be987d5b7
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>