### PR TITLE
[Releng] Do not remove maven folders in the final product

### DIFF
--- a/releng/plugins/org.polarsys.capella.rcp.product/pom.xml
+++ b/releng/plugins/org.polarsys.capella.rcp.product/pom.xml
@@ -89,9 +89,6 @@
 									<!-- Create the Capella .zip with 2 folders (capella + samples) -->
 									
 									<zip destfile="${project.build.directory}/products/capella-${unqualifiedVersion}.${buildQualifier}-linux-gtk-x86_64.zip">
-										<zipfileset dir="${project.build.directory}/products/org.polarsys.capella.rcp.product/linux/gtk/x86_64" prefix="capella">
-											<exclude name="**/META-INF/maven/**"/>
-										</zipfileset>
 										<zipfileset dir="../../../samples" prefix="samples">
 											<exclude name="target/**"/>
 											<exclude name="pom.xml"/>
@@ -99,9 +96,6 @@
 									</zip>
 									
 									<zip destfile="${project.build.directory}/products/capella-${unqualifiedVersion}.${buildQualifier}-macosx-cocoa-x86_64.zip">
-										<zipfileset dir="${project.build.directory}/products/org.polarsys.capella.rcp.product/macosx/cocoa/x86_64" prefix="capella">
-											<exclude name="**/META-INF/maven/**"/>
-										</zipfileset>
 										<zipfileset dir="../../../samples" prefix="samples">
 											<exclude name="target/**"/>
 											<exclude name="pom.xml"/>
@@ -112,9 +106,6 @@
 										  tofile="${project.build.directory}/products/org.polarsys.capella.rcp.product/win32/win32/x86_64/capellac.exe"/>
 									
 									<zip destfile="${project.build.directory}/products/capella-${unqualifiedVersion}.${buildQualifier}-win32-win32-x86_64.zip">
-										<zipfileset dir="${project.build.directory}/products/org.polarsys.capella.rcp.product/win32/win32/x86_64" prefix="capella">
-											<exclude name="**/META-INF/maven/**"/>
-										</zipfileset>
 										<zipfileset dir="../../../samples" prefix="samples">
 											<exclude name="target/**"/>
 											<exclude name="pom.xml"/>


### PR DESCRIPTION
We want to remove maven folder in plugins in the final product but these
plugins are already signed. If the content of the plugin changes, we'll
end up with invalid plugins in our product.

Change-Id: I33137e98f5b2defae614a245c9d29118e98be03c
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>