### PR TITLE
[568599] [Regression] The resulting CSV file after export to Excel of metrics on model is not sorted

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/actions/MetricAction.java
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/actions/MetricAction.java
@@ -87,10 +87,8 @@ public class MetricAction extends BaseSelectionListenerAction {
 
     if (metricTree != null) {
       for (MetricTree<EObject> leaf : metricTree.getLeafs()) {
-
         EObject container = leaf.getElement();
         Map<EClass, Integer> classToCount = countObjectByClass(container);
-
         for (Entry<EClass, Integer> entry : classToCount.entrySet()) {
           // Create temporary objects just to get their name and image.
           EClass eClass = entry.getKey();
@@ -99,6 +97,7 @@ public class MetricAction extends BaseSelectionListenerAction {
           MetricTree<EObject> newTreeNode = new MetricTree<>(tempEObject, leaf);
           newTreeNode.increaseCount(countOfClass);
         }
+        leaf.sortChildren();
       }
     }
     return metricTree;

--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/core/MetricTree.java
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/core/MetricTree.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 
+import org.eclipse.emf.ecore.EObject;
+import org.polarsys.capella.core.ui.metric.dialog.MetricLabelProvider;
+
 public class MetricTree<T> {
 
   private MetricTree<T> parent = null;
@@ -95,6 +98,20 @@ public class MetricTree<T> {
     }
 
     return leafs;
+  }
+  
+  public void sortChildren() {
+    MetricLabelProvider labelProvider = new MetricLabelProvider();
+    children.sort((obj1, obj2) -> {
+      String text1 = labelProvider.getText(obj1);
+      String text2 = labelProvider.getText(obj2);
+      if (text1.equals(text2)) {
+        // In case of meta-classes with the same name, use the fully qualified name to have the exact order
+        return ((EObject) obj1.getElement()).eClass().getInstanceTypeName()
+            .compareTo(((EObject) obj2.getElement()).eClass().getInstanceTypeName());
+      }
+      return text1.compareTo(text2);
+    });
   }
 
 }

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/build.properties
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/build.properties
@@ -16,4 +16,5 @@ bin.includes = META-INF/,\
                .,\
                about.html,\
                plugin.properties,\
-               model/
+               model/,\
+               testResult/

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/src/org/polarsys/capella/test/progressmonitoring/ju/testcases/MetricTest.java
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/src/org/polarsys/capella/test/progressmonitoring/ju/testcases/MetricTest.java
@@ -12,16 +12,25 @@
  *******************************************************************************/
 package org.polarsys.capella.test.progressmonitoring.ju.testcases;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.business.api.session.Session;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.polarsys.capella.core.data.capellamodeller.Project;
 import org.polarsys.capella.core.data.capellamodeller.SystemEngineering;
 import org.polarsys.capella.core.libraries.model.CapellaModel;
+import org.polarsys.capella.core.model.helpers.BlockArchitectureExt.Type;
 import org.polarsys.capella.core.ui.metric.actions.MetricAction;
 import org.polarsys.capella.core.ui.metric.core.MetricTree;
 import org.polarsys.capella.core.ui.metric.dialog.MetricLabelProvider;
@@ -31,186 +40,6 @@ public class MetricTest extends BasicTestCase {
 
   @Override
   public void test() throws Exception {
-    Map<String, Integer> oaMetrics = new HashMap<>();
-    oaMetrics.put("Change Event", 1);
-    oaMetrics.put("Combined Fragment", 2);
-    oaMetrics.put("Communication Mean", 2);
-    oaMetrics.put("Constraint", 4);
-    oaMetrics.put("Data Pkg", 2);
-    oaMetrics.put("Entity", 8);
-    oaMetrics.put("Entity Pkg", 1);
-    oaMetrics.put("Execution", 15);
-    oaMetrics.put("Fragment End", 4);
-    oaMetrics.put("Interaction", 23);
-    oaMetrics.put("Initial Pseudo State", 1);
-    oaMetrics.put("Instance Role", 3);
-    oaMetrics.put("Operand", 4);
-    oaMetrics.put("Interface Pkg", 1);
-    oaMetrics.put("Opaque Expression", 3);
-    oaMetrics.put("Operational Activity", 24);
-    oaMetrics.put("Operational Activity Pkg", 1);
-    oaMetrics.put("Operational Capability", 3);
-    oaMetrics.put("Operational Capability Pkg", 1);
-    oaMetrics.put("Operational Context", 1);
-    oaMetrics.put("Operational Process", 2);
-    oaMetrics.put("Part", 8);
-    oaMetrics.put("Region", 7);
-    oaMetrics.put("Requirements Pkg", 1);
-    oaMetrics.put("Role Pkg", 1);
-    oaMetrics.put("Scenario", 1);
-    oaMetrics.put("Sequence Message", 15);
-    oaMetrics.put("State Fragment", 6);
-    oaMetrics.put("State Machine", 1);
-    oaMetrics.put("State Transition", 7);
-
-    Map<String, Integer> saMetrics = new HashMap<>();
-    saMetrics.put("Abstract Capability Include", 1);
-    saMetrics.put("Actor Pkg", 1);
-    saMetrics.put("Association", 8);
-    saMetrics.put("Boolean Type", 1);
-    saMetrics.put("Capability", 13);
-    saMetrics.put("Capability Exploitation", 12);
-    saMetrics.put("Capability Pkg", 1);
-    saMetrics.put("Change Event", 1);
-    saMetrics.put("Choice Pseudo State", 2);
-    saMetrics.put("Class", 7);
-    saMetrics.put("Constraint", 7);
-    saMetrics.put("Data Pkg", 3);
-    saMetrics.put("Deep History Pseudo State", 1);
-    saMetrics.put("Enumeration", 1);
-    saMetrics.put("Enumeration Literal", 3);
-    saMetrics.put("Exchange Category", 7);
-    saMetrics.put("Execution", 25);
-    saMetrics.put("Final State", 2);
-    saMetrics.put("Function Input Port", 41);
-    saMetrics.put("Function Output Port", 40);
-    saMetrics.put("Functional Chain", 10);
-    saMetrics.put("Functional Exchange", 41);
-    saMetrics.put("Initial Pseudo State", 4);
-    saMetrics.put("Instance Role", 19);
-    saMetrics.put("State", 36);
-    saMetrics.put("Interface Pkg", 1);
-    saMetrics.put("Key Value", 3);
-    saMetrics.put("= <undefined>", 46);
-    saMetrics.put("Mission", 5);
-    saMetrics.put("Mission Pkg", 1);
-    saMetrics.put("Mode", 24);
-    saMetrics.put("Opaque Expression", 7);
-    saMetrics.put("Part", 5);
-    saMetrics.put("undefined", 23);
-    saMetrics.put("Region", 27);
-    saMetrics.put("Requirements Pkg", 1);
-    saMetrics.put("Scenario", 6);
-    saMetrics.put("Sequence Message", 25);
-    saMetrics.put("State Fragment", 18);
-    saMetrics.put("State Machine", 2);
-    saMetrics.put("State Transition", 39);
-    saMetrics.put("String Type", 1);
-    saMetrics.put("System Component", 5);
-    saMetrics.put("System Context", 1);
-    saMetrics.put("System Function", 44);
-    saMetrics.put("System Function Pkg", 1);
-
-    Map<String, Integer> laMetrics = new HashMap<>();
-    laMetrics.put("Association", 6);
-    laMetrics.put("Capability Realization", 13);
-    laMetrics.put("Capability Realization Pkg", 1);
-    laMetrics.put("Change Event", 1);
-    laMetrics.put("Choice Pseudo State", 2);
-    laMetrics.put("Class", 12);
-    laMetrics.put("Combined Fragment", 2);
-    laMetrics.put("Component Exchange", 12);
-    laMetrics.put("Component Port", 24);
-    laMetrics.put("Constraint", 11);
-    laMetrics.put("Data Pkg", 5);
-    laMetrics.put("Deep History Pseudo State", 1);
-    laMetrics.put("Enumeration", 2);
-    laMetrics.put("Enumeration Literal", 6);
-    laMetrics.put("Exchange Category", 13);
-    laMetrics.put("Exchange Item", 7);
-    laMetrics.put("Exchange Item Element", 9);
-    laMetrics.put("Execution", 40);
-    laMetrics.put("Final State", 2);
-    laMetrics.put("Fragment End", 6);
-    laMetrics.put("Function Input Port", 88);
-    laMetrics.put("Function Output Port", 84);
-    laMetrics.put("Functional Chain", 10);
-    laMetrics.put("Functional Exchange", 88);
-    laMetrics.put("Generalization", 4);
-    laMetrics.put("Initial Pseudo State", 4);
-    laMetrics.put("Instance Role", 37);
-    laMetrics.put("Operand", 4);
-    laMetrics.put("State", 46);
-    laMetrics.put("Use", 1);
-    laMetrics.put("Interface Pkg", 1);
-    laMetrics.put("Key Value", 215);
-    laMetrics.put("= <undefined>", 70);
-    laMetrics.put("Logical Component Pkg", 1);
-    laMetrics.put("Logical Component", 23);
-    laMetrics.put("Logical Context", 1);
-    laMetrics.put("Logical Function", 64);
-    laMetrics.put("Logical Function Pkg", 1);
-    laMetrics.put("Mode", 24);
-    laMetrics.put("Numeric Type", 2);
-    laMetrics.put("Opaque Expression", 11);
-    laMetrics.put("Part", 23);
-    laMetrics.put("Physical Quantity", 1);
-    laMetrics.put("undefined", 26);
-    laMetrics.put("Region", 27);
-    laMetrics.put("Requirements Pkg", 1);
-    laMetrics.put("Scenario", 6);
-    laMetrics.put("Sequence Message", 40);
-    laMetrics.put("State Fragment", 23);
-    laMetrics.put("State Machine", 2);
-    laMetrics.put("State Transition", 39);
-    laMetrics.put("Unit", 1);
-
-    Map<String, Integer> paMetrics = new HashMap<>();
-    paMetrics.put("Boolean Type", 1);
-    paMetrics.put("Capability Realization", 10);
-    paMetrics.put("Capability Realization Pkg", 1);
-    paMetrics.put("Class", 15);
-    paMetrics.put("Component Exchange", 11);
-    paMetrics.put("Component Port", 28);
-    paMetrics.put("Data Pkg", 6);
-    paMetrics.put("Enumeration", 6);
-    paMetrics.put("Enumeration Literal", 19);
-    paMetrics.put("Exchange Category", 12);
-    paMetrics.put("Exchange Item", 10);
-    paMetrics.put("Exchange Item Allocation", 5);
-    paMetrics.put("Exchange Item Element", 13);
-    paMetrics.put("Function Input Port", 109);
-    paMetrics.put("Function Output Port", 100);
-    paMetrics.put("Functional Chain", 11);
-    paMetrics.put("Functional Exchange", 110);
-    paMetrics.put("Generalization", 3);
-    paMetrics.put("Interface", 4);
-    paMetrics.put("Interface Pkg", 2);
-    paMetrics.put("Key Value", 6);
-    paMetrics.put("= <undefined>", 108);
-    paMetrics.put("Numeric Type", 3);
-    paMetrics.put("Part", 63);
-    paMetrics.put("Physical Component Pkg", 1);
-    paMetrics.put("Physical Component", 63);
-    paMetrics.put("Physical Context", 1);
-    paMetrics.put("Physical Function", 92);
-    paMetrics.put("Physical Function Pkg", 2);
-    paMetrics.put("Physical Link", 21);
-    paMetrics.put("Physical Path", 2);
-    paMetrics.put("Physical Port", 37);
-    paMetrics.put("Physical Quantity", 3);
-    paMetrics.put("undefined", 39);
-    paMetrics.put("Requirements Pkg", 1);
-    paMetrics.put("String Type", 1);
-    paMetrics.put("System Non Functional Requirement", 2);
-    paMetrics.put("Unit", 3);
-
-    Map<String, Integer> epbsMetrics = new HashMap<>();
-    epbsMetrics.put("Capability Realization Pkg", 1);
-    epbsMetrics.put("Unset", 11);
-    epbsMetrics.put("Configuration Item Pkg", 1);
-    epbsMetrics.put("Part", 11);
-
     String requiredModel = getRequiredTestModels().get(0);
     CapellaModel model = getTestModel(requiredModel);
     Session session = getSession(requiredModel);
@@ -225,39 +54,79 @@ public class MetricTest extends BasicTestCase {
     MetricLabelProvider labelProvider = new MetricLabelProvider();
     for (MetricTree<EObject> metricForArchitecture : computeMetricTree.getChildren()) {
       if (labelProvider.getText(metricForArchitecture).equals("Operational Analysis")) {
-        testOnArchitecture(metricForArchitecture, oaMetrics);
+        testOnArchitecture(metricForArchitecture, Type.OA);
       }
       if (labelProvider.getText(metricForArchitecture).equals("System Analysis")) {
-        testOnArchitecture(metricForArchitecture, saMetrics);
+        testOnArchitecture(metricForArchitecture, Type.SA);
       }
       if (labelProvider.getText(metricForArchitecture).equals("Logical Architecture")) {
-        testOnArchitecture(metricForArchitecture, laMetrics);
+        testOnArchitecture(metricForArchitecture, Type.LA);
       }
       if (labelProvider.getText(metricForArchitecture).equals("Physical Architecture")) {
-        testOnArchitecture(metricForArchitecture, paMetrics);
+        testOnArchitecture(metricForArchitecture, Type.PA);
       }
       if (labelProvider.getText(metricForArchitecture).equals("EPBS Architecture")) {
-        testOnArchitecture(metricForArchitecture, epbsMetrics);
+        testOnArchitecture(metricForArchitecture, Type.EPBS);
       }
     }
   }
 
-  private void testOnArchitecture(MetricTree<EObject> metricForArchitecture, Map<String, Integer> expectedMetrics) {
-    MetricLabelProvider labelProvider = new MetricLabelProvider();
-    String archLabel = labelProvider.getText(metricForArchitecture);
-    for (MetricTree<EObject> metric : metricForArchitecture.getChildren()) {
-      String elementLabel = labelProvider.getText(metric);
-      int count = metric.getCount();
-      if (expectedMetrics.containsKey(elementLabel)) {
-        assertEquals("On level " + archLabel + "; count of " + elementLabel,
-            expectedMetrics.get(elementLabel).intValue(), count);
-      }
+  private void testOnArchitecture(MetricTree<EObject> metricForArchitecture, Type type) {
+    List<String> expectedMetricNames = new ArrayList<>();
+    List<Integer> expectedMetricValues = new ArrayList<>();
+    switch (type) {
+    case OA:
+      readTestResult("oaMetric.txt", expectedMetricNames, expectedMetricValues);
+      break;
+    case SA:
+      readTestResult("saMetric.txt", expectedMetricNames, expectedMetricValues);
+      break;
+    case LA:
+      readTestResult("laMetric.txt", expectedMetricNames, expectedMetricValues);
+      break;
+    case PA:
+      readTestResult("paMetric.txt", expectedMetricNames, expectedMetricValues);
+      break;
+    case EPBS:
+      readTestResult("epbsMetric.txt", expectedMetricNames, expectedMetricValues);
+      break;
+    default:
+      break;
     }
+
+    MetricLabelProvider labelProvider = new MetricLabelProvider();
+    List<String> metricNames = metricForArchitecture.getChildren().stream().map(m -> labelProvider.getText(m))
+        .collect(Collectors.toList());
+    assertTrue("Metric list is different from what is expected", metricNames.equals(expectedMetricNames));
+    List<Integer> metricValues = metricForArchitecture.getChildren().stream().map(m -> m.getCount())
+        .collect(Collectors.toList());
+    assertTrue("Metric values are different from what is expected", metricValues.equals(expectedMetricValues));
   }
 
   @Override
   public List<String> getRequiredTestModels() {
-    return Arrays.asList(new String[] { "In-Flight Entertainment System" });
+    return Arrays.asList("In-Flight Entertainment System");
+  }
+
+  private void readTestResult(String fileName, List<String> metricName, List<Integer> metricValue) {
+    try {
+      File inputFile = getTestResult(fileName);
+      List<String> lines = Files.readAllLines(inputFile.toPath());
+      for (String line : lines) {
+        metricName.add(line.split(",")[0]);
+        metricValue.add(Integer.parseInt(line.split(",")[1]));
+      }
+    } catch (IOException | URISyntaxException ex) {
+      fail("I/O error while reading test result files");
+    }
+  }
+
+  private File getTestResult(String fileName) throws URISyntaxException, IOException {
+    Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+    URL fileURL = bundle.getEntry("testResult/" + fileName);
+    URL resolvedFileURL  = FileLocator.toFileURL(fileURL);
+    java.net.URI resolvedURI = new java.net.URI(resolvedFileURL.getProtocol(), resolvedFileURL.getPath(), null);
+    return new File(resolvedURI);
   }
 
 }

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/epbsMetric.txt
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/epbsMetric.txt
@@ -1,0 +1,4 @@
+Capability Realization Pkg,1
+Configuration Item Pkg,1
+Part,11
+Unset,11

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/laMetric.txt
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/laMetric.txt
@@ -1,0 +1,51 @@
+ = <undefined>,70
+Association,6
+Capability Realization,13
+Capability Realization Pkg,1
+Change Event,1
+Choice Pseudo State,2
+Class,12
+Combined Fragment,2
+Component Exchange,12
+Component Port,24
+Constraint,11
+Data Pkg,5
+Deep History Pseudo State,1
+Enumeration,2
+Enumeration Literal,6
+Exchange Category,13
+Exchange Item,7
+Exchange Item Element,9
+Execution,40
+Final State,2
+Fragment End,6
+Function Input Port,88
+Function Output Port,84
+Functional Chain,10
+Functional Exchange,88
+Generalization,4
+Initial Pseudo State,4
+Instance Role,37
+Interface Pkg,1
+Key Value,215
+Logical Component,23
+Logical Component Pkg,1
+Logical Function,64
+Logical Function Pkg,1
+Mode,24
+Numeric Type,2
+Opaque Expression,11
+Operand,4
+Part,23
+Physical Quantity,1
+Region,27
+Requirements Pkg,1
+Scenario,6
+Sequence Message,40
+State,46
+State Fragment,23
+State Machine,2
+State Transition,39
+Unit,1
+Use,1
+undefined,26

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/oaMetric.txt
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/oaMetric.txt
@@ -1,0 +1,31 @@
+Change Event,1
+Combined Fragment,2
+Communication Mean,2
+Constraint,4
+Data Pkg,2
+Entity Pkg,1
+Execution,15
+Fragment End,4
+Initial Pseudo State,1
+Instance Role,3
+Interaction,23
+Interface Pkg,1
+Opaque Expression,3
+Operand,4
+Operational Activity,24
+Operational Activity Pkg,1
+Operational Capability,3
+Operational Capability Pkg,1
+Operational Entity,8
+Operational Process,2
+Part,8
+Region,7
+Requirements Pkg,1
+Role Pkg,1
+Scenario,1
+Sequence Message,15
+State,6
+State,12
+State Fragment,6
+State Machine,1
+State Transition,7

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/paMetric.txt
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/paMetric.txt
@@ -1,0 +1,37 @@
+ = <undefined>,108
+Boolean Type,1
+Capability Realization,10
+Capability Realization Pkg,1
+Class,15
+Component Exchange,11
+Component Port,28
+Data Pkg,6
+Enumeration,6
+Enumeration Literal,19
+Exchange Category,12
+Exchange Item,10
+Exchange Item Allocation,5
+Exchange Item Element,13
+Function Input Port,109
+Function Output Port,100
+Functional Chain,11
+Functional Exchange,110
+Generalization,3
+Interface,4
+Interface Pkg,2
+Key Value,6
+Numeric Type,3
+Part,63
+Physical Component,63
+Physical Component Pkg,1
+Physical Function,92
+Physical Function Pkg,2
+Physical Link,21
+Physical Path,2
+Physical Port,37
+Physical Quantity,3
+Requirements Pkg,1
+String Type,1
+System Non Functional Requirement,2
+Unit,3
+undefined,39

--- a/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/saMetric.txt
+++ b/tests/plugins/org.polarsys.capella.test.progressmonitoring.ju/testResult/saMetric.txt
@@ -1,0 +1,45 @@
+ = <undefined>,46
+Abstract Capability Include,1
+Association,8
+Boolean Type,1
+Capability,13
+Capability Exploitation,12
+Capability Pkg,1
+Change Event,1
+Choice Pseudo State,2
+Class,7
+Constraint,7
+Data Pkg,3
+Deep History Pseudo State,1
+Enumeration,1
+Enumeration Literal,3
+Exchange Category,7
+Execution,25
+Final State,2
+Function Input Port,41
+Function Output Port,40
+Functional Chain,10
+Functional Exchange,41
+Initial Pseudo State,4
+Instance Role,19
+Interface Pkg,1
+Key Value,3
+Mission,5
+Mission Pkg,1
+Mode,24
+Opaque Expression,7
+Part,5
+Region,27
+Requirements Pkg,1
+Scenario,6
+Sequence Message,25
+State,36
+State Fragment,18
+State Machine,2
+State Transition,39
+String Type,1
+System Component,5
+System Component Pkg,1
+System Function,44
+System Function Pkg,1
+undefined,23


### PR DESCRIPTION
The resulting CSV file after export to Excel of metrics on model is not sorted due to a refactoring done with the commit I093788bb00785f899098c7f2710ba0b1eeae56a4.
- Also take into account the case when meta-classes have the same name: use the fully qualified name to have the exact order when displaying in tree and exporting to csv.