### PR TITLE
[566008] Display "Move Diagrams" menu after opening a diagram.

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/move/representation/MoveRepresentationMenuManager.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/move/representation/MoveRepresentationMenuManager.java
@@ -41,7 +41,7 @@ public class MoveRepresentationMenuManager extends MenuManager implements ISelec
   }
 
   public void initializeSubMenus(ISelection selection) {
-    // Remove existing menu items
+    // Remove existing menu items in order to make sure action contained list are freed at each selection time.
     this.removeAll();
 
     List<?> selectionList = ((IStructuredSelection) selection).toList();

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/providers/RepresentationActionProvider.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/providers/RepresentationActionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2014 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -96,8 +96,6 @@ public class RepresentationActionProvider extends CommonActionProvider {
    */
   @Override
   public void fillActionBars(IActionBars actionBars_p) {
-    // Make sure action contained list are freed at each selection time.
-    moveRepresentationMenu.dispose();
     actionBars_p.setGlobalActionHandler(ICommonActionConstants.OPEN, _openRepresentation);
     actionBars_p.setGlobalActionHandler(ActionFactory.DELETE.getId(), _deleteRepresentationAction);
     actionBars_p.setGlobalActionHandler(ActionFactory.RENAME.getId(), _renameRepresentationAction);


### PR DESCRIPTION
This commit display the "Move Diagrams" menu after opening a diagram.
This fix keeps the cleaning of the MoveDiagrams submenu items. Existing
associated rcptt tests do not fail.

Bug: 566008
Change-Id: Iba6426e8cbfb243c6aaf85d78e799418bfef61ff
Signed-off-by: jmallet <jessy.mallet@obeo.fr>