### PR TITLE
[566558] Inserting an image in relative path fails on Properties description tab

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
@@ -89,6 +89,8 @@ public abstract class ElementDescriptionGroup {
   protected GridData reloadBtnGridData;
   
   protected Composite parentComposite;
+  
+  private String baseHrefPath;
 
   private static final String EXISTED_EDITOR_TEXT = "The description is currently opened in an editor. Please use this editor to edit your description."; //$NON-NLS-1$
   
@@ -527,11 +529,15 @@ public abstract class ElementDescriptionGroup {
   }
 
   protected MDERichTextWidget showEditor() {
+    MDERichTextWidget widget;
     if (!RichtextManager.getInstance().isOnWidget(descriptionContainer)) {
-      MDERichTextWidget widget = RichtextManager.getInstance().addWidget(descriptionContainer);
-      return widget;
+      widget = RichtextManager.getInstance().addWidget(descriptionContainer);
+    } else {
+      widget = RichtextManager.getInstance().getRichtextWidget(descriptionContainer);
     }
-    return RichtextManager.getInstance().getRichtextWidget(descriptionContainer);
+    // Make sure editor's base href path is always set
+    widget.setBaseHrefPath(baseHrefPath);
+    return widget;
   }
 
   protected void hideEditor() {
@@ -542,6 +548,14 @@ public abstract class ElementDescriptionGroup {
 
   public boolean shouldRefresh() {
     return descriptionTextField == null || !descriptionTextField.hasFocus();
+  }
+  
+  public String getBaseHrefPath() {
+    return baseHrefPath;
+  }
+
+  public void setBaseHrefPath(String baseHrefPath) {
+    this.baseHrefPath = baseHrefPath;
   }
   
 }

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/fields/ElementDescriptionGroup.java
@@ -419,7 +419,9 @@ public abstract class ElementDescriptionGroup {
    * Save the text field's content
    */
   public void save() {
-    descriptionTextField.saveContent();
+    if (descriptionTextField.getElement() != null && descriptionTextField.getFeature() != null) {
+      descriptionTextField.saveContent();
+    }
   }
 
   /**

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/DescriptionPropertySection.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/DescriptionPropertySection.java
@@ -26,6 +26,7 @@ import org.polarsys.capella.core.ui.properties.richtext.RichtextManager;
 import org.polarsys.capella.core.ui.properties.richtext.fields.CapellaElementDescriptionGroup;
 import org.polarsys.capella.core.ui.properties.richtext.fields.FallbackDescriptionGroup;
 import org.polarsys.capella.core.ui.properties.sections.AbstractSection;
+import org.polarsys.kitalpha.richtext.common.util.MDERichTextHelper;
 
 public abstract class DescriptionPropertySection extends AbstractSection {
 
@@ -163,5 +164,11 @@ public abstract class DescriptionPropertySection extends AbstractSection {
   @Override
   public void performFinish() {
     descriptionGroup.save();
+  }
+  
+  @Override
+  public void loadData(EObject object) {
+    super.loadData(object);
+    descriptionGroup.setBaseHrefPath(MDERichTextHelper.getProjectPath(object));
   }
 }

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/04. User Interface/4.06. Properties View.html
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/04. User Interface/4.06. Properties View.html
@@ -132,6 +132,12 @@
 				<b>HKEY_CURRENT_USER / SOFTWARE / Internet Explorer / Main / FeatureControl / FEATURE_SPELLCHECKING / eclipse.exe = (DWORD) 00000001</b> and then restart the application.
 			</li>
 		</ul>
+		<p>
+			<b>Known issues</b>
+		</p>
+		<ul>
+			<li>The editor is web-based which makes the text in the editor is saved in an asynchronous way. Some actions can lead to the lost of its text, for example, double-clicking on an element right after modifying the text in the property view. To avoid all of these issues, users should click on the Save button inside the editor to make sure everything is properly saved.</li>
+		</ul>
 		<p><hr/>
 
 			<b>Disable Richtext</b>

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/04. User Interface/4.06. Properties View.mediawiki
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/04. User Interface/4.06. Properties View.mediawiki
@@ -117,6 +117,10 @@ If not activated, there are two possibilities:
 * Verify whether the language pack used for spellchecking is installed on the system. If you want to check the typing in French, the French language package must be installed on the Windows. One way to verify the available languages for spellchecking is to look at the folder '''%AppData%\Microsoft\Spelling'''
 * Override the registry value for the feature control '''HKEY_CURRENT_USER / SOFTWARE / Internet Explorer / Main / FeatureControl / FEATURE_SPELLCHECKING / eclipse.exe = (DWORD) 00000001''' and then restart the application.
 
+'''Known issues'''
+
+* The editor is web-based which makes the text in the editor is saved in an asynchronous way. Some actions can lead to the lost of its text, for example, double-clicking on an element right after modifying the text in the property view. To avoid all of these issues, users should click on the Save button inside the editor to make sure everything is properly saved.
+
 ----
 '''Disable Richtext'''
 


### PR DESCRIPTION
* The bug is due the fact that editor's href path MUST be set before the editor is ready. Since we load the data for the editor in asynchronous jobs (to avoid concurrency problems), we must find a way to set the href path before launching the editor.
* Update the doc about known issues

Bug: 566558
Change-Id: I2ad8e11afb55a6dc6c9ac69b1831da6a727321dc
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>