### PR TITLE
[releng] Add the dependency to org.antlr.runtime v3.2.0 so that RCPTT

### DIFF
--- a/core/features/org.polarsys.capella.core.feature/feature.xml
+++ b/core/features/org.polarsys.capella.core.feature/feature.xml
@@ -37,4 +37,12 @@
          id="org.polarsys.capella.core.properties.richtext.feature"
          version="0.0.0"/>
 
+   <!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=548517 -->
+   <plugin
+         id="org.antlr.runtime"
+         download-size="0"
+         install-size="0"
+         version="3.2.0.v201101311130"
+         unpack="false"/>
+
 </feature>

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -114,3 +114,7 @@ location orbit-R20160221192158 "https://download.eclipse.org/tools/orbit/downloa
 	com.google.guava [15.0.0.v201403281430,15.0.0.v201403281430]
 }
 
+location orbit-R20140525021250 "http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository" {
+	org.antlr.runtime 3.2.0.v201101311130
+}
+


### PR DESCRIPTION
works with Eclipse 2020-06

The rcptt team has not yet fixed the bug
https://bugs.eclipse.org/bugs/show_bug.cgi?id=548517

This is the only workaround available for the moment.

Change-Id: Iff65c05d5a1c59752ff5f51885125e3b8d5ac766
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>