### PR TITLE
[566264] Some operations might create unwanted Entities as a side effect

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/epbs/EPBSArchitectureItemContribution.java
+++ b/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/epbs/EPBSArchitectureItemContribution.java
@@ -37,6 +37,7 @@ public class EPBSArchitectureItemContribution implements IMDEMenuItemContributio
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#selectionContribution()
    */
+  @Override
   public boolean selectionContribution(ModelElement modelElement, EClass cls, EStructuralFeature feature) {
     if ((modelElement instanceof SystemEngineering) && EpbsPackage.Literals.EPBS_ARCHITECTURE.equals(cls)
         && CapellacorePackage.Literals.ABSTRACT_MODELLING_STRUCTURE__OWNED_ARCHITECTURES.equals(feature)) {
@@ -48,6 +49,7 @@ public class EPBSArchitectureItemContribution implements IMDEMenuItemContributio
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#executionContribution()
    */
+  @Override
   public Command executionContribution(EditingDomain editingDomain, ModelElement containerElement,
       ModelElement createdElement, EStructuralFeature feature) {
     if ((createdElement instanceof EPBSArchitecture) && (containerElement instanceof SystemEngineering)) {
@@ -57,8 +59,7 @@ public class EPBSArchitectureItemContribution implements IMDEMenuItemContributio
         @Override
         protected void doExecute() {
           new CreateEPBSArchiCmd(engineering, NamingConstants.CreateEPBSArchCmd_name, architecture,
-              (PhysicalComponent) BlockArchitectureExt.getFirstComponent(architecture, false),
-              (EPBSArchitecture) createdElement).run();
+              (PhysicalComponent) architecture.getSystem(), (EPBSArchitecture) createdElement).run();
         }
       };
     }
@@ -68,6 +69,7 @@ public class EPBSArchitectureItemContribution implements IMDEMenuItemContributio
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#getMetaclass()
    */
+  @Override
   public EClass getMetaclass() {
     return EpbsPackage.Literals.EPBS_ARCHITECTURE;
   }

--- a/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/la/LogicalArchitectureItemContribution.java
+++ b/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/la/LogicalArchitectureItemContribution.java
@@ -38,6 +38,7 @@ public class LogicalArchitectureItemContribution implements IMDEMenuItemContribu
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#selectionContribution()
    */
+  @Override
   public boolean selectionContribution(ModelElement modelElement, EClass cls, EStructuralFeature feature) {
     if ((modelElement instanceof SystemEngineering) && LaPackage.Literals.LOGICAL_ARCHITECTURE.equals(cls)
         && CapellacorePackage.Literals.ABSTRACT_MODELLING_STRUCTURE__OWNED_ARCHITECTURES.equals(feature)) {
@@ -49,6 +50,7 @@ public class LogicalArchitectureItemContribution implements IMDEMenuItemContribu
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#executionContribution()
    */
+  @Override
   public Command executionContribution(EditingDomain editingDomain, ModelElement containerElement,
       ModelElement createdElement, EStructuralFeature feature) {
     if ((createdElement instanceof LogicalArchitecture) && (containerElement instanceof SystemEngineering)) {
@@ -59,8 +61,7 @@ public class LogicalArchitectureItemContribution implements IMDEMenuItemContribu
         protected void doExecute() {
           new CreateLogicalArchiCmd(engineering, NamingConstants.CreateLogicalArchCmd_name, architecture,
               (SystemFunction) BlockArchitectureExt.getRootFunction(architecture, false),
-              (SystemComponent) BlockArchitectureExt.getFirstComponent(architecture, false),
-              (LogicalArchitecture) createdElement).run();
+              (SystemComponent) architecture.getSystem(), (LogicalArchitecture) createdElement).run();
         }
       };
     }
@@ -70,6 +71,7 @@ public class LogicalArchitectureItemContribution implements IMDEMenuItemContribu
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#getMetaclass()
    */
+  @Override
   public EClass getMetaclass() {
     return LaPackage.Literals.LOGICAL_ARCHITECTURE;
   }

--- a/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/pa/PhysicalArchitectureItemContribution.java
+++ b/core/plugins/org.polarsys.capella.core.data.menu.contributions/src/org/polarsys/capella/core/data/menu/contributions/pa/PhysicalArchitectureItemContribution.java
@@ -38,6 +38,7 @@ public class PhysicalArchitectureItemContribution implements IMDEMenuItemContrib
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#selectionContribution()
    */
+  @Override
   public boolean selectionContribution(ModelElement modelElement, EClass cls, EStructuralFeature feature) {
     if ((modelElement instanceof SystemEngineering) && PaPackage.Literals.PHYSICAL_ARCHITECTURE.equals(cls)
         && CapellacorePackage.Literals.ABSTRACT_MODELLING_STRUCTURE__OWNED_ARCHITECTURES.equals(feature)) {
@@ -49,6 +50,7 @@ public class PhysicalArchitectureItemContribution implements IMDEMenuItemContrib
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#executionContribution()
    */
+  @Override
   public Command executionContribution(EditingDomain editingDomain, ModelElement containerElement,
       ModelElement createdElement, EStructuralFeature feature) {
     if ((createdElement instanceof PhysicalArchitecture) && (containerElement instanceof SystemEngineering)) {
@@ -58,7 +60,7 @@ public class PhysicalArchitectureItemContribution implements IMDEMenuItemContrib
         @Override
         protected void doExecute() {
           new CreatePhysicalArchiCmd(engineering, NamingConstants.CreatePhysicalArchCmd_name, architecture,
-              (LogicalComponent) BlockArchitectureExt.getFirstComponent(architecture, false),
+              (LogicalComponent) architecture.getSystem(),
               (LogicalFunction) BlockArchitectureExt.getRootFunction(architecture, false),
               (PhysicalArchitecture) createdElement).run();
         }
@@ -70,6 +72,7 @@ public class PhysicalArchitectureItemContribution implements IMDEMenuItemContrib
   /**
    * @see org.polarsys.capella.common.ui.menu.IMDEMenuItemContribution#getMetaclass()
    */
+  @Override
   public EClass getMetaclass() {
     return PaPackage.Literals.PHYSICAL_ARCHITECTURE;
   }

--- a/core/plugins/org.polarsys.capella.core.explorer.activity.ui/src/org/polarsys/capella/core/explorer/activity/ui/hyperlinkadapter/ModelCreationHelper.java
+++ b/core/plugins/org.polarsys.capella.core.explorer.activity.ui/src/org/polarsys/capella/core/explorer/activity/ui/hyperlinkadapter/ModelCreationHelper.java
@@ -65,7 +65,7 @@ public class ModelCreationHelper {
 
   protected static Scenario createScenario(AbstractCapability abstractCapability, ScenarioKind scenarioKind) {
     if (abstractCapability != null) {
-      Scenario sc = InteractionFactory.eINSTANCE.createScenario(); //$NON-NLS-1$
+      Scenario sc = InteractionFactory.eINSTANCE.createScenario(); // $NON-NLS-1$
       sc.setKind(scenarioKind);
       abstractCapability.getOwnedScenarios().add(sc);
       CapellaElementExt.creationService(sc);
@@ -90,7 +90,7 @@ public class ModelCreationHelper {
       defaultRegion = region;
     }
     if (defaultRegion == null) {
-      defaultRegion = CapellacommonFactory.eINSTANCE.createRegion(); //$NON-NLS-1$
+      defaultRegion = CapellacommonFactory.eINSTANCE.createRegion(); // $NON-NLS-1$
       defaultSM.getOwnedRegions().add(defaultRegion);
       CapellaElementExt.creationService(defaultRegion);
     }
@@ -115,6 +115,7 @@ public class ModelCreationHelper {
       }
       // No capability found, let's create a new one.
       AbstractReadWriteCommand cmd = new AbstractReadWriteCommand() {
+        @Override
         public void run() {
           result[0] = createAbstractCapability(capabilityPkg);
         }
@@ -128,21 +129,21 @@ public class ModelCreationHelper {
   public static AbstractCapability createAbstractCapability(AbstractCapabilityPkg capabilityPkg) {
     AbstractCapability result = null;
     if (capabilityPkg instanceof CapabilityPkg) {
-      result = CtxFactory.eINSTANCE.createCapability(); //$NON-NLS-1$
+      result = CtxFactory.eINSTANCE.createCapability(); // $NON-NLS-1$
       ((CapabilityPkg) capabilityPkg).getOwnedCapabilities().add((Capability) result);
     } else if (capabilityPkg instanceof CapabilityRealizationPkg) {
-      result = LaFactory.eINSTANCE.createCapabilityRealization(); //$NON-NLS-1$
+      result = LaFactory.eINSTANCE.createCapabilityRealization(); // $NON-NLS-1$
       ((CapabilityRealizationPkg) capabilityPkg).getOwnedCapabilityRealizations().add((CapabilityRealization) result);
     } else if (capabilityPkg instanceof OperationalCapabilityPkg) {
-      result = OaFactory.eINSTANCE.createOperationalCapability(); //$NON-NLS-1$
+      result = OaFactory.eINSTANCE.createOperationalCapability(); // $NON-NLS-1$
       ((OperationalCapabilityPkg) capabilityPkg).getOwnedOperationalCapabilities().add((OperationalCapability) result);
     }
     CapellaElementExt.creationService(result);
     return result;
   }
 
-  public static Scenario selectCapabilityAndCreateScenario(final Project project,
-      final BlockArchitecture architecture, final ScenarioKind scenarioKind) {
+  public static Scenario selectCapabilityAndCreateScenario(final Project project, final BlockArchitecture architecture,
+      final ScenarioKind scenarioKind) {
     AbstractReadWriteCommand cmd = new AbstractReadWriteCommand() {
       private Scenario scenario;
 
@@ -157,6 +158,7 @@ public class ModelCreationHelper {
       /**
        * @see java.lang.Runnable#run()
        */
+      @Override
       public void run() {
         AbstractCapability capability = selectCapability(project, architecture);
         if (capability != null) {
@@ -171,17 +173,20 @@ public class ModelCreationHelper {
 
   @Deprecated
   public static Scenario selectLACapabilityRealizationAndCreateDataFlowScenario(final Project project) {
-    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getLogicalArchitecture(project), ScenarioKind.DATA_FLOW);
+    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getLogicalArchitecture(project),
+        ScenarioKind.DATA_FLOW);
   }
 
   @Deprecated
   public static Scenario selectOperationalCapabilityAndCreateInteractionScenario(final Project project) {
-    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getOperationalAnalysis(project), ScenarioKind.INTERACTION);
+    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getOperationalAnalysis(project),
+        ScenarioKind.INTERACTION);
   }
 
   @Deprecated
   public static Scenario selectPACapabilityRealizationAndCreateDataFlowScenario(final Project project) {
-    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getPhysicalArchitecture(project), ScenarioKind.DATA_FLOW);
+    return selectCapabilityAndCreateScenario(project, ModelQueryHelper.getPhysicalArchitecture(project),
+        ScenarioKind.DATA_FLOW);
   }
 
   /**
@@ -230,10 +235,11 @@ public class ModelCreationHelper {
       /**
        * @see java.lang.Runnable#run()
        */
+      @Override
       public void run() {
         components[0] = selectComponent(architecture);
         if (null != components[0]) {
-          createStateMachineRegion(components[0]); //$NON-NLS-1$
+          createStateMachineRegion(components[0]); // $NON-NLS-1$
         }
       }
     };
@@ -258,7 +264,7 @@ public class ModelCreationHelper {
       return (Component) SelectionDialogHelper.simplePropertySelectionDialogWizard(new ArrayList<EObject>(components),
           PlatformUI.getWorkbench().getDisplay().getActiveShell());
     }
-    return BlockArchitectureExt.getFirstComponent(architecture, true);
+    return BlockArchitectureExt.getOrCreateSystem(architecture);
   }
 
 }

--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/BlockArchitectureExt.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/BlockArchitectureExt.java
@@ -684,15 +684,24 @@ public class BlockArchitectureExt {
    * @param architecture
    * @param create
    * @return
+   * 
+   * @deprecated use {@link BlockArchitecture::getSystem} or {@link BlockArchitectureExt::getOrCreateComponent} instead.
    */
+  @Deprecated
   public static Component getFirstComponent(BlockArchitecture architecture, boolean create) {
     Component first = null;
 
     if (architecture instanceof OperationalAnalysis) {
-      first = ((OperationalAnalysis) architecture).getSystem();
+      EntityPkg entityPkg = (EntityPkg) getComponentPkg(architecture, true);
+      EList<Entity> ownedEntities = entityPkg.getOwnedEntities();
+
+      first = ownedEntities.stream().filter(x -> !x.isActor()).findFirst().orElse(null);
+
       if ((first == null) && create) {
         first = OaFactory.eINSTANCE.createEntity(NamingConstants.CreateOaAnalysisCmd_entity_name);
-        ((EntityPkg) getComponentPkg(architecture, true)).getOwnedEntities().add((Entity) first);
+        ownedEntities.add((Entity) first);
+
+        CapellaElementExt.creationService(first);
       }
 
     } else if (architecture instanceof SystemAnalysis) {

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.actions/src/org/polarsys/capella/core/platform/sirius/ui/actions/AllocationManagementData.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.actions/src/org/polarsys/capella/core/platform/sirius/ui/actions/AllocationManagementData.java
@@ -11,7 +11,6 @@
  *    Thales - initial API and implementation
  *******************************************************************************/
 
-
 package org.polarsys.capella.core.platform.sirius.ui.actions;
 
 import java.util.ArrayList;
@@ -96,6 +95,7 @@ public class AllocationManagementData {
 
   /**
    * Return list of elements used for allocation or deployment
+   * 
    * @param element
    * @param titleMessage
    * @return
@@ -218,8 +218,8 @@ public class AllocationManagementData {
       // add all components from current architecture to temp list
       temp.addAll(BlockArchitectureExt.getAllComponents(arch));
       // remove first component from temp list
-      Component firstComponent = BlockArchitectureExt.getOrCreateSystem(arch);
-      if (!(arch instanceof SystemAnalysis)) {
+      Component firstComponent = arch.getSystem();
+      if (!(arch instanceof SystemAnalysis) && firstComponent != null) {
         temp.remove(firstComponent);
       }
       // filter ComponentContext from temp list... and add to result list
@@ -253,6 +253,7 @@ public class AllocationManagementData {
 
   /**
    * Return all the interfaces from all the layers
+   * 
    * @param element
    * @return
    */
@@ -270,6 +271,7 @@ public class AllocationManagementData {
 
   /**
    * Return all parts from PC layer (except the root and )
+   * 
    * @param nonDeployedPCParts
    * @return
    */
@@ -284,8 +286,11 @@ public class AllocationManagementData {
           return components;
         }
         // remove first component
-        Component firstComponent = BlockArchitectureExt.getOrCreateSystem(arch);
-        components.remove(firstComponent);
+        Component firstComponent = arch.getSystem();
+        if (firstComponent != null) {
+          components.remove(firstComponent);
+        }
+
         for (CapellaElement capellaElement : components) {
           if (capellaElement instanceof PhysicalComponent) {
             PhysicalComponent comp = (PhysicalComponent) capellaElement;
@@ -322,9 +327,9 @@ public class AllocationManagementData {
       if (null != arch) {
         for (ComponentExchange link : BlockArchitectureExt.getAllComponentExchanges(arch)) {
           // get availableComponentExhanges for current PhysicalLink
-          IBusinessQuery query =
-              BusinessQueriesProvider.getInstance().getContribution(FaPackage.Literals.COMPONENT_EXCHANGE,
-                  FaPackage.Literals.COMPONENT_EXCHANGE__OWNED_COMPONENT_EXCHANGE_FUNCTIONAL_EXCHANGE_ALLOCATIONS);
+          IBusinessQuery query = BusinessQueriesProvider.getInstance().getContribution(
+              FaPackage.Literals.COMPONENT_EXCHANGE,
+              FaPackage.Literals.COMPONENT_EXCHANGE__OWNED_COMPONENT_EXCHANGE_FUNCTIONAL_EXCHANGE_ALLOCATIONS);
           List<EObject> compExchanges = query.getAvailableElements(link);
           for (EObject functionalExchange : compExchanges) {
             // if availableComponentExhanges for current PhysicalLink is one of the selected component exchange
@@ -342,6 +347,7 @@ public class AllocationManagementData {
 
   /**
    * Returns all the physical link available for allocating <to be improved>
+   * 
    * @param nonAllocatedCompExcs
    * @return
    */
@@ -357,9 +363,8 @@ public class AllocationManagementData {
       if (arch instanceof PhysicalArchitecture) {
         for (PhysicalLink link : PhysicalArchitectureExt.getAllPhysicalLinks((PhysicalArchitecture) arch)) {
           // get availableComponentExhanges for current PhysicalLink
-          IBusinessQuery query =
-              BusinessQueriesProvider.getInstance().getContribution(CsPackage.Literals.PHYSICAL_LINK,
-                  FaPackage.Literals.COMPONENT_EXCHANGE_ALLOCATOR__OWNED_COMPONENT_EXCHANGE_ALLOCATIONS);
+          IBusinessQuery query = BusinessQueriesProvider.getInstance().getContribution(CsPackage.Literals.PHYSICAL_LINK,
+              FaPackage.Literals.COMPONENT_EXCHANGE_ALLOCATOR__OWNED_COMPONENT_EXCHANGE_ALLOCATIONS);
           List<EObject> compExchanges = query.getAvailableElements(link);
           for (EObject compExchange : compExchanges) {
             // if availableComponentExhanges for current PhysicalLink is one of the selected component exchange
@@ -377,6 +382,7 @@ public class AllocationManagementData {
 
   /**
    * return true if all he element in the list are of type AbstractFunction, false otherwise
+   * 
    * @return
    */
   private boolean areAllElementFunctions(List<EObject> elements) {
@@ -394,6 +400,7 @@ public class AllocationManagementData {
 
   /**
    * return true if all he element in the list are of type PhysicalComponent(!Node), false otherwise
+   * 
    * @return
    */
   private boolean areAllElementPCParts(List<EObject> elements) {
@@ -415,6 +422,7 @@ public class AllocationManagementData {
 
   /**
    * return true if all he element in the list are of type ExchangeItem, false otherwise
+   * 
    * @return
    */
   private boolean areAllElementExchangeItems(List<EObject> elements) {
@@ -432,7 +440,9 @@ public class AllocationManagementData {
 
   /**
    * allow multiple selection or not
-   * @param elements list of element selected
+   * 
+   * @param elements
+   *          list of element selected
    * @return
    */
   public boolean isMultiSelection(List<EObject> elements) {
@@ -447,6 +457,7 @@ public class AllocationManagementData {
 
   /**
    * decides weather list of elements are valid or not for allocation action
+   * 
    * @param elements
    * @return
    */
@@ -492,18 +503,22 @@ public class AllocationManagementData {
     } else if (allocationSelectionType == AllocationSelectionType.EXCHANGE_ITEM_ALLOCATION) {
       result = NLS.bind(Messages.Allocation_ExchangeItems_Selection_Message, new String[] { plural, elementsNames });
     } else if (allocationSelectionType == AllocationSelectionType.PHYSICAL_PART_DEPLOYMENT) {
-      result = NLS.bind(Messages.Allocation_PhysicalComponents_Selection_Message, new String[] { plural, elementsNames });
+      result = NLS.bind(Messages.Allocation_PhysicalComponents_Selection_Message,
+          new String[] { plural, elementsNames });
     } else if (allocationSelectionType == AllocationSelectionType.FUNCTIONAL_EXCHANGE_ALLOCATION) {
-      result = NLS.bind(Messages.Allocation_FunctionalExchagnes_Selection_Message, new String[] { plural, elementsNames });
+      result = NLS.bind(Messages.Allocation_FunctionalExchagnes_Selection_Message,
+          new String[] { plural, elementsNames });
     } else if (allocationSelectionType == AllocationSelectionType.COMPONENT_EXCHANGE_ALLOCATION) {
-      result = NLS.bind(Messages.Allocation_ComponentExchagnes_Selection_Message, new String[] { plural, elementsNames });
+      result = NLS.bind(Messages.Allocation_ComponentExchagnes_Selection_Message,
+          new String[] { plural, elementsNames });
     }
 
     return result;
   }
 
   /**
-   * @param dataMessage the dataMessage to set
+   * @param dataMessage
+   *          the dataMessage to set
    */
   private void setDataMessage(String dataMessage) {
     _dataMessage = dataMessage;
@@ -524,7 +539,8 @@ public class AllocationManagementData {
   }
 
   /**
-   * @param dataType the dataType to set
+   * @param dataType
+   *          the dataType to set
    */
   private void setAllocationType(AllocationSelectionType dataType) {
     _allocationType = dataType;
@@ -558,7 +574,8 @@ public class AllocationManagementData {
   }
 
   /**
-   * @param sourceDataVoid the sourceDataVoid to set
+   * @param sourceDataVoid
+   *          the sourceDataVoid to set
    */
   private void setSourceDataVoid(boolean sourceDataVoid) {
     _sourceDataVoid = sourceDataVoid;

--- a/core/plugins/org.polarsys.capella.core.re/src/org/polarsys/capella/core/re/rules/cs/PhysicalPortRule.java
+++ b/core/plugins/org.polarsys.capella.core.re/src/org/polarsys/capella/core/re/rules/cs/PhysicalPortRule.java
@@ -27,11 +27,11 @@ public class PhysicalPortRule extends org.polarsys.capella.core.transition.syste
   protected EObject getDefaultContainer(EObject element, EObject result, IContext context) {
     BlockArchitecture architecture = BlockArchitectureExt.getRootBlockArchitecture(element);
     EObject container = element.eContainer();
-    if (container != null && container.equals(BlockArchitectureExt.getFirstComponent(architecture, false))) {
+    if (container != null && container.equals(architecture.getSystem())) {
       EObject root = TransformationHandlerHelper.getInstance(context).getLevelElement(element, context);
       BlockArchitecture target = (BlockArchitecture) TransformationHandlerHelper.getInstance(context)
           .getBestTracedElement(root, context, CsPackage.Literals.BLOCK_ARCHITECTURE, element, result);
-      return BlockArchitectureExt.getFirstComponent(target, true);
+      return BlockArchitectureExt.getOrCreateSystem(target);
     }
     return super.getDefaultContainer(element, result, context);
   }

--- a/core/plugins/org.polarsys.capella.core.re/src/org/polarsys/capella/core/re/rules/fa/ComponentPortRule.java
+++ b/core/plugins/org.polarsys.capella.core.re/src/org/polarsys/capella/core/re/rules/fa/ComponentPortRule.java
@@ -27,11 +27,11 @@ public class ComponentPortRule extends org.polarsys.capella.core.transition.syst
   protected EObject getDefaultContainer(EObject element, EObject result, IContext context) {
     BlockArchitecture architecture = BlockArchitectureExt.getRootBlockArchitecture(element);
     EObject container = element.eContainer();
-    if (container != null && container.equals(BlockArchitectureExt.getFirstComponent(architecture, false))) {
+    if (container != null && container.equals(architecture.getSystem())) {
       EObject root = TransformationHandlerHelper.getInstance(context).getLevelElement(element, context);
       BlockArchitecture target = (BlockArchitecture) TransformationHandlerHelper.getInstance(context)
           .getBestTracedElement(root, context, CsPackage.Literals.BLOCK_ARCHITECTURE, element, result);
-      return BlockArchitectureExt.getFirstComponent(target, true);
+      return BlockArchitectureExt.getOrCreateSystem(target);
     }
     return super.getDefaultContainer(element, result, context);
   }

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/ContextServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/ContextServices.java
@@ -80,13 +80,13 @@ public class ContextServices {
   public List<EObject> getCRIComponents(DSemanticDecorator diagram) {
 
     EObject target = diagram.getTarget();
-    Component rootComponent = BlockArchitectureExt
-        .getOrCreateSystem(BlockArchitectureExt.getRootBlockArchitecture(target));
-
-    Collection<Component> subComponents = ComponentExt.getAllSubUsedComponents(rootComponent);
-
+    Component rootComponent = BlockArchitectureExt.getRootBlockArchitecture(target).getSystem();
     List<EObject> result = new ArrayList<>();
-    result.addAll(subComponents);
+
+    if (rootComponent != null) {
+      Collection<Component> subComponents = ComponentExt.getAllSubUsedComponents(rootComponent);
+      result.addAll(subComponents);
+    }
 
     return result;
   }
@@ -240,7 +240,7 @@ public class ContextServices {
         components = CsServices.getService().getSubComponents(parentContainer);
 
       } else if (parentContainer instanceof BlockArchitecture) {
-        Component firstComponent = BlockArchitectureExt.getOrCreateSystem((BlockArchitecture) parentContainer);
+        Component firstComponent = ((BlockArchitecture) parentContainer).getSystem();
 
         if (null != firstComponent) {
           components = CsServices.getService().getSubComponents(firstComponent);

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CsServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CsServices.java
@@ -1241,7 +1241,7 @@ public class CsServices {
         .executeQuery(QueryIdentifierConstants.GET_CCII_SHOW_HIDE_ACTORS, rootActorContainer);
     return Streams.concat(siblingActors.stream(), firstLevelRootActors.stream()).collect(Collectors.toSet());
   }
-  
+
   public Collection<Component> getIBShowHideActor(DSemanticDecorator decorator) {
     return QueryInterpretor.executeQuery(QueryIdentifierConstants.GET_IB_SHOW_HIDE_ACTORS_FOR_LIB, decorator);
   }
@@ -5915,7 +5915,7 @@ public class CsServices {
     if (parentContainer instanceof Component) {
       return getSubComponents(parentContainer);
     } else if (parentContainer instanceof BlockArchitecture) {
-      Component firstComponent = BlockArchitectureExt.getOrCreateSystem((BlockArchitecture) parentContainer);
+      Component firstComponent = ((BlockArchitecture) parentContainer).getSystem();
       if (null != firstComponent) {
         return getSubComponents(firstComponent);
       }

--- a/core/plugins/org.polarsys.capella.core.transition.diagram/src/org/polarsys/capella/core/transition/diagram/commands/DiagramTransitionRunnable.java
+++ b/core/plugins/org.polarsys.capella.core.transition.diagram/src/org/polarsys/capella/core/transition/diagram/commands/DiagramTransitionRunnable.java
@@ -82,6 +82,7 @@ import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 import org.eclipse.sirius.viewpoint.description.RepresentationDescription;
 import org.eclipse.swt.widgets.Shell;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
 import org.polarsys.capella.common.data.modellingcore.TraceableElement;
 import org.polarsys.capella.common.helpers.EObjectExt;
 import org.polarsys.capella.common.tools.report.EmbeddedMessage;
@@ -674,10 +675,13 @@ public class DiagramTransitionRunnable extends AbstractProcessingCommands<DDiagr
 
       if (targetView == null) {
         if (targetSemantic instanceof Part) {
-          if (((Part) targetSemantic).getAbstractType() instanceof Component) {
-            if (BlockArchitectureExt.getOrCreateSystem(BlockArchitectureExt.getRootBlockArchitecture(targetSemantic)).equals(
-                ((Part) targetSemantic).getAbstractType())) {
-              targetView = ((DSemanticDecorator)targetContents.getDDiagram());
+          AbstractType targetSemanticComponent = ((Part) targetSemantic).getAbstractType();
+          if (targetSemanticComponent instanceof Component) {
+            BlockArchitecture blockArchitecture = BlockArchitectureExt.getRootBlockArchitecture(targetSemantic);
+            Component systemComponent = blockArchitecture.getSystem();
+
+            if (targetSemanticComponent.equals(systemComponent)) {
+              targetView = ((DSemanticDecorator) targetContents.getDDiagram());
             }
           }
         }

--- a/core/plugins/org.polarsys.capella.core.transition.diagram/src/org/polarsys/capella/core/transition/diagram/handlers/ArchitectureHandler.java
+++ b/core/plugins/org.polarsys.capella.core.transition.diagram/src/org/polarsys/capella/core/transition/diagram/handlers/ArchitectureHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.diagram.description.EdgeMapping;
 import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 import org.eclipse.sirius.viewpoint.description.RepresentationDescription;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
 import org.polarsys.capella.core.data.cs.BlockArchitecture;
 import org.polarsys.capella.core.data.cs.Component;
 import org.polarsys.capella.core.data.cs.Part;
@@ -83,9 +84,10 @@ public class ArchitectureHandler extends AbstractDiagramHandler {
       DDiagramContents targetContents_p, AbstractNodeMapping mapping_p, DSemanticDecorator containerNode_p,
       EObject targetSemantic_p) {
     if (targetSemantic_p instanceof Part) {
-      if (((Part) targetSemantic_p).getAbstractType() instanceof PhysicalComponent) {
-        if (BlockArchitectureExt.getOrCreateSystem(BlockArchitectureExt.getRootBlockArchitecture(targetSemantic_p))
-            .equals(((Part) targetSemantic_p).getAbstractType())) {
+      AbstractType targetSemanticComponent = ((Part) targetSemantic_p).getAbstractType();
+      if (targetSemanticComponent instanceof PhysicalComponent) {
+        BlockArchitecture blockArchitecture = BlockArchitectureExt.getRootBlockArchitecture(targetSemantic_p);
+        if (targetSemanticComponent.equals(blockArchitecture.getSystem())) {
           return null;
         }
       }

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/commands/IntramodelTransitionCommand.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/commands/IntramodelTransitionCommand.java
@@ -116,7 +116,7 @@ public class IntramodelTransitionCommand extends LauncherCommand {
         rootElement = ComponentExt.getInterfacePkg((Component) rootElement, false);
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_DATA:
       if (rootElement instanceof BlockArchitecture) {
         rootElement = BlockArchitectureExt.getDataPkg((BlockArchitecture) rootElement, false);
@@ -125,10 +125,10 @@ public class IntramodelTransitionCommand extends LauncherCommand {
         rootElement = ComponentExt.getDataPkg((Component) rootElement, false);
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_STATEMACHINE:
       if (rootElement instanceof BlockArchitecture) {
-        rootElement = BlockArchitectureExt.getFirstComponent((BlockArchitecture) rootElement, false);
+        rootElement = ((BlockArchitecture) rootElement).getSystem();
       }
       if (rootElement instanceof Component) {
         Collection<Object> result = new HashSet<>();
@@ -136,7 +136,7 @@ public class IntramodelTransitionCommand extends LauncherCommand {
         return result;
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_ACTOR:
       Collection<Object> result = new HashSet<>();
       if (rootElement instanceof BlockArchitecture) {
@@ -155,13 +155,13 @@ public class IntramodelTransitionCommand extends LauncherCommand {
         result.add(rootElement);
       }
       return result;
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_SYSTEM:
       if (rootElement instanceof SystemComponentPkg) {
         rootElement = BlockArchitectureExt.getRootBlockArchitecture((SystemComponentPkg) rootElement);
       }
       if (rootElement instanceof BlockArchitecture) {
-        rootElement = BlockArchitectureExt.getFirstComponent((BlockArchitecture) rootElement, false);
+        rootElement = ((BlockArchitecture) rootElement).getSystem();
       }
       return Collections.singleton(rootElement);
     case ITopDownConstants.TRANSITION_TOPDOWN_LC2PC:
@@ -170,28 +170,28 @@ public class IntramodelTransitionCommand extends LauncherCommand {
         rootElement = BlockArchitectureExt.getComponentPkg((BlockArchitecture) rootElement, false);
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_OE2ACTOR:
     case ITopDownConstants.TRANSITION_TOPDOWN_OE2SYSTEM:
       if (rootElement instanceof OperationalAnalysis) {
         rootElement = ((OperationalAnalysis) rootElement).getOwnedEntityPkg();
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_CAPABILITY:
     case ITopDownConstants.TRANSITION_TOPDOWN_OC2SM:
       if (rootElement instanceof BlockArchitecture) {
         rootElement = BlockArchitectureExt.getAbstractCapabilityPkg((BlockArchitecture) rootElement, false);
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_OA2SC:
     case ITopDownConstants.TRANSITION_TOPDOWN_OA2SM:
       if (rootElement instanceof BlockArchitecture) {
         rootElement = BlockArchitectureExt.getFunctionPkg((BlockArchitecture) rootElement, false);
       }
       return Collections.singleton(rootElement);
-      
+
     case ITopDownConstants.TRANSITION_TOPDOWN_PROPERTYVALUE:
     case ITopDownConstants.TRANSITION_TOPDOWN_EXCHANGEITEM:
     default:

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/commands/TransitionCommandHelper.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/commands/TransitionCommandHelper.java
@@ -282,7 +282,7 @@ public class TransitionCommandHelper {
         && (CapellaLayerCheckingExt.isInLogicalLayer((CapellaElement) object)
             || CapellaLayerCheckingExt.isInContextLayer((CapellaElement) object));
   }
-  
+
   public boolean isExchangeItemTransitionAvailable(EObject object) {
     return ((object instanceof CapellaElement)
         && (CapellaLayerCheckingExt.isInContextLayer((CapellaElement) object)
@@ -356,13 +356,15 @@ public class TransitionCommandHelper {
     if (CapellaLayerCheckingExt.isInLogicalLayer((CapellaElement) object)) {
       Component component = getComponent(object);
       if ((component instanceof LogicalComponent && (ComponentExt.isExternalActor(component))) || //
-          ((object instanceof LogicalComponentPkg && !ComponentPkgExt.getExternalActors((ComponentPkg) object).isEmpty())) || //
+          ((object instanceof LogicalComponentPkg
+              && !ComponentPkgExt.getExternalActors((ComponentPkg) object).isEmpty()))
+          || //
           ((object instanceof ComponentExchange) && ComponentExchangeExt.isLinkToAnActor((ComponentExchange) object)) || //
           (object instanceof PhysicalLink)) {
         return true;
       }
     }
-    
+
     return false;
   }
 
@@ -376,11 +378,11 @@ public class TransitionCommandHelper {
 
     } else if (object instanceof SystemComponentPkg && object.eContainer() instanceof BlockArchitecture) {
       return true;
-      
+
     } else if (object instanceof SystemComponent) {
       BlockArchitecture architecture = BlockArchitectureExt.getRootBlockArchitecture(object);
-      return (object.equals(BlockArchitectureExt.getFirstComponent(architecture, false)));
-      
+      return (object.equals(architecture.getSystem()));
+
     }
     return false;
   }

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/MergeSourceConfiguration.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/MergeSourceConfiguration.java
@@ -79,8 +79,8 @@ public class MergeSourceConfiguration extends ExtendedTraceabilityConfiguration 
           BlockArchitectureExt.getRootFunction(target, false), context);
       addMapping(map, BlockArchitectureExt.getDataPkg(source, false), BlockArchitectureExt.getDataPkg(target, false),
           context);
-      addMapping(map, BlockArchitectureExt.getComponentPkg(source, false), BlockArchitectureExt.getComponentPkg(target, false),
-          context);
+      addMapping(map, BlockArchitectureExt.getComponentPkg(source, false),
+          BlockArchitectureExt.getComponentPkg(target, false), context);
 
       if (!((target instanceof PhysicalArchitecture) && !(source instanceof PhysicalArchitecture))) {
         addMapping(map, BlockArchitectureExt.getInterfacePkg(source, false),
@@ -91,16 +91,16 @@ public class MergeSourceConfiguration extends ExtendedTraceabilityConfiguration 
           BlockArchitectureExt.getRequirementsPkg(target, false), context);
       addMapping(map, BlockArchitectureExt.getAbstractCapabilityPkg(source, false),
           BlockArchitectureExt.getAbstractCapabilityPkg(target, false), context);
-      addMapping(map, BlockArchitectureExt.getFirstComponent(source, false),
-          BlockArchitectureExt.getFirstComponent(target, false), context);
+      addMapping(map, source.getSystem(), target.getSystem(), context);
     }
 
     @Override
     protected void initializeRootMappings(IContext context) {
       super.initializeRootMappings(context);
       addMappings(ContextHelper.getSourceProject(context), ContextHelper.getTransformedProject(context), context);
-      addMappings(ContextHelper.getSourceEngineering(context), ContextHelper.getTransformedEngineering(context), context);
-    } 
+      addMappings(ContextHelper.getSourceEngineering(context), ContextHelper.getTransformedEngineering(context),
+          context);
+    }
   }
 
   protected class TopDownSourceSIDTraceabilityHandler extends RealizationLinkTraceabilityHandler {
@@ -112,7 +112,8 @@ public class MergeSourceConfiguration extends ExtendedTraceabilityConfiguration 
     @Override
     protected void initializeRootMappings(IContext context) {
       super.initializeRootMappings(context);
-      initializeMappings(ContextHelper.getSourceProject(context), ContextHelper.getTransformedProject(context), context);
+      initializeMappings(ContextHelper.getSourceProject(context), ContextHelper.getTransformedProject(context),
+          context);
     }
 
   }

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/MergeTargetConfiguration.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/MergeTargetConfiguration.java
@@ -198,8 +198,8 @@ public class MergeTargetConfiguration extends ExtendedTraceabilityConfiguration 
           BlockArchitectureExt.getRootFunction(target, false), context);
       addMapping(map, BlockArchitectureExt.getDataPkg(source, false), BlockArchitectureExt.getDataPkg(target, false),
           context);
-      addMapping(map, BlockArchitectureExt.getComponentPkg(source, false), BlockArchitectureExt.getComponentPkg(target, false),
-          context);
+      addMapping(map, BlockArchitectureExt.getComponentPkg(source, false),
+          BlockArchitectureExt.getComponentPkg(target, false), context);
 
       if (!((target instanceof PhysicalArchitecture) && !(source instanceof PhysicalArchitecture))) {
         addMapping(map, BlockArchitectureExt.getInterfacePkg(source, false),
@@ -210,8 +210,7 @@ public class MergeTargetConfiguration extends ExtendedTraceabilityConfiguration 
           BlockArchitectureExt.getRequirementsPkg(target, false), context);
       addMapping(map, BlockArchitectureExt.getAbstractCapabilityPkg(source, false),
           BlockArchitectureExt.getAbstractCapabilityPkg(target, false), context);
-      addMapping(map, BlockArchitectureExt.getFirstComponent(source, false),
-          BlockArchitectureExt.getFirstComponent(target, false), context);
+      addMapping(map, source.getSystem(), target.getSystem(), context);
     }
 
     @Override
@@ -223,7 +222,8 @@ public class MergeTargetConfiguration extends ExtendedTraceabilityConfiguration 
   }
 
   public EObject getTargetEngineering(IContext context) {
-    //In topdown transition, like TargetProject is the same than SourceProject, the SystemEngineering is the same than the source
+    // In topdown transition, like TargetProject is the same than SourceProject, the SystemEngineering is the same than
+    // the source
     return ContextHelper.getSourceEngineering(context);
   }
 
@@ -252,7 +252,7 @@ public class MergeTargetConfiguration extends ExtendedTraceabilityConfiguration 
     addHandler(context, new TopDownRealizationTraceabilityHandler(getIdentifier(context)));
     addHandler(context, new LibraryTraceabilityHandler());
   }
-  
+
   public Collection<EObject> retrieveTracedElementsByRealization(EObject object, IContext context) {
     ITraceabilityHandler handler = getDefinedHandler(context, RealizationLinkTraceabilityHandler.class);
     if (handler != null) {

--- a/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/TransformationConfiguration.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system.topdown/src/org/polarsys/capella/core/transition/system/topdown/handlers/traceability/config/TransformationConfiguration.java
@@ -75,8 +75,7 @@ public class TransformationConfiguration extends ExtendedTraceabilityConfigurati
             BlockArchitectureExt.getRequirementsPkg(target, false), context);
         addMapping(map, BlockArchitectureExt.getAbstractCapabilityPkg(source, false),
             BlockArchitectureExt.getAbstractCapabilityPkg(target, false), context);
-        addMapping(map, BlockArchitectureExt.getFirstComponent(source, false),
-            BlockArchitectureExt.getFirstComponent(target, false), context);
+        addMapping(map, source.getSystem(), target.getSystem(), context);
       }
 
       /**

--- a/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/common/StateMachineRule.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/common/StateMachineRule.java
@@ -48,10 +48,9 @@ public class StateMachineRule extends AbstractCapellaElementRule {
   @Override
   protected EObject getDefaultContainer(EObject element, EObject result, IContext context) {
     EObject root = TransformationHandlerHelper.getInstance(context).getLevelElement(element, context);
-    BlockArchitecture target =
-        (BlockArchitecture) TransformationHandlerHelper.getInstance(context).getBestTracedElement(root, context, CsPackage.Literals.BLOCK_ARCHITECTURE,
-            element, result);
-    return BlockArchitectureExt.getFirstComponent(target, true);
+    BlockArchitecture target = (BlockArchitecture) TransformationHandlerHelper.getInstance(context)
+        .getBestTracedElement(root, context, CsPackage.Literals.BLOCK_ARCHITECTURE, element, result);
+    return BlockArchitectureExt.getOrCreateSystem(target);
   }
 
   /**
@@ -62,13 +61,16 @@ public class StateMachineRule extends AbstractCapellaElementRule {
    */
   @Override
   protected EObject getBestContainer(EObject element, EObject result, IContext context) {
-    ISelectionContext sContext = SelectionContextHandlerHelper.getHandler(context).getSelectionContext(context, ITransitionConstants.SELECTION_CONTEXT__TRANSFORMATION, element, result);
+    ISelectionContext sContext = SelectionContextHandlerHelper.getHandler(context).getSelectionContext(context,
+        ITransitionConstants.SELECTION_CONTEXT__TRANSFORMATION, element, result);
     EObject parent = element.eContainer();
     while (parent != null) {
-      EObject bestTracedElement = TransformationHandlerHelper.getInstance(context).getBestTracedElement(parent, context, sContext);
+      EObject bestTracedElement = TransformationHandlerHelper.getInstance(context).getBestTracedElement(parent, context,
+          sContext);
       if (bestTracedElement != null) {
-        EStructuralFeature containmentFeature = getTargetContainementFeature(element, result, bestTracedElement, context);
-        if (bestTracedElement.eClass().getEAllStructuralFeatures().contains(containmentFeature)){
+        EStructuralFeature containmentFeature = getTargetContainementFeature(element, result, bestTracedElement,
+            context);
+        if (bestTracedElement.eClass().getEAllStructuralFeatures().contains(containmentFeature)) {
           return bestTracedElement;
         }
       }
@@ -82,7 +84,7 @@ public class StateMachineRule extends AbstractCapellaElementRule {
    */
   @Override
   protected void retrieveContainer(EObject element, List<EObject> result, IContext context) {
-    
+
   }
 
   @Override
@@ -95,7 +97,8 @@ public class StateMachineRule extends AbstractCapellaElementRule {
     super.premicesRelated(element, needed);
 
     if (!(element.eContainer() instanceof org.polarsys.capella.core.data.information.Class)) {
-      Collection<EObject> transfoSources = (Collection<EObject>) getCurrentContext().get(ITransitionConstants.TRANSITION_SOURCES);
+      Collection<EObject> transfoSources = (Collection<EObject>) getCurrentContext()
+          .get(ITransitionConstants.TRANSITION_SOURCES);
       for (EObject transfoSource : transfoSources) {
         if ((transfoSource instanceof Part) || (transfoSource instanceof Component)) {
           needed.addAll(createDefaultPrecedencePremices(transfoSources, "part"));
@@ -111,20 +114,22 @@ public class StateMachineRule extends AbstractCapellaElementRule {
     result.addAll(sourceElement.getOwnedRegions());
 
     if (ContextScopeHandlerHelper.getInstance(context).contains(ITransitionConstants.SOURCE_SCOPE, source, context)) {
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, sourceElement.getOwnedRegions(), context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE,
+          sourceElement.getOwnedRegions(), context);
     }
 
   }
 
   @Override
-  protected EStructuralFeature getTargetContainementFeature(EObject element, EObject result, EObject container, IContext context) {
+  protected EStructuralFeature getTargetContainementFeature(EObject element, EObject result, EObject container,
+      IContext context) {
     if (container instanceof Component) {
       return CsPackage.Literals.BLOCK__OWNED_STATE_MACHINES;
     } else if (container instanceof Class) {
       return InformationPackage.Literals.CLASS__OWNED_STATE_MACHINES;
     } else if (container instanceof ComponentPkg) {
       return CsPackage.Literals.COMPONENT_PKG__OWNED_STATE_MACHINES;
-    } 
+    }
     return element.eContainingFeature();
   }
 

--- a/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/cs/ComponentRule.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/cs/ComponentRule.java
@@ -115,7 +115,7 @@ public class ComponentRule extends AbstractCapellaElementRule {
     if (result instanceof Entity || ComponentExt.isActor(result)) {
       return BlockArchitectureExt.getComponentPkg(target, true);
     }
-    return BlockArchitectureExt.getFirstComponent(target, true);
+    return BlockArchitectureExt.getOrCreateSystem(target);
   }
 
   @Override


### PR DESCRIPTION
The problem resides in the use of the
`org.polarsys.capella.core.model.helpers.BlockArchitectureExt.getFirstComponent(BlockArchitecture,
boolean: TRUE)` method in functions called at the Operational Level.

Since there is no Operational System concept at that level, this method
constantly creates a new Entity at each call.

Change-Id: I3f031760613b3c6759910bce56ea1d479d7a9e85
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>