### PR TITLE
[566392] Description can be lost when switching quickly between elements with an opened description editor in property view

### DIFF
--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -60,7 +60,7 @@ location sirius "https://download.eclipse.org/sirius/updates/stable/6.3.3-S20200
 	org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group
 }
 
-location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.1.IT5-1" {	
+location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/1.4.2it2" {	
 	org.polarsys.kitalpha.ad.runtime.feature.feature.group
 	org.polarsys.kitalpha.cadence.feature.feature.group
 	org.polarsys.kitalpha.common.feature.feature.group
@@ -87,7 +87,7 @@ location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/upd
 	org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group
 	org.polarsys.kitalpha.transposer.feature.feature.group
 }
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.1.IT5-1" {
+location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.2it2" {
 	org.polarsys.kitalpha.doc.feature.feature.group
 	org.polarsys.kitalpha.emde.sdk.feature.feature.group
 }


### PR DESCRIPTION
Due to the asynchronization of Nebula Richtext editor events, when we switch quickly between elements with an opened description editor in property view, the description of an element can be unexpectedly replaced by the description of another element. 
The solution for the bug 561365 was to dispatch all the events of Nebula Richtext editor for each action. However, this has some side-effects, for example double-click events appear without any reason.
We need to find a way to react to asynchronized events of Nebula Richtext editor instead of forcing them to be synchronized with our UI events.

Bug: 561365
Change-Id: Ie4febe641226dd431502e9974b3b00b8459f8498
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>