### PR TITLE
[566393] Problems with the layout of the Capella search page

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchPage.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/CapellaSearchPage.java
@@ -102,15 +102,30 @@ public class CapellaSearchPage extends DialogPage implements ISearchPage, IRepla
   private CapellaLeftSearchForContainerArea leftCont;
   private CapellaRightSearchForContainerArea rightCont;
 
+  // A customized composite whose layout is not changed by the Search page
+  private class CompositeForSearchPage extends Composite {
+
+    public CompositeForSearchPage(Composite parent, int style) {
+      super(parent, style);
+    }
+
+    @Override
+    public void setLayoutData(Object layoutData) {
+      if (getLayoutData() == null)
+        super.setLayoutData(layoutData);
+    }
+  }
+
   @Override
   public void createControl(Composite parent) {
     initializeDialogUnits(parent);
     // init history searches
     previousSearchSettings.addAll(CapellaSearchSettingsHistory.getInstance().getAllSearchSettings());
 
-    Composite composite = new Composite(parent, SWT.NONE);
+    CompositeForSearchPage composite = new CompositeForSearchPage(parent, SWT.NONE);
     composite.setFont(parent.getFont());
-    GridLayoutFactory.swtDefaults().numColumns(2).applyTo(composite);
+    GridDataFactory.fillDefaults().grab(true, true).applyTo(composite);
+    GridLayoutFactory.swtDefaults().numColumns(2).equalWidth(false).applyTo(composite);
 
     // create the text field search area and checkboxes (case sensitive etc)
     createSearchPatternControls(composite);
@@ -146,7 +161,7 @@ public class CapellaSearchPage extends DialogPage implements ISearchPage, IRepla
   private void createLabelForComboSearchPattern(Composite group) {
     labelForComboSearchPattern = new Label(group, SWT.LEAD);
     labelForComboSearchPattern.setText(CapellaSearchConstants.CapellaSearchPage_Combo_Pattern_Label_Regex_Disabled);
-    GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).span(2, 1).grab(true, true)
+    GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).span(2, 1).grab(false, false)
         .applyTo(labelForComboSearchPattern);
     labelForComboSearchPattern.setFont(group.getFont());
   }
@@ -255,9 +270,8 @@ public class CapellaSearchPage extends DialogPage implements ISearchPage, IRepla
     Group scopeGroup = new Group(parent, SWT.NONE);
     scopeGroup.setLayout(new GridLayout(4, false));
 
-    GridData gdGrp = new GridData(GridData.FILL_BOTH);
-    gdGrp.horizontalSpan = 2;
-    scopeGroup.setLayoutData(gdGrp);
+    GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).span(2, 1).grab(false, false).applyTo(scopeGroup);
+
     scopeGroup.setText(CapellaSearchConstants.ScopeGroup_text);
 
     workspaceBtn = new Button(scopeGroup, SWT.RADIO);

--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/AbstractCapellaSearchForContainerArea.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/AbstractCapellaSearchForContainerArea.java
@@ -82,7 +82,7 @@ public abstract class AbstractCapellaSearchForContainerArea {
 
     GridData chechboxTreeViewerGridData = new GridData(GridData.FILL_BOTH);
     chechboxTreeViewerGridData.heightHint = 140;
-    chechboxTreeViewerGridData.widthHint = 140;
+    chechboxTreeViewerGridData.widthHint = 250;
 
     filteredTree.getViewer().getTree().setLayoutData(chechboxTreeViewerGridData);
 

--- a/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/CapellaLeftSearchForContainerArea.java
+++ b/core/plugins/org.polarsys.capella.core.ui.search/src/org/polarsys/capella/core/ui/search/searchfor/CapellaLeftSearchForContainerArea.java
@@ -31,7 +31,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
@@ -127,11 +126,10 @@ public class CapellaLeftSearchForContainerArea extends AbstractCapellaSearchForC
 
   public void createFiltercontainer(Group parentGroup) {
     Group searchForSelectionGroup = new Group(parentGroup, SWT.NONE);
-    GridLayoutFactory.swtDefaults().numColumns(2).applyTo(searchForSelectionGroup);
 
-    GridData gdGrp = new GridData(GridData.FILL_BOTH);
-    gdGrp.widthHint = 50;
-    searchForSelectionGroup.setLayoutData(gdGrp);
+    GridLayoutFactory.swtDefaults().numColumns(2).applyTo(searchForSelectionGroup);
+    GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).span(2, 1).grab(false, false)
+        .applyTo(searchForSelectionGroup);
 
     searchForSelectionGroup.setText(CapellaSearchConstants.Filters_Label);
     checkboxFilterAbstract = createCheckboxFilters(searchForSelectionGroup, CapellaSearchConstants.Abstract_Label,
@@ -143,7 +141,7 @@ public class CapellaLeftSearchForContainerArea extends AbstractCapellaSearchForC
   private Button createCheckboxFilters(Composite group, String label, boolean selected) {
     Button checkboxFilters = new Button(group, SWT.CHECK);
     checkboxFilters.setText(label);
-    GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).applyTo(checkboxFilters);
+    GridDataFactory.fillDefaults().applyTo(checkboxFilters);
     checkboxFilters.setFont(group.getFont());
     checkboxFilters.setSelection(selected);
 


### PR DESCRIPTION
There are some problems with the layout of Capella search page:
1. The filtered tree does not grab the extra space when possible. When we resize the Search dialog or expand it, the filtered tree does not change its size.
2. The filter checkboxs are not well layouted. Sometimes it's overlapped by other fields.

Bug: 566393
Change-Id: I1d7784618f3cea70fc4b7ccb409c3a8065faf260
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>