### PR TITLE
[565894] [CEI|CII] Show/Hide Actors dialog does not show existing actors

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaServices.java
@@ -1736,12 +1736,14 @@ public class CapellaServices {
    * @param second
    * @return
    */
-  public List<?> getIntersection(EObject eObject, List<?> first, List<?> second) {
-    if (first == null) // for acceleo2aql
-      first = new ArrayList<>();
-    List<Object> first2 = new LinkedList<>(first);
-    first2.retainAll(second);
-    return first2;
+  public Collection<?> getIntersection(EObject eObject, Collection<?> first, Collection<?> second) {
+    if (first == null) { // for acceleo2aql
+      first = Collections.emptyList();
+    }
+
+    List<Object> firstCopy = new LinkedList<>(first);
+    firstCopy.retainAll(second);
+    return firstCopy;
   }
 
   /**
@@ -2208,7 +2210,7 @@ public class CapellaServices {
     // an element can be displayed in a container, if all of its children can be displayed in that container
     // compute the subproblem on all children
     for (AbstractFunction subFunction : subFunctions) {
-      if (!isAllocatedFunction(subFunction, container, (DNodeContainer) containerView)) {
+      if (!isAllocatedFunction(subFunction, container, containerView)) {
         return false;
       }
     }


### PR DESCRIPTION
In order to compute the initial selection, the following aql expression
is used `aql:self.void2Null(self.getIntersection(visibleTargets,scope))`.

The `getIntersection` method takes two `java.util.List` as a parameter,
but for CEI|CII we provide a `java.util.Set` parameter.

Since the method signature does not match with the runtime arguments, we
get a void -> null initial selection.

Change-Id: I9d634561b0b22757128c9857486dc5e203395e40
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>