### PR TITLE
[566380] Actors can be decomposed in OAB diagrams by DnD model elements

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/src/org/polarsys/capella/core/data/cs/ui/quickfix/generator/DWF_DC_36_Generator.java
+++ b/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/src/org/polarsys/capella/core/data/cs/ui/quickfix/generator/DWF_DC_36_Generator.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.ui.IMarkerResolution;
 import org.polarsys.capella.common.tools.report.appenders.reportlogview.MarkerViewHelper;
 import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.cs.ui.quickfix.resolver.DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver;
 import org.polarsys.capella.core.data.cs.ui.quickfix.resolver.SwitchIsActorIsHumanFlag_Resolver;
 import org.polarsys.capella.core.data.cs.ui.quickfix.resolver.SwitchIsActorIsHumanFlag_ResolverAll;
 import org.polarsys.capella.core.data.oa.Entity;
@@ -43,10 +44,14 @@ public class DWF_DC_36_Generator extends AbstractMarkerResolutionGenerator {
       if (component instanceof Entity) {
         resolutions.add(new SwitchIsActorIsHumanFlag_Resolver(switch_OE, false, false));
         resolutions.add(new SwitchIsActorIsHumanFlag_ResolverAll(switch_OE, false, false));
+
+        resolutions.add(new DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver());
+
       } else {
         // switch to non human
         resolutions.add(new SwitchIsActorIsHumanFlag_Resolver(switch_non_human, component.isActor(), false));
         resolutions.add(new SwitchIsActorIsHumanFlag_ResolverAll(switch_non_human, component.isActor(), false));
+
       }
     }
 

--- a/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/src/org/polarsys/capella/core/data/cs/ui/quickfix/resolver/DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver.java
+++ b/core/plugins/org.polarsys.capella.core.data.cs.ui.quickfix/src/org/polarsys/capella/core/data/cs/ui/quickfix/resolver/DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.data.cs.ui.quickfix.resolver;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.emf.ecore.EObject;
+import org.polarsys.capella.common.ef.ExecutionManager;
+import org.polarsys.capella.common.ef.command.AbstractReadWriteCommand;
+import org.polarsys.capella.common.ef.command.ICommand;
+import org.polarsys.capella.common.helpers.TransactionHelper;
+import org.polarsys.capella.common.tools.report.appenders.reportlogview.MarkerViewHelper;
+import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.cs.Part;
+import org.polarsys.capella.core.data.oa.Entity;
+import org.polarsys.capella.core.data.oa.EntityPkg;
+import org.polarsys.capella.core.model.helpers.ComponentExt;
+import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractCapellaMarkerResolution;
+
+/**
+ * The DWF_DC_36 rule identifies Operational Human Actors that are decomposed (they contain child Entities). This quick
+ * fix moves all the invalid children to the closest valid ancestor.
+ *
+ */
+public class DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver extends AbstractCapellaMarkerResolution {
+
+  private static final String RULE_ID = "org.polarsys.capella.core.data.cs.validation.DWF_DC_36";
+
+  public DWF_DC_36_Children_To_Closest_Valid_Ancestor_Resolver() {
+    setLabel("Move children to their closest valid ancestor");
+  }
+
+  @Override
+  public void run(IMarker marker) {
+    List<EObject> elements = getModelElements(marker);
+
+    for (EObject element : elements) {
+      if (element instanceof Component) {
+        Component component = (Component) element;
+        Set<Component> allSubComponents = getAllSubComponents(component);
+
+        Set<Entity> allSubEntities = new HashSet<>();
+        Set<Part> allSubParts = new HashSet<>();
+
+        for (Component subComponent : allSubComponents) {
+          if (subComponent instanceof Entity) {
+            Entity entity = (Entity) subComponent;
+            List<Part> parts = entity.getRepresentingParts();
+
+            allSubEntities.add(entity);
+            allSubParts.addAll(parts);
+          }
+        }
+
+        EObject closestValidAncestor = getclosestValidAncestor(component);
+        ExecutionManager executionManager = TransactionHelper.getExecutionManager(component);
+        ICommand command = new MoveChildrenToClosestValidAncestorCommand(closestValidAncestor, allSubEntities,
+            allSubParts);
+
+        executionManager.execute(command);
+      }
+    }
+
+    deleteMarker(marker);
+
+  }
+
+  /**
+   * Since Actors that are decomposed might contain only a children part or a children entity without the part (due to
+   * the nature of the bug), we must extract both sub defined components and sub used components.
+   * 
+   * @param component
+   *          the component
+   * @return both sub defined components and sub used components
+   */
+  private static Set<Component> getAllSubComponents(Component component) {
+    Set<Component> allSubComponents = new HashSet<>();
+
+    Collection<Component> allSubDefinedComponents = ComponentExt.getAllSubDefinedComponents(component);
+    Collection<Component> allSubUsedComponents = ComponentExt.getAllSubUsedComponents(component);
+
+    allSubComponents.addAll(allSubDefinedComponents);
+    allSubComponents.addAll(allSubUsedComponents);
+
+    allSubComponents.remove(component);
+
+    return allSubComponents;
+  }
+
+  private static EObject getclosestValidAncestor(EObject root) {
+
+    for (EObject parent = root.eContainer(); parent != null; parent = parent.eContainer()) {
+      if (ComponentExt.canCreateABActor(parent)) {
+        return parent;
+      }
+    }
+
+    return null;
+  }
+
+  private static class MoveChildrenToClosestValidAncestorCommand extends AbstractReadWriteCommand {
+
+    private EObject closestValidAncestor;
+    private Set<Entity> allSubEntities;
+    private Set<Part> allSubParts;
+
+    public MoveChildrenToClosestValidAncestorCommand(EObject closestValidAncestor, Set<Entity> allSubEntities,
+        Set<Part> allSubParts) {
+      this.closestValidAncestor = closestValidAncestor;
+      this.allSubEntities = allSubEntities;
+      this.allSubParts = allSubParts;
+    }
+
+    @Override
+    public void run() {
+      if (closestValidAncestor instanceof Entity) {
+        Entity ancestor = (Entity) closestValidAncestor;
+        ancestor.getOwnedEntities().addAll(allSubEntities);
+        ancestor.getOwnedFeatures().addAll(allSubParts);
+
+      } else if (closestValidAncestor instanceof EntityPkg) {
+        EntityPkg ancestor = (EntityPkg) closestValidAncestor;
+        ancestor.getOwnedEntities().addAll(allSubEntities);
+        ancestor.getOwnedParts().addAll(allSubParts);
+
+      }
+    }
+  }
+
+  @Override
+  protected boolean canResolve(IMarker marker) {
+    String markerRuleId = MarkerViewHelper.getRuleID(marker, true);
+    return RULE_ID.equals(markerRuleId);
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/description/oa.odesign
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/description/oa.odesign
@@ -1179,7 +1179,7 @@
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
-          <ownedTools xsi:type="tool_1:ContainerDropDescription" name="DnD Entitiy" precondition="aql:element.isActor() or (element.oclIsKindOf(oa::Entity) and not (newViewContainer.target.isActor()))" mappings="//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']" moveEdges="true">
+          <ownedTools xsi:type="tool_1:ContainerDropDescription" name="DnD Entitiy" precondition="aql:element.isValidDndABComponent(newViewContainer)" mappings="//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']" moveEdges="true">
             <oldContainer name="oldSemanticContainer"/>
             <newContainer name="newSemanticContainer"/>
             <element name="element"/>

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/ABServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/ABServices.java
@@ -268,8 +268,7 @@ public class ABServices {
       if (pcMoved instanceof Part) {
         newComponentPkg.getOwnedParts().add((Part) pcMoved);
         component = (Component) ((Part) pcMoved).getType();
-      }
-      else if (pcMoved instanceof Component) {
+      } else if (pcMoved instanceof Component) {
         for (Part part : getCache(ComponentExt::getRepresentingParts, (Component) pcMoved)) {
           if (!newComponentPkg.equals(part.eContainer())) {
             newComponentPkg.getOwnedParts().add(part);
@@ -691,7 +690,22 @@ public class ABServices {
   }
 
   /**
-   * Returns whether the given part can be drop into the target element view
+   * Returns whether the given component can be dropped into the target element view
+   */
+  public boolean isValidDndABComponent(Component semanticObjectToDrop, EObject targetContainerView) {
+
+    List<Part> representingParts = semanticObjectToDrop.getRepresentingParts();
+
+    if (representingParts.isEmpty()) {
+      return false;
+    }
+
+    Part part = representingParts.get(0);
+    return isValidDndABComponent(part, targetContainerView);
+  }
+
+  /**
+   * Returns whether the given part can be dropped into the target element view
    */
   public boolean isValidDndABComponent(Part semanticObjectToDrop, EObject targetContainerView) {
     EObject context = null;

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/.project
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>OAB-DragAndDrop</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.afm
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_IUo5gObQEeqUc8Y6CrCvEA">
+  <viewpointReferences id="_IVZHcObQEeqUc8Y6CrCvEA" vpId="org.polarsys.capella.core.viewpoint" version="1.4.2"/>
+</metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.aird
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.aird
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/1.4.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_IU1GwObQEeqUc8Y6CrCvEA" selectedViews="_IVsCYObQEeqUc8Y6CrCvEA _IWukMObQEeqUc8Y6CrCvEA _IfhT0ObQEeqUc8Y6CrCvEA _IgtmoObQEeqUc8Y6CrCvEA _IhAhkObQEeqUc8Y6CrCvEA _IhwIcObQEeqUc8Y6CrCvEA _IiWlYObQEeqUc8Y6CrCvEA" version="14.3.1.202003261200">
+    <semanticResources>OAB-DragAndDrop.afm</semanticResources>
+    <semanticResources>OAB-DragAndDrop.melodymodeller</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IVsCYObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IWukMObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IfhT0ObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_LaYicebQEeqUc8Y6CrCvEA" name="[OAB] Operational Entities Package" repPath="#_LZ72gObQEeqUc8Y6CrCvEA" changeId="8340ea7f-45d8-4307-bedf-e8c4e078e1b9">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:EntityPkg" href="OAB-DragAndDrop.melodymodeller#2ae0ea1d-3afb-4b36-af9f-0660ee566f74"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_5xtmIebQEeqUc8Y6CrCvEA" name="[OAB] Operational Entities" repPath="#_5xkcMObQEeqUc8Y6CrCvEA" changeId="9b330136-d552-490d-8913-55fb27c88723">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#2b881abc-1497-43ee-be6b-a7eda9b85609"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IgtmoObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IhAhkObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IhwIcObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_IiWlYObQEeqUc8Y6CrCvEA">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_LZ72gObQEeqUc8Y6CrCvEA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_LardYObQEeqUc8Y6CrCvEA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_LardYebQEeqUc8Y6CrCvEA" type="Sirius" element="_LZ72gObQEeqUc8Y6CrCvEA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_OP4v8ObQEeqUc8Y6CrCvEA" type="2002" element="_OPl1AObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_OP4v8-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_OP4v9ObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_OP4v9ebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_OP4v9ubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_OP4v8ebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OP4v8ubQEeqUc8Y6CrCvEA" x="90" y="100"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_OmiVYObQEeqUc8Y6CrCvEA" type="2002" element="_OmFpcObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_OmiVY-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_OmiVZObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_OmiVZebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_OmiVZubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_OmiVYebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OmiVYubQEeqUc8Y6CrCvEA" x="90" y="250"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_PR5mkObQEeqUc8Y6CrCvEA" type="2002" element="_PRv1kObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_PR5mk-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_PR5mlObQEeqUc8Y6CrCvEA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_P8Ek8ObQEeqUc8Y6CrCvEA" type="3008" element="_P76z8ObQEeqUc8Y6CrCvEA">
+              <children xmi:type="notation:Node" xmi:id="_P8Ek8-bQEeqUc8Y6CrCvEA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_P8Ek9ObQEeqUc8Y6CrCvEA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_P8Ek9ebQEeqUc8Y6CrCvEA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_P8Ek9ubQEeqUc8Y6CrCvEA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_P8Ek8ebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_P8Ek8ubQEeqUc8Y6CrCvEA" x="55" y="34"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_PR5mlebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_PR5mlubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_PR5mkebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_PR5mkubQEeqUc8Y6CrCvEA" x="330" y="100"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_RfA-YObQEeqUc8Y6CrCvEA" type="2002" element="_ReuDcObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_RfA-Y-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_RfA-ZObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_RfA-ZebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_RfA-ZubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_RfA-YebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RfA-YubQEeqUc8Y6CrCvEA" x="330" y="250"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_SYF7fObQEeqUc8Y6CrCvEA" type="2002" element="_SX8KcObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_SYF7f-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_SYF7gObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_SYF7gebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_SYF7gubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_SYF7febQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SYF7fubQEeqUc8Y6CrCvEA" x="670" y="110"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_SvLlwObQEeqUc8Y6CrCvEA" type="2002" element="_SvCb0ObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_SvLlw-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_SvVWwObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_SvVWwebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_SvVWwubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_SvLlwebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SvLlwubQEeqUc8Y6CrCvEA" x="680" y="250"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_TWYIoObQEeqUc8Y6CrCvEA" type="2002" element="_TWFNsObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_TWYIo-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_TWYIpObQEeqUc8Y6CrCvEA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_UihLoObQEeqUc8Y6CrCvEA" type="3008" element="_UiFGwObQEeqUc8Y6CrCvEA">
+              <children xmi:type="notation:Node" xmi:id="_UihLo-bQEeqUc8Y6CrCvEA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_UihLpObQEeqUc8Y6CrCvEA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_UihLpebQEeqUc8Y6CrCvEA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_UihLpubQEeqUc8Y6CrCvEA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_UihLoebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UihLoubQEeqUc8Y6CrCvEA" x="65" y="24"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_TWYIpebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_TWYIpubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_TWYIoebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TWYIoubQEeqUc8Y6CrCvEA" x="960" y="110"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_TnOBAObQEeqUc8Y6CrCvEA" type="2002" element="_Tm6fAObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_TnOBA-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_TnOBBObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_TnOBBebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_TnOBBubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_TnOBAebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TnOBAubQEeqUc8Y6CrCvEA" x="960" y="250"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_LardYubQEeqUc8Y6CrCvEA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_LcBhMObQEeqUc8Y6CrCvEA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_LcBhMebQEeqUc8Y6CrCvEA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_OPl1AObQEeqUc8Y6CrCvEA" name="OE Valid Target 1">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#763b8cef-c9f1-43f1-b5fa-01705f5d868c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#763b8cef-c9f1-43f1-b5fa-01705f5d868c"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_OPl1AebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_OmFpcObQEeqUc8Y6CrCvEA" name="OA Source 1">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#61aecda1-b7d2-4e37-a201-a3a48db9128f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#61aecda1-b7d2-4e37-a201-a3a48db9128f"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_OmFpcebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_PRv1kObQEeqUc8Y6CrCvEA" name="OE 3">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#cf5a5e7b-6686-40ec-b324-2392bc08af21"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#cf5a5e7b-6686-40ec-b324-2392bc08af21"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_PRv1kebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_P76z8ObQEeqUc8Y6CrCvEA" name="OE Valid Target 2">
+        <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#9ae303c1-dacf-4ff5-bb52-0c9f8f444d5c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#9ae303c1-dacf-4ff5-bb52-0c9f8f444d5c"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_P76z8ebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ReuDcObQEeqUc8Y6CrCvEA" name="OA Source 2">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#eb6e23fd-ebc1-49b9-90f6-bc3b7da015cf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#eb6e23fd-ebc1-49b9-90f6-bc3b7da015cf"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ReuDcebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_SX8KcObQEeqUc8Y6CrCvEA" name="OA Invalid Target 3">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#d4f9cdb7-7f87-4ae4-9b37-83cf27662e01"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#d4f9cdb7-7f87-4ae4-9b37-83cf27662e01"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_SX8KcebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_SvCb0ObQEeqUc8Y6CrCvEA" name="OA Source 3">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#fd4263d8-6028-413b-8128-6c0c6cbc8a16"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#fd4263d8-6028-413b-8128-6c0c6cbc8a16"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_SvCb0ebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_TWFNsObQEeqUc8Y6CrCvEA" name="OE 7">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#6f97aee4-fd4f-4026-ad33-9a1650ddb57f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#6f97aee4-fd4f-4026-ad33-9a1650ddb57f"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TWFNsebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_UiFGwObQEeqUc8Y6CrCvEA" name="OA Invalid Target 4">
+        <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#c2f6c623-a5e2-42af-a678-33ab0a4de386"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#c2f6c623-a5e2-42af-a678-33ab0a4de386"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_UiOQsObQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Tm6fAObQEeqUc8Y6CrCvEA" name="OA Source 4">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#5d9f58ca-beff-44d8-97db-f89a218a9abf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#5d9f58ca-beff-44d8-97db-f89a218a9abf"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tm6fAebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_LaFngObQEeqUc8Y6CrCvEA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:EntityPkg" href="OAB-DragAndDrop.melodymodeller#2ae0ea1d-3afb-4b36-af9f-0660ee566f74"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_5xkcMObQEeqUc8Y6CrCvEA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5xtmIubQEeqUc8Y6CrCvEA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_5xtmI-bQEeqUc8Y6CrCvEA" type="Sirius" element="_5xkcMObQEeqUc8Y6CrCvEA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_6kiKMObQEeqUc8Y6CrCvEA" type="2002" element="_6kOoMObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_6kiKM-bQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_6kiKNObQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_6kiKNebQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_6kiKNubQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_6kiKMebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6kiKMubQEeqUc8Y6CrCvEA" x="70" y="80"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="__28fBObQEeqUc8Y6CrCvEA" type="2002" element="__2pkEObQEeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="__3Fo8ObQEeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="__3Fo8ebQEeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="__3Fo8ubQEeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="__3Fo8-bQEeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="__28fBebQEeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="__28fBubQEeqUc8Y6CrCvEA" x="110" y="230"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_AI05NubREeqUc8Y6CrCvEA" type="2002" element="_AIh-QObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_AI05OebREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_AI-DIObREeqUc8Y6CrCvEA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_AXIa-ObREeqUc8Y6CrCvEA" type="3008" element="_AW-p8ObREeqUc8Y6CrCvEA">
+              <children xmi:type="notation:Node" xmi:id="_AXIa--bREeqUc8Y6CrCvEA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_AXIa_ObREeqUc8Y6CrCvEA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_AXIa_ebREeqUc8Y6CrCvEA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_AXIa_ubREeqUc8Y6CrCvEA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_AXIa-ebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AXIa-ubREeqUc8Y6CrCvEA" x="95" y="24"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_AI-DIebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_AI-DIubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_AI05N-bREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AI05OObREeqUc8Y6CrCvEA" x="380" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ApmrAObREeqUc8Y6CrCvEA" type="2002" element="_ApTwEObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_ApmrA-bREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_ApmrBObREeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_ApmrBebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_ApmrBubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ApmrAebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ApmrAubREeqUc8Y6CrCvEA" x="790" y="90"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_BLblsObREeqUc8Y6CrCvEA" type="2002" element="_BLIqwObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_BLbls-bREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_BLbltObREeqUc8Y6CrCvEA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_BU0yQObREeqUc8Y6CrCvEA" type="3008" element="_BUhQQObREeqUc8Y6CrCvEA">
+              <children xmi:type="notation:Node" xmi:id="_BU0yQ-bREeqUc8Y6CrCvEA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_BU0yRObREeqUc8Y6CrCvEA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_BU0yRebREeqUc8Y6CrCvEA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_BU0yRubREeqUc8Y6CrCvEA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_BU0yQebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BU0yQubREeqUc8Y6CrCvEA" x="85" y="14"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BLbltebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BLbltubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BLblsebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BLblsubREeqUc8Y6CrCvEA" x="1040" y="95"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_EJui0ObREeqUc8Y6CrCvEA" type="2002" element="_EJbn4ObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_EJui0-bREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_EJui1ObREeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_EJui1ebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_EJui1ubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_EJui0ebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EJui0ubREeqUc8Y6CrCvEA" x="470" y="240"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Eb538ObREeqUc8Y6CrCvEA" type="2002" element="_Ebm9AObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_Eb538-bREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Eb539ObREeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Eb539ebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Eb539ubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Eb538ebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Eb538ubREeqUc8Y6CrCvEA" x="830" y="240"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Em7cRObREeqUc8Y6CrCvEA" type="2002" element="_EmySQObREeqUc8Y6CrCvEA">
+          <children xmi:type="notation:Node" xmi:id="_Em7cR-bREeqUc8Y6CrCvEA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Em7cSObREeqUc8Y6CrCvEA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Em7cSebREeqUc8Y6CrCvEA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Em7cSubREeqUc8Y6CrCvEA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Em7cRebREeqUc8Y6CrCvEA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Em7cRubREeqUc8Y6CrCvEA" x="1070" y="250"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_5xtmJObQEeqUc8Y6CrCvEA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_5xtmJebQEeqUc8Y6CrCvEA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_5xtmJubQEeqUc8Y6CrCvEA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_6kOoMObQEeqUc8Y6CrCvEA" name="OE Valid Target 5">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#56ca8893-569b-4966-9112-ddb5da5be5bf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#56ca8893-569b-4966-9112-ddb5da5be5bf"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_6kOoMebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="__2pkEObQEeqUc8Y6CrCvEA" name="OA Source 5">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#e1497434-470f-4a65-87b4-2914059f89bf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#e1497434-470f-4a65-87b4-2914059f89bf"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="__2pkEebQEeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_AIh-QObREeqUc8Y6CrCvEA" name="OE 4">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#5054c8a8-cf15-4662-98cb-01a3b216ae2d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#5054c8a8-cf15-4662-98cb-01a3b216ae2d"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_AIh-QebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_AW-p8ObREeqUc8Y6CrCvEA" name="OE Valid Target 6">
+        <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#eda8661f-5e36-41e7-82e1-d9c57d5950f4"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#eda8661f-5e36-41e7-82e1-d9c57d5950f4"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_AW-p8ebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ApTwEObREeqUc8Y6CrCvEA" name="OA Invalid Target 7">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#29d989c7-1d2c-4fcd-ae97-b451bef991d6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#29d989c7-1d2c-4fcd-ae97-b451bef991d6"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_ApTwEebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BLIqwObREeqUc8Y6CrCvEA" name="OE 3">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#c43ed794-6117-4270-9cca-850c5c64284b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#c43ed794-6117-4270-9cca-850c5c64284b"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BLIqwebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BUhQQObREeqUc8Y6CrCvEA" name="OA Invalid Target 8">
+        <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#ea80860d-1487-4fe9-af2a-c46b628f5467"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#ea80860d-1487-4fe9-af2a-c46b628f5467"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BUhQQebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EJbn4ObREeqUc8Y6CrCvEA" name="OA Source 6">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#1ede86e5-2ff0-4c41-9575-5297e0bcfe5b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#1ede86e5-2ff0-4c41-9575-5297e0bcfe5b"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EJbn4ebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Ebm9AObREeqUc8Y6CrCvEA" name="OA Source 7">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#1ec88d5f-a426-4636-adb4-0b99f70a5f01"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#1ec88d5f-a426-4636-adb4-0b99f70a5f01"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ebm9AebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EmySQObREeqUc8Y6CrCvEA" name="OA Source 8">
+      <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#39095f56-71f4-43cc-ae08-9e740bda13c9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#39095f56-71f4-43cc-ae08-9e740bda13c9"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EmySQebREeqUc8Y6CrCvEA" borderSize="1" borderSizeComputationExpression="1" borderColor="69,69,69" backgroundStyle="GradientTopToBottom" backgroundColor="249,248,245" foregroundColor="221,221,200">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer/@containerMappings[name='OAB_Entity1']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_5xkcMebQEeqUc8Y6CrCvEA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:Entity" href="OAB-DragAndDrop.melodymodeller#2b881abc-1497-43ee-be6b-a7eda9b85609"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.melodymodeller
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/model/OAB-DragAndDrop/OAB-DragAndDrop.melodymodeller
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_1.4.2-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/1.4.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/1.4.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/1.4.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/1.4.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/1.4.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/1.4.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/1.4.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/1.4.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/1.4.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/1.4.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/1.4.0"
+    id="57c62cb0-0f6b-4547-a54f-5d025719b517"
+    name="OAB-DragAndDrop">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="6c6e48e7-e68f-42e2-b354-3098a48819b1"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="6a703c34-03ec-4e12-9427-a06e458b2b6f" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="f9ab55aa-f485-47c0-a1b4-0d8d3cbfcae6" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="9a8d43b6-2cc0-4d30-9105-762c4f5f7d54" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="f0a8d009-61f6-4d64-854f-d3799888ebbd" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="6c6345f6-f350-4c39-aa01-e97a421af994" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="9150abbe-93f1-47c6-a030-b4316c69a206" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="41eeefc8-2b2a-4d74-b78a-d2db6865ec42" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="6092804c-7015-45d5-bdd2-8dc8388ebc93"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="a0cd4243-62db-4cb0-8962-c4a54c384023" name="OAB-DragAndDrop">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="afba25c3-4537-4672-bbf3-5a109826c057" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="eee25eee-2d45-4456-91b7-71746fa28cd6" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="cd76fbef-500a-42e2-b825-39ab1fb7c604" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="a47e1ca0-7cfc-47e1-a68b-26790b87e1ad" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="c9ee973b-a9dd-4cbe-a84b-b6f9a73f0b26" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="3829dc20-764d-401b-aca3-2d5c730c82fe" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="dd8097d2-7cd4-4b3f-abd8-852735aba339"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="2ae0ea1d-3afb-4b36-af9f-0660ee566f74"
+          name="Operational Entities">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="6b10701c-3668-4f2b-9a51-6c2f23eff0ea"
+            name="OE Valid Target 1" abstractType="#763b8cef-c9f1-43f1-b5fa-01705f5d868c"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="e5400406-4331-45f9-b7e3-c2d5eeb6dae1"
+            name="OA Source 1" abstractType="#61aecda1-b7d2-4e37-a201-a3a48db9128f"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="81e45ebf-5895-42ec-bb39-e798bbd1a4c6"
+            name="OE 3" abstractType="#cf5a5e7b-6686-40ec-b324-2392bc08af21"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="51374ed0-66b2-4e41-978c-523e810bf5ab"
+            name="OA Source 2" abstractType="#eb6e23fd-ebc1-49b9-90f6-bc3b7da015cf"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="2bd8fe10-e7b9-43a1-913c-3c5a16f2c339"
+            name="OA Invalid Target 3" abstractType="#d4f9cdb7-7f87-4ae4-9b37-83cf27662e01"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="b00a3431-f2b6-466f-bb6b-fb34dbbb5f8c"
+            name="OA Source 3" abstractType="#fd4263d8-6028-413b-8128-6c0c6cbc8a16"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="a3d06b08-bbbd-472f-afbc-3c498d01e042"
+            name="OE 7" abstractType="#6f97aee4-fd4f-4026-ad33-9a1650ddb57f"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="aff00538-cb0c-4a6e-b719-e514c106dc74"
+            name="OA Source 4" abstractType="#5d9f58ca-beff-44d8-97db-f89a218a9abf"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="0e09977d-1877-4878-953b-7226196c3006"
+            name="OE 9" abstractType="#2b881abc-1497-43ee-be6b-a7eda9b85609"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="5380e3e0-2c43-4074-a9a4-e5d5303f9d6a"
+            name="OA Source 5" abstractType="#e1497434-470f-4a65-87b4-2914059f89bf"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="f5c3d171-caa4-4671-be1c-f9f74540bb7a"
+            name="OA Invalid Target 7" abstractType="#29d989c7-1d2c-4fcd-ae97-b451bef991d6"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="2d9801c3-34c6-4425-ae62-d2ef031243cc"
+            name="OA Source 6" abstractType="#1ede86e5-2ff0-4c41-9575-5297e0bcfe5b"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="58e69923-0c56-4b19-a130-d62c49f34e28"
+            name="OA Source 7" abstractType="#1ec88d5f-a426-4636-adb4-0b99f70a5f01"/>
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="ac9ff1d5-0d09-48c8-afcb-c6c8b599e9b2"
+            name="OA Source 8" abstractType="#39095f56-71f4-43cc-ae08-9e740bda13c9"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="763b8cef-c9f1-43f1-b5fa-01705f5d868c"
+            name="OE Valid Target 1"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="61aecda1-b7d2-4e37-a201-a3a48db9128f"
+            name="OA Source 1" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="cf5a5e7b-6686-40ec-b324-2392bc08af21"
+            name="OE 3">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="e72a58b6-77cb-43da-bc3c-bd61dafe0293"
+              name="OE Valid Target 2" abstractType="#9ae303c1-dacf-4ff5-bb52-0c9f8f444d5c"/>
+          <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="9ae303c1-dacf-4ff5-bb52-0c9f8f444d5c"
+              name="OE Valid Target 2"/>
+        </ownedEntities>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="eb6e23fd-ebc1-49b9-90f6-bc3b7da015cf"
+            name="OA Source 2" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="d4f9cdb7-7f87-4ae4-9b37-83cf27662e01"
+            name="OA Invalid Target 3" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="fd4263d8-6028-413b-8128-6c0c6cbc8a16"
+            name="OA Source 3" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="6f97aee4-fd4f-4026-ad33-9a1650ddb57f"
+            name="OE 7">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="caaee45e-6ec2-4e4c-8a28-2317aff4af8e"
+              name="OA Invalid Target 4" abstractType="#c2f6c623-a5e2-42af-a678-33ab0a4de386"/>
+          <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="c2f6c623-a5e2-42af-a678-33ab0a4de386"
+              name="OA Invalid Target 4" actor="true" human="true"/>
+        </ownedEntities>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="5d9f58ca-beff-44d8-97db-f89a218a9abf"
+            name="OA Source 4" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="2b881abc-1497-43ee-be6b-a7eda9b85609"
+            name="OE 9">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="15989a6c-527d-448e-a7dd-52caf1666540"
+              name="OE Valid Target 5" abstractType="#56ca8893-569b-4966-9112-ddb5da5be5bf"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="9c1079fe-80d7-4430-85f3-075d3ca22b20"
+              name="OE 4" abstractType="#5054c8a8-cf15-4662-98cb-01a3b216ae2d"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="c48326cb-7150-4be7-9426-d2e27a01fcdf"
+              name="OE 3" abstractType="#c43ed794-6117-4270-9cca-850c5c64284b"/>
+          <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="56ca8893-569b-4966-9112-ddb5da5be5bf"
+              name="OE Valid Target 5"/>
+          <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="5054c8a8-cf15-4662-98cb-01a3b216ae2d"
+              name="OE 4">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a106ccda-8f17-4f13-a084-7488bc8efd97"
+                name="OE Valid Target 6" abstractType="#eda8661f-5e36-41e7-82e1-d9c57d5950f4"/>
+            <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="eda8661f-5e36-41e7-82e1-d9c57d5950f4"
+                name="OE Valid Target 6"/>
+          </ownedEntities>
+          <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="c43ed794-6117-4270-9cca-850c5c64284b"
+              name="OE 3">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="44716f1a-3e1e-4c44-a84e-92be2d656c3d"
+                name="OA Invalid Target 8" abstractType="#ea80860d-1487-4fe9-af2a-c46b628f5467"/>
+            <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="ea80860d-1487-4fe9-af2a-c46b628f5467"
+                name="OA Invalid Target 8" actor="true" human="true"/>
+          </ownedEntities>
+        </ownedEntities>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="e1497434-470f-4a65-87b4-2914059f89bf"
+            name="OA Source 5" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="29d989c7-1d2c-4fcd-ae97-b451bef991d6"
+            name="OA Invalid Target 7" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="1ede86e5-2ff0-4c41-9575-5297e0bcfe5b"
+            name="OA Source 6" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="1ec88d5f-a426-4636-adb4-0b99f70a5f01"
+            name="OA Source 7" actor="true" human="true"/>
+        <ownedEntities xsi:type="org.polarsys.capella.core.data.oa:Entity" id="39095f56-71f4-43cc-ae08-9e740bda13c9"
+            name="OA Source 8" actor="true" human="true"/>
+      </ownedEntityPkg>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="fa34b112-882d-407d-a94e-325675c18c73" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="cf52b948-2582-4c42-8165-a97a90108917" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="dc9e0d46-8c82-471d-8d90-1515c6651c95" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="b37e118f-451e-4b30-a548-f148b016a69b" targetElement="#cd76fbef-500a-42e2-b825-39ab1fb7c604"
+              sourceElement="#dc9e0d46-8c82-471d-8d90-1515c6651c95"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="858b8253-7435-4c43-b2fc-5f1543466d96" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="ba0b3950-3a48-4450-8246-7f7106fc72b8" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="c1593263-d7e2-4012-bfce-6c00a19cc4b0" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="4b475329-d822-4d8a-a021-0c1ea83eb1ff" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="18aa2e89-c779-47e3-8d33-1afde54ec342" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="33bbb6ce-b93a-4421-9fb3-4468eba9bb75" name="True" abstractType="#18aa2e89-c779-47e3-8d33-1afde54ec342"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="b4ccff9a-933c-466b-8fa1-9469a08920d3" name="False" abstractType="#18aa2e89-c779-47e3-8d33-1afde54ec342"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5e7cf3ec-5b29-45f8-a477-5f2e25f1ab37" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="4f2d2841-0a10-4826-ae8e-f0293243a082" name="" abstractType="#5e7cf3ec-5b29-45f8-a477-5f2e25f1ab37"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="46bb2ae9-49a8-4ea5-ad2c-8892fcc419c8" name="" abstractType="#5e7cf3ec-5b29-45f8-a477-5f2e25f1ab37"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="5565be33-4bbd-40fa-a309-aa90223a3096" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="286a663f-e506-4117-b3c9-9870473006e0" name="" abstractType="#11e22932-5a90-4ac2-960e-1d94abd67ad5"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9b725aef-c666-4698-86f1-b56bdb5f34b9" name="" abstractType="#11e22932-5a90-4ac2-960e-1d94abd67ad5"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="1d37f872-0cc4-4fd0-a712-34b411557438" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="876c3784-9143-4eb7-8926-7e695779529c" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="460f07a2-6bc8-450e-a1b6-3e554f00864d" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="4f2afa4e-6c0b-430a-b509-c01b00dfb468" name="" abstractType="#460f07a2-6bc8-450e-a1b6-3e554f00864d"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="ff3ae4ce-1950-4297-b42e-01060738b975" abstractType="#460f07a2-6bc8-450e-a1b6-3e554f00864d"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="61af8161-8668-4562-9c62-ad979ae97d76" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="f287770f-8c50-41db-adcd-c31cc2d10b49" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="3e32b1fb-3eea-4ea2-a743-b67605443cbb" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="34320df5-3e42-4e4f-b9b5-907c38e6769e" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="7269fed2-d410-4b6e-ad30-9a41de247846" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a153c6a7-c7dd-4cca-8630-5385090e0c85" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="38270675-fa66-44f1-8771-295f795ecb4f" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="0c8ddfa0-ae2c-41ab-a9da-d138666de308" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="98982156-655e-4f45-a381-f0c281775e3d" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="269777e2-3327-49a6-9202-7da116cce390" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="cdcb6da9-a204-40b0-8a2d-84c762260507" name="" abstractType="#269777e2-3327-49a6-9202-7da116cce390"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="11e22932-5a90-4ac2-960e-1d94abd67ad5" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="2dc2f44d-2250-49e5-9d7c-46a2a791efd7" name="" abstractType="#11e22932-5a90-4ac2-960e-1d94abd67ad5"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="c723dc29-565a-416c-a54b-31776e602a42" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="484cfc64-30b2-4c06-8dfe-36b763dc3724" name="" abstractType="#c723dc29-565a-416c-a54b-31776e602a42"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="caca7242-df8c-4267-a1fe-4d3a7a57f49c" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="48a39470-2487-457b-b688-e8d468ce8a9e" name="" abstractType="#caca7242-df8c-4267-a1fe-4d3a7a57f49c"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="9df97827-b6e6-4f71-babb-6c8fcbaa83fa" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="56d27e67-18d0-4aa8-a2bf-65a5e9a1a6f1"
+            name="System" abstractType="#55924582-fe8b-455e-8042-d430e806f17b"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="55924582-fe8b-455e-8042-d430e806f17b" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="930e4aca-e605-46ca-b79a-192fc5484d5b" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="a21de114-77e8-403b-be9e-9944f1011670" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="733eb1fe-ec60-4263-b2e6-7b069b8d93b6"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="5c3b7f6a-7e44-47f7-b1db-2a7427eea20b" targetElement="#afba25c3-4537-4672-bbf3-5a109826c057"
+          sourceElement="#fa34b112-882d-407d-a94e-325675c18c73"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="62d3c9bd-86e8-48b9-8e06-e8c8b25289a5" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="eb15d051-1297-423e-8132-a78f9b4934ab" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="b40b6a58-d627-4c28-99cd-75bf5b72a4db" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="33cbb951-3e9e-4c0c-92cd-ad8d5643606b" targetElement="#dc9e0d46-8c82-471d-8d90-1515c6651c95"
+              sourceElement="#b40b6a58-d627-4c28-99cd-75bf5b72a4db"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="854ef9b5-9bbe-4aef-82fd-e546439ba20f" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="0c7232b1-3075-4fb7-adb4-c49e62944dc9" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="f70c1b71-f466-4f0f-b03d-f8c4f922418a" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="9316ed83-c87e-4c89-92f2-a5383ba6a97f" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="b551c4dd-372e-4a65-b68a-8882db8cab2a"
+            name="Logical System" abstractType="#f7c479af-bb4f-450e-ad86-b28005634104"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="f7c479af-bb4f-450e-ad86-b28005634104" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="83ff7c52-b93a-43ef-938a-64030895b690" targetElement="#55924582-fe8b-455e-8042-d430e806f17b"
+              sourceElement="#f7c479af-bb4f-450e-ad86-b28005634104"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="0cc96df4-4a82-44f9-961a-56659a676aaa" targetElement="#fa34b112-882d-407d-a94e-325675c18c73"
+          sourceElement="#62d3c9bd-86e8-48b9-8e06-e8c8b25289a5"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="6c347361-027d-4984-95dc-f662413e9e0d" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="8f4ded8d-0125-461f-8133-26976c5bdc38" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="4ac697b6-f936-4566-bc3f-645b0be6fb29" name="Root Physical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="3c86f99a-93ff-4648-8441-67b002920757" targetElement="#b40b6a58-d627-4c28-99cd-75bf5b72a4db"
+              sourceElement="#4ac697b6-f936-4566-bc3f-645b0be6fb29"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="5c9f2761-5541-425c-af13-a9c7ada69f9b" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="b2f4b37d-644f-47a6-86fd-5200e4ab7d70" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="ed714ffe-bea3-4373-86dc-84b32cc4af6f" name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="0e252a34-ed51-4c26-834e-466e816d856e" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="5cafb40e-0ab3-4998-a5ac-ae4270bc5bb7"
+            name="Physical System" abstractType="#ee42c977-86c2-4fba-b574-99f26bb35a60"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="ee42c977-86c2-4fba-b574-99f26bb35a60" name="Physical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="4d544c2a-bc28-4b57-8886-f4e28388e7fc" targetElement="#f7c479af-bb4f-450e-ad86-b28005634104"
+              sourceElement="#ee42c977-86c2-4fba-b574-99f26bb35a60"/>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="f85bbefa-4667-4e31-aaad-9bfc055a83d4" targetElement="#62d3c9bd-86e8-48b9-8e06-e8c8b25289a5"
+          sourceElement="#6c347361-027d-4984-95dc-f662413e9e0d"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="c3b24db4-e254-4f4b-a56c-8e437322e265" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="2c21e2cb-e678-45b0-aebe-e7f693903692" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="a2b1a3b0-1128-488a-839b-f11de22e160b" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="e7aaf1fb-2cd1-4cce-be58-9c0dbc489225"
+            name="System" abstractType="#adb1ea40-7f65-4931-8b1b-d6340af50ed1"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="adb1ea40-7f65-4931-8b1b-d6340af50ed1" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="dc320275-288e-4a2a-a2a5-1fa4ac2d2cea" targetElement="#ee42c977-86c2-4fba-b574-99f26bb35a60"
+              sourceElement="#adb1ea40-7f65-4931-8b1b-d6340af50ed1"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="81427223-2cf6-40dd-b359-f5ec83f39d3c" targetElement="#6c347361-027d-4984-95dc-f662413e9e0d"
+          sourceElement="#c3b24db4-e254-4f4b-a56c-8e437322e265"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/testsuites/partial/XABDiagramToolsTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/testsuites/partial/XABDiagramToolsTestSuite.java
@@ -42,6 +42,7 @@ import org.polarsys.capella.test.diagram.tools.ju.xab.DeleteConstraintLink;
 import org.polarsys.capella.test.diagram.tools.ju.xab.DiagramPartIcon;
 import org.polarsys.capella.test.diagram.tools.ju.xab.DragAndDropEABTest;
 import org.polarsys.capella.test.diagram.tools.ju.xab.DragAndDropFunction;
+import org.polarsys.capella.test.diagram.tools.ju.xab.DragAndDropOABActors;
 import org.polarsys.capella.test.diagram.tools.ju.xab.DragAndDropPhysicalComponent;
 import org.polarsys.capella.test.diagram.tools.ju.xab.DragAndDropTest;
 import org.polarsys.capella.test.diagram.tools.ju.xab.ElementsFromModeAndStates;
@@ -136,7 +137,7 @@ public class XABDiagramToolsTestSuite extends BasicTestSuite {
     tests.add(new CreateComponentExchangeGroup());
     tests.add(new CreateActor());
     tests.add(new CreateComponentPort());
-    tests.add(new CreateComponentPortAllocation());    
+    tests.add(new CreateComponentPortAllocation());
     tests.add(new ReconnectComponentExchange());
     tests.add(new ManageBehaviorPCsDeployment());
     tests.add(new ReuseComponents());
@@ -147,7 +148,7 @@ public class XABDiagramToolsTestSuite extends BasicTestSuite {
     tests.add(new ShowHideActors());
     tests.add(new ShowHideBehaviorPCGroup());
     tests.add(new ShowHidePorts());
-    
+
     tests.add(new ShowHideComponentsMultipart());
     tests.add(new ShowHideActorsMultipart());
 
@@ -167,9 +168,9 @@ public class XABDiagramToolsTestSuite extends BasicTestSuite {
     tests.add(new XABShowHideFunctionsTestSuite());
     tests.add(new ShowHideFunctionalExchanges());
     tests.add(new ShowHidePortAllocations());
-    tests.add(new ShowHideFunctionPorts()); 
+    tests.add(new ShowHideFunctionPorts());
     tests.add(new InitializeDiagramInvalidFunction());
-    
+
     tests.add(new CreateConstraint());
     tests.add(new CreateConstraintElement());
     tests.add(new ShowHideConstraints());
@@ -188,6 +189,7 @@ public class XABDiagramToolsTestSuite extends BasicTestSuite {
     tests.add(new DragAndDropPhysicalComponent());
     tests.add(new DragAndDropTest());
     tests.add(new DragAndDropEABTest());
+    tests.add(new DragAndDropOABActors());
 
     tests.add(new ShowHideFETestCase());
     tests.add(new SwitchCategoryWithDelegation());

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/xab/DragAndDropOABActors.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/xab/DragAndDropOABActors.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.diagram.tools.ju.xab;
+
+import org.eclipse.sirius.business.api.session.Session;
+import org.junit.Assert;
+import org.polarsys.capella.core.model.helpers.BlockArchitectureExt;
+import org.polarsys.capella.test.diagram.common.ju.api.AbstractDiagramTestCase;
+import org.polarsys.capella.test.diagram.common.ju.context.XABDiagram;
+import org.polarsys.capella.test.framework.context.SessionContext;
+
+public class DragAndDropOABActors extends AbstractDiagramTestCase {
+
+  private static final String MODEL_NAME = "OAB-DragAndDrop";
+
+  public static final String OAB_OPERATIONAL_ENTITIES_PACKAGE = "[OAB] Operational Entities Package"; //$NON-NLS-1$
+
+  public static final String OA_SOURCE_1 = "61aecda1-b7d2-4e37-a201-a3a48db9128f"; //$NON-NLS-1$
+  public static final String OA_SOURCE_2 = "eb6e23fd-ebc1-49b9-90f6-bc3b7da015cf"; //$NON-NLS-1$
+  public static final String OA_SOURCE_3 = "fd4263d8-6028-413b-8128-6c0c6cbc8a16"; //$NON-NLS-1$
+  public static final String OA_SOURCE_4 = "5d9f58ca-beff-44d8-97db-f89a218a9abf"; //$NON-NLS-1$
+
+  public static final String OE_VALID_TARGET_1 = "763b8cef-c9f1-43f1-b5fa-01705f5d868c"; //$NON-NLS-1$
+  public static final String OE_VALID_TARGET_2 = "9ae303c1-dacf-4ff5-bb52-0c9f8f444d5c"; //$NON-NLS-1$
+  public static final String OA_INVALID_TARGET_3 = "d4f9cdb7-7f87-4ae4-9b37-83cf27662e01"; //$NON-NLS-1$
+  public static final String OA_INVALID_TARGET_4 = "c2f6c623-a5e2-42af-a678-33ab0a4de386"; //$NON-NLS-1$
+
+  public static final String OAB_OPERATIONAL_ENTITIES = "[OAB] Operational Entities"; //$NON-NLS-1$
+
+  public static final String OA_SOURCE_5 = "e1497434-470f-4a65-87b4-2914059f89bf"; //$NON-NLS-1$
+  public static final String OA_SOURCE_6 = "1ede86e5-2ff0-4c41-9575-5297e0bcfe5b"; //$NON-NLS-1$
+  public static final String OA_SOURCE_7 = "1ec88d5f-a426-4636-adb4-0b99f70a5f01"; //$NON-NLS-1$
+  public static final String OA_SOURCE_8 = "39095f56-71f4-43cc-ae08-9e740bda13c9"; //$NON-NLS-1$
+
+  public static final String OE_VALID_TARGET_5 = "56ca8893-569b-4966-9112-ddb5da5be5bf"; //$NON-NLS-1$
+  public static final String OE_VALID_TARGET_6 = "eda8661f-5e36-41e7-82e1-d9c57d5950f4"; //$NON-NLS-1$
+  public static final String OA_INVALID_TARGET_7 = "29d989c7-1d2c-4fcd-ae97-b451bef991d6"; //$NON-NLS-1$
+  public static final String OA_INVALID_TARGET_8 = "ea80860d-1487-4fe9-af2a-c46b628f5467"; //$NON-NLS-1$
+
+  private SessionContext context;
+
+  @Override
+  protected String getRequiredTestModel() {
+    return MODEL_NAME;
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    Session session = getSession(getRequiredTestModel());
+    context = new SessionContext(session);
+  }
+
+  @Override
+  public void test() throws Exception {
+
+    testOABEntitiesPackageDiagram();
+
+    testOABEntitiesDiagram();
+  }
+
+  public void testOABEntitiesPackageDiagram() {
+    XABDiagram diagram = XABDiagram.openDiagram(context, OAB_OPERATIONAL_ENTITIES_PACKAGE,
+        BlockArchitectureExt.Type.OA);
+
+    dragAndDropShouldSucceed(diagram, OA_SOURCE_1, OE_VALID_TARGET_1);
+    dragAndDropShouldSucceed(diagram, OA_SOURCE_2, OE_VALID_TARGET_2);
+
+    dragAndDropShouldFail(diagram, OA_SOURCE_3, OA_INVALID_TARGET_3);
+    dragAndDropShouldFail(diagram, OA_SOURCE_4, OA_INVALID_TARGET_4);
+
+    diagram.close();
+  }
+
+  public void testOABEntitiesDiagram() {
+    XABDiagram diagram = XABDiagram.openDiagram(context, OAB_OPERATIONAL_ENTITIES, BlockArchitectureExt.Type.OA);
+
+    dragAndDropShouldSucceed(diagram, OA_SOURCE_5, OE_VALID_TARGET_5);
+    dragAndDropShouldSucceed(diagram, OA_SOURCE_6, OE_VALID_TARGET_6);
+
+    dragAndDropShouldFail(diagram, OA_SOURCE_7, OA_INVALID_TARGET_7);
+    dragAndDropShouldFail(diagram, OA_SOURCE_8, OA_INVALID_TARGET_8);
+
+    diagram.close();
+  }
+
+  private static void dragAndDropShouldSucceed(XABDiagram diagram, String sourceId, String targetId) {
+    diagram.dragAndDropComponent(sourceId, targetId);
+  }
+
+  private static void dragAndDropShouldFail(XABDiagram diagram, String sourceId, String targetId) {
+    try {
+      diagram.dragAndDropComponent(sourceId, targetId);
+      Assert.fail(
+          "Drag and drop should have failed for diagram: " + diagram + " source " + sourceId + " target " + targetId);
+    } catch (AssertionError error) {
+      Assert.assertTrue(error.getMessage().startsWith("Precondition"));
+    }
+  }
+
+}


### PR DESCRIPTION
- Forbid actor decomposition
- Add a quick fix on DWF_DC_36 that moves the children to the nearest
valid ancestor
- Add JUnit

Change-Id: Iac2be81afff2e9c133ec7f098b39666ba95df33c
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>