### PR TITLE
[568858] Enforce same name between Abstract Type Elements and their

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/plugin.properties
+++ b/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/plugin.properties
@@ -40,6 +40,9 @@ quickFix.I_03.desc = Open Manage References wizard to resolve the problem
 quickFix.I_44.label = Delete unknown feature(s)
 quickFix.I_44.desc = Delete unknown feature(s)
 
+quickFix.I_45.label = Rename element with type name
+quickFix.I_45.desc = Rename element with type name
+
 
 providerName = Eclipse.org
 pluginName = Quickfix for validation rules on core data

--- a/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/plugin.xml
@@ -96,6 +96,15 @@
                ruleId="I_44">
          </rules>
       </resolver>
+      <resolver
+            class="org.polarsys.capella.core.data.core.ui.quickfix.resolver.TypedElementHasDifferentNameThanTypeResolver"
+            desc="%quickFix.I_45.desc"
+            icon="icons/search16.gif"
+            label="%quickFix.I_45.label">
+         <rules
+               ruleId="I_45">
+         </rules>
+      </resolver>
    </extension>
 
 </plugin>

--- a/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/src/org/polarsys/capella/core/data/core/ui/quickfix/resolver/TypedElementHasDifferentNameThanTypeResolver.java
+++ b/core/plugins/org.polarsys.capella.core.data.core.ui.quickfix/src/org/polarsys/capella/core/data/core/ui/quickfix/resolver/TypedElementHasDifferentNameThanTypeResolver.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.data.core.ui.quickfix.resolver;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.emf.ecore.EObject;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
+import org.polarsys.capella.common.data.modellingcore.AbstractTypedElement;
+import org.polarsys.capella.common.tools.report.appenders.reportlogview.MarkerViewHelper;
+import org.polarsys.capella.core.model.utils.NamingHelper;
+import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractCapellaMarkerResolution;
+
+public class TypedElementHasDifferentNameThanTypeResolver extends AbstractCapellaMarkerResolution {
+
+  @Override
+  public void run(IMarker marker) {
+    for (EObject element : MarkerViewHelper.getModelElementsFromMarker(marker)) {
+      if (element instanceof AbstractTypedElement) {
+        AbstractTypedElement typedElement = (AbstractTypedElement) element;
+        AbstractType type = typedElement.getAbstractType();
+        String newName = type.getName();
+
+        NamingHelper.synchronizeName(typedElement, newName);
+      }
+    }
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.data.core.validation/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.data.core.validation/plugin.xml
@@ -593,6 +593,25 @@ This rule checks that an capella element doesn&apos;t contain any naming conflic
                      class="Involvement">
                </target>
             </constraint>
+            <constraint
+                  class="org.polarsys.capella.core.data.core.validation.capellaelement.TypedElementHasDifferentNameThanType"
+                  id="I_45"
+                  isEnabledByDefault="true"
+                  lang="Java"
+                  mode="Batch"
+                  name="I_45 - Typed Element has different name than its Type"
+                  severity="ERROR"
+                  statusCode="1">
+               <message>
+                  {0} ({1}) should have the same name as its type {2} ({3})
+               </message>
+               <description>
+                  This rule checks the Typed Element (Part, Exchange Item Instance) has the same name as its Type (Component, Exchange Item).
+               </description>
+               <target
+                     class="AbstractTypedElement">
+               </target>
+            </constraint>
          </constraints>
       </constraintProvider>
    </extension>

--- a/core/plugins/org.polarsys.capella.core.data.core.validation/src/org/polarsys/capella/core/data/core/validation/capellaelement/TypedElementHasDifferentNameThanType.java
+++ b/core/plugins/org.polarsys.capella.core.data.core.validation/src/org/polarsys/capella/core/data/core/validation/capellaelement/TypedElementHasDifferentNameThanType.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.data.core.validation.capellaelement;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.EMFEventType;
+import org.eclipse.emf.validation.IValidationContext;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
+import org.polarsys.capella.common.data.modellingcore.AbstractTypedElement;
+import org.polarsys.capella.common.helpers.EObjectLabelProviderHelper;
+import org.polarsys.capella.core.data.cs.Part;
+import org.polarsys.capella.core.data.helpers.information.services.ExchangeItemExt;
+import org.polarsys.capella.core.data.information.ExchangeItem;
+import org.polarsys.capella.core.data.information.ExchangeItemInstance;
+import org.polarsys.capella.core.model.handler.helpers.CapellaProjectHelper;
+import org.polarsys.capella.core.model.handler.helpers.CapellaProjectHelper.TriStateBoolean;
+import org.polarsys.capella.core.validation.rule.AbstractValidationRule;
+
+public class TypedElementHasDifferentNameThanType extends AbstractValidationRule {
+
+  @Override
+  public IStatus validate(IValidationContext validationContext) {
+    EObject target = validationContext.getTarget();
+    EMFEventType eventType = validationContext.getEventType();
+
+    if (eventType == EMFEventType.NULL && target instanceof AbstractTypedElement) {
+      AbstractTypedElement typedElement = (AbstractTypedElement) target;
+      AbstractType type = typedElement.getAbstractType();
+
+      // another validation rules checks if the name is null
+      // we only raise an error if there is a name against which we can compare
+      if (type != null && type.getName() != null && !type.getName().equals(typedElement.getName())) {
+        if (typedElement instanceof Part
+            && TriStateBoolean.True.equals(CapellaProjectHelper.isSingletonComponentsDriven(typedElement))) {
+          return constructFailureStatus(validationContext, typedElement, type);
+        }
+
+        else if (typedElement instanceof ExchangeItemInstance && type instanceof ExchangeItem) {
+          ExchangeItem exchangeItem = (ExchangeItem) type;
+          if (ExchangeItemExt.getTypedExchangeItemInstances(exchangeItem).size() == 1) {
+            return constructFailureStatus(validationContext, typedElement, type);
+          }
+
+        }
+      }
+    }
+
+    return validationContext.createSuccessStatus();
+  }
+
+  private IStatus constructFailureStatus(IValidationContext validationContext, AbstractTypedElement typedElement,
+      AbstractType type) {
+    return validationContext.createFailureStatus(typedElement.getName(),
+        EObjectLabelProviderHelper.getMetaclassLabel(typedElement, false), type.getName(),
+        EObjectLabelProviderHelper.getMetaclassLabel(type, false));
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.data.helpers/src/org/polarsys/capella/core/data/helpers/information/services/ExchangeItemExt.java
+++ b/core/plugins/org.polarsys.capella.core.data.helpers/src/org/polarsys/capella/core/data/helpers/information/services/ExchangeItemExt.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -40,6 +41,7 @@ import org.polarsys.capella.core.data.helpers.capellacore.services.Generalizable
 import org.polarsys.capella.core.data.information.ElementKind;
 import org.polarsys.capella.core.data.information.ExchangeItem;
 import org.polarsys.capella.core.data.information.ExchangeItemElement;
+import org.polarsys.capella.core.data.information.ExchangeItemInstance;
 import org.polarsys.capella.core.data.information.ExchangeMechanism;
 import org.polarsys.capella.core.data.information.InformationFactory;
 import org.polarsys.capella.core.data.information.ParameterDirection;
@@ -97,7 +99,9 @@ public class ExchangeItemExt {
 
   /**
    * Gets the parameters.
-   * @param item the given exchangeItem
+   * 
+   * @param item
+   *          the given exchangeItem
    * @return the type of parameters associated to the exchange item
    */
   public static List<AbstractType> getData(AbstractExchangeItem item) {
@@ -130,7 +134,9 @@ public class ExchangeItemExt {
 
   /**
    * Gets the parameters.
-   * @param item the given exchangeItem
+   * 
+   * @param item
+   *          the given exchangeItem
    * @return the type of parameters associated to the exchange item
    */
   public static List<AbstractType> getExceptions(ExchangeItem item) {
@@ -149,7 +155,8 @@ public class ExchangeItemExt {
   /**
    * @see #getExchangeItemDependencies(AbstractExchangeItem)
    */
-  public static Map<AbstractDependenciesPkg, Collection<EObject>> getExchangeItemDependencies2(AbstractExchangeItem exchangeItem) {
+  public static Map<AbstractDependenciesPkg, Collection<EObject>> getExchangeItemDependencies2(
+      AbstractExchangeItem exchangeItem) {
 
     Map<AbstractDependenciesPkg, Collection<EObject>> result = new HashMap<>();
 
@@ -161,10 +168,13 @@ public class ExchangeItemExt {
   }
 
   /** for internal use */
-  private static void checkDependenciesAndAddToResult(Map<AbstractDependenciesPkg, Collection<EObject>> map, EObject eobject) {
-    // TODO we'd like to use AbstractDependenciesPkgExt.checkDependenciesAndAddToResult, but that would cause a plugin-dependency cycle.
+  private static void checkDependenciesAndAddToResult(Map<AbstractDependenciesPkg, Collection<EObject>> map,
+      EObject eobject) {
+    // TODO we'd like to use AbstractDependenciesPkgExt.checkDependenciesAndAddToResult, but that would cause a
+    // plugin-dependency cycle.
     if (null != eobject) {
-      AbstractDependenciesPkg adp = (AbstractDependenciesPkg) EcoreUtil2.getFirstContainer(eobject, CapellacorePackage.Literals.ABSTRACT_DEPENDENCIES_PKG);
+      AbstractDependenciesPkg adp = (AbstractDependenciesPkg) EcoreUtil2.getFirstContainer(eobject,
+          CapellacorePackage.Literals.ABSTRACT_DEPENDENCIES_PKG);
       if (adp != null) {
         if (!map.containsKey(adp)) {
           Set<EObject> set = new HashSet<>();
@@ -204,7 +214,8 @@ public class ExchangeItemExt {
   public static List<ExchangeItem> getOperations(List<? extends AbstractExchangeItem> exchangeItems) {
     List<ExchangeItem> types = new ArrayList<>();
     for (AbstractExchangeItem item : exchangeItems) {
-      if ((item instanceof ExchangeItem) && (((ExchangeItem) item).getExchangeMechanism() == ExchangeMechanism.OPERATION)) {
+      if ((item instanceof ExchangeItem)
+          && (((ExchangeItem) item).getExchangeMechanism() == ExchangeMechanism.OPERATION)) {
         types.add((ExchangeItem) item);
       }
     }
@@ -213,7 +224,9 @@ public class ExchangeItemExt {
 
   /**
    * Gets the parameters.
-   * @param item the given exchangeItem
+   * 
+   * @param item
+   *          the given exchangeItem
    * @return the type of parameters associated to the exchange item
    */
   public static List<AbstractType> getParameters(AbstractExchangeItem item) {
@@ -264,6 +277,7 @@ public class ExchangeItemExt {
 
   /**
    * Returns all communication exchanger which are related to the exchange item. Include also childs by generalization
+   * 
    * @param item
    * @return
    */
@@ -275,7 +289,8 @@ public class ExchangeItemExt {
         result.add(exchanger);
 
         if (exchanger instanceof GeneralizableElement) {
-          for (GeneralizableElement child : GeneralizableElementExt.getAllSubGeneralizableElements((GeneralizableElement) exchanger)) {
+          for (GeneralizableElement child : GeneralizableElementExt
+              .getAllSubGeneralizableElements((GeneralizableElement) exchanger)) {
             if (child instanceof CommunicationLinkExchanger) {
               result.add((CommunicationLinkExchanger) child);
             }
@@ -288,7 +303,9 @@ public class ExchangeItemExt {
 
   /**
    * Gets the types.
-   * @param item the given exchangeItem
+   * 
+   * @param item
+   *          the given exchangeItem
    * @return the types associated to the exchange item
    */
   public static List<AbstractType> getTypes(AbstractExchangeItem item) {
@@ -298,8 +315,8 @@ public class ExchangeItemExt {
       for (ExchangeItemElement element : ((ExchangeItem) item).getOwnedElements()) {
         if (ElementKind.TYPE.equals(element.getKind())) {
           Type type = element.getType();
-          if(type != null) {
-            types.add(type);            
+          if (type != null) {
+            types.add(type);
           }
         }
       }
@@ -310,28 +327,38 @@ public class ExchangeItemExt {
 
   /**
    * Checks if the exchange item is ACCESS by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isAccess(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.ACCESS)
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.ACCESS)
         .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is CALL by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isCall(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.CALL).contains(sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.CALL)
+        .contains(sndItem);
   }
 
   /**
-   * Checks if both sndItem is produce/call/send/write by the sndCpnt and if rcvItem is consume/execute/receive/access by rcvCpnt with cohesion between
-   * CommunicaionLinks
+   * Checks if both sndItem is produce/call/send/write by the sndCpnt and if rcvItem is consume/execute/receive/access
+   * by rcvCpnt with cohesion between CommunicaionLinks
+   * 
    * @param sndCpnt
    * @param sndItem
    * @param rcvCpnt
@@ -339,7 +366,8 @@ public class ExchangeItemExt {
    * @return
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  public static boolean isCoherentExchangeItem(Component sndCpnt, AbstractExchangeItem sndItem, Component rcvCpnt, AbstractExchangeItem rcvItem) {
+  public static boolean isCoherentExchangeItem(Component sndCpnt, AbstractExchangeItem sndItem, Component rcvCpnt,
+      AbstractExchangeItem rcvItem) {
     List<GeneralizableElement> sndComponents = GeneralizableElementExt.getAllSuperGeneralizableElements(sndCpnt);
     List<GeneralizableElement> rcvComponents = GeneralizableElementExt.getAllSuperGeneralizableElements(rcvCpnt);
 
@@ -377,97 +405,136 @@ public class ExchangeItemExt {
       }
     }
 
-    return (sndProduce.contains(sndItem) && rcvConsume.contains(rcvItem)) || (sndCall.contains(sndItem) && rcvExecute.contains(rcvItem))
-           || (sndSend.contains(sndItem) && rcvReceive.contains(rcvItem)) || (sndWrite.contains(sndItem) && rcvAccess.contains(rcvItem));
+    return (sndProduce.contains(sndItem) && rcvConsume.contains(rcvItem))
+        || (sndCall.contains(sndItem) && rcvExecute.contains(rcvItem))
+        || (sndSend.contains(sndItem) && rcvReceive.contains(rcvItem))
+        || (sndWrite.contains(sndItem) && rcvAccess.contains(rcvItem));
   }
 
   /**
    * Checks if the exchange item is CONSUME by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isConsume(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.CONSUME).contains(
-        sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.CONSUME)
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is EXECUTE by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isExecute(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.EXECUTE).contains(
-        sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.EXECUTE)
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is PRODUCE by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isProduce(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.PRODUCE).contains(
-        sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.PRODUCE)
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is RECEIVE by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isReceive(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.RECEIVE).contains(
-        sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.RECEIVE)
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is SEND by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isSend(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.SEND).contains(sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.SEND)
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is CONSUME, EXECUTE, RECEIVE, ACCESS by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isSendingByLinks(CommunicationLinkExchanger sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt
-        .getExchangeItemsByKinds(
-            CommunicationLinkExt.getAllCommunicationLinks(sndCpnt),
-            new CommunicationLinkKind[] { CommunicationLinkKind.CONSUME, CommunicationLinkKind.EXECUTE, CommunicationLinkKind.RECEIVE,
-                                         CommunicationLinkKind.ACCESS }).contains(sndItem);
+    return CommunicationLinkExt.getExchangeItemsByKinds(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt),
+        new CommunicationLinkKind[] { CommunicationLinkKind.CONSUME, CommunicationLinkKind.EXECUTE,
+            CommunicationLinkKind.RECEIVE, CommunicationLinkKind.ACCESS })
+        .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is PRODUCE, CALL, SEND, WRITE by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isUsingByLinks(CommunicationLinkExchanger sndCpnt, AbstractExchangeItem sndItem) {
     return CommunicationLinkExt.getExchangeItemsByKinds(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt),
-        new CommunicationLinkKind[] { CommunicationLinkKind.PRODUCE, CommunicationLinkKind.CALL, CommunicationLinkKind.SEND, CommunicationLinkKind.WRITE })
+        new CommunicationLinkKind[] { CommunicationLinkKind.PRODUCE, CommunicationLinkKind.CALL,
+            CommunicationLinkKind.SEND, CommunicationLinkKind.WRITE })
         .contains(sndItem);
   }
 
   /**
    * Checks if the exchange item is WRITE by the component (including inheritance links)
-   * @param sndCpnt the given component
-   * @param sndItem the given abstractExchangeItem
+   * 
+   * @param sndCpnt
+   *          the given component
+   * @param sndItem
+   *          the given abstractExchangeItem
    * @return true, if is produce
    */
   public static boolean isWrite(Component sndCpnt, AbstractExchangeItem sndItem) {
-    return CommunicationLinkExt.getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.WRITE).contains(sndItem);
+    return CommunicationLinkExt
+        .getExchangeItemsByKind(CommunicationLinkExt.getAllCommunicationLinks(sndCpnt), CommunicationLinkKind.WRITE)
+        .contains(sndItem);
+  }
+
+  public static List<ExchangeItemInstance> getTypedExchangeItemInstances(ExchangeItem exchangeItem) {
+    return exchangeItem.getTypedElements().stream().filter(ExchangeItemInstance.class::isInstance)
+        .map(ExchangeItemInstance.class::cast).collect(Collectors.toList());
   }
 }

--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/listeners/CapellaModelDataListenerForExchangeItemAndExchangeItemInstance.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/listeners/CapellaModelDataListenerForExchangeItemAndExchangeItemInstance.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.model.helpers.listeners;
+
+import java.util.List;
+
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
+import org.polarsys.capella.common.data.modellingcore.ModellingcorePackage;
+import org.polarsys.capella.core.data.helpers.information.services.ExchangeItemExt;
+import org.polarsys.capella.core.data.information.ExchangeItem;
+import org.polarsys.capella.core.data.information.ExchangeItemInstance;
+import org.polarsys.capella.core.model.utils.NamingHelper;
+
+/**
+ * 
+ * This listener will synchronize the name of ExchangeItem and its ExchangeItemInstance if and only if a single typed
+ * ExchangeItemInstance exists.
+ * 
+ */
+public class CapellaModelDataListenerForExchangeItemAndExchangeItemInstance extends CapellaModelDataListener {
+  @Override
+  public void notifyChanged(Notification notification) {
+
+    if (filterNotification(notification)) {
+      return;
+    }
+
+    if (notification.getEventType() != Notification.SET) {
+      return;
+    }
+
+    EStructuralFeature feature = (EStructuralFeature) notification.getFeature();
+    if (ModellingcorePackage.Literals.ABSTRACT_NAMED_ELEMENT__NAME.equals(feature)) {
+      String newName = notification.getNewStringValue();
+      Object notifier = notification.getNotifier();
+
+      if (notifier instanceof ExchangeItem) {
+        ExchangeItem exchangeItem = (ExchangeItem) notifier;
+        List<ExchangeItemInstance> exchangeItemInstances = ExchangeItemExt.getTypedExchangeItemInstances(exchangeItem);
+
+        if (exchangeItemInstances.size() == 1) {
+          ExchangeItemInstance exchangeItemInstance = exchangeItemInstances.get(0);
+          NamingHelper.synchronizeName(exchangeItemInstance, newName);
+        }
+
+      } else if (notifier instanceof ExchangeItemInstance) {
+        ExchangeItemInstance exchangeItemInstance = (ExchangeItemInstance) notifier;
+        AbstractType abstractType = exchangeItemInstance.getAbstractType();
+        if (abstractType instanceof ExchangeItem) {
+          ExchangeItem exchangeItem = (ExchangeItem) abstractType;
+          List<ExchangeItemInstance> exchangeItemInstances = ExchangeItemExt
+              .getTypedExchangeItemInstances(exchangeItem);
+
+          if (exchangeItemInstances.size() == 1) {
+            NamingHelper.synchronizeName(exchangeItem, newName);
+          }
+
+        }
+
+      }
+
+    }
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/listeners/CapellaModelEditingDomainListener.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/listeners/CapellaModelEditingDomainListener.java
@@ -31,6 +31,7 @@ public class CapellaModelEditingDomainListener extends ResourceSetListenerImpl i
   private CapellaModelDataListenerForPartsAndComponents _dataListenerForPartsAndComponents;
   private CapellaModelDataListenerForInstanceRole dataListenerForInstanceRole;
   private CapellaModelDataListenerForExchangeItemsAndCommunicationLinks _dataListenerForExchangeItemsAndCommunicationLinks;
+  private CapellaModelDataListenerForExchangeItemAndExchangeItemInstance dataListenerForExchangeItemAndExchangeItemInstance;
 
   /**
    * @see org.polarsys.capella.common.ef.domain.IEditingDomainListener#createdEditingDomain(EditingDomain)
@@ -58,6 +59,7 @@ public class CapellaModelEditingDomainListener extends ResourceSetListenerImpl i
     loadDataListenerForPartsAndComponents(editingDomain);
     loadDataListenerForInstanceRoles(editingDomain);
     loadDataListenerForAbstractStates(editingDomain);
+    loadDataListenerForExchangeItemAndExchangeItemInstance(editingDomain);
   }
 
   /**
@@ -123,6 +125,16 @@ public class CapellaModelEditingDomainListener extends ResourceSetListenerImpl i
         _dataListenerForExchangeItemsAndCommunicationLinks = new CapellaModelDataListenerForExchangeItemsAndCommunicationLinks();
         editingDomain.getDataNotifier().addAdapter(AbstractNamedElement.class,
             _dataListenerForExchangeItemsAndCommunicationLinks);
+      }
+    }
+  }
+
+  private void loadDataListenerForExchangeItemAndExchangeItemInstance(SemanticEditingDomain editingDomain) {
+    if (dataListenerForExchangeItemAndExchangeItemInstance == null) {
+      if (editingDomain.getDataNotifier() != null) {
+        dataListenerForExchangeItemAndExchangeItemInstance = new CapellaModelDataListenerForExchangeItemAndExchangeItemInstance();
+        editingDomain.getDataNotifier().addAdapter(AbstractNamedElement.class,
+            dataListenerForExchangeItemAndExchangeItemInstance);
       }
     }
   }

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
@@ -526,5 +526,36 @@
 				<td colspan="2">This rule checks if a model Element references aird element (e.g. gmf)</td>
 			</tr>
 		</table>
+		<p>
+			<br/>
+		</p>
+		<table class="VALIDATION-RULE">
+			<tr>
+				<th>
+					<img title="ERROR" alt="ERROR" border="0" src="../../Images/error.gif"/>
+				</th>
+				<td>I_44 - Check existence of unknown model features</td>
+			</tr>
+			<tr>
+				<td colspan="2">This rule checks the existence of unkown model features. 
+					<p>An unkown model feature is a feature that is persisted in your textual model representation, but is not recognised by the metamodel and therefore is not loaded during model opening.
+						Its existence does not add any corruption risk to your model, but it does represent an anomaly so it should be removed.</p>
+				</td>
+			</tr>
+		</table>
+		<p>
+			<br/>
+		</p>
+		<table class="VALIDATION-RULE">
+			<tr>
+				<th>
+					<img title="ERROR" alt="ERROR" border="0" src="../../Images/error.gif"/>
+				</th>
+				<td>I_45 - Typed Element has different name than its type</td>
+			</tr>
+			<tr>
+				<td colspan="2">This rule checks the Typed Element (Part, Exchange Item Instance) has the same name as its Type (Component, Exchange Item).</td>
+			</tr>
+		</table>
 	</body>
 </html>

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
@@ -268,3 +268,19 @@ In Case the ComponentExchange is of kind DELEGATION
 |-
 | colspan="2"|This rule checks if a model Element references aird element (e.g. gmf)
 |}
+<br>
+{| class="VALIDATION-RULE"
+!|[[Image:../../Images/error.gif|ERROR]]
+|I_44 - Check existence of unknown model features
+|-
+| colspan="2"|This rule checks the existence of unkown model features. 
+An unkown model feature is a feature that is persisted in your textual model representation, but is not recognised by the metamodel and therefore is not loaded during model opening.
+Its existence does not add any corruption risk to your model, but it does represent an anomaly so it should be removed.
+|}
+<br>
+{| class="VALIDATION-RULE"
+!|[[Image:../../Images/error.gif|ERROR]]
+|I_45 - Typed Element has different name than its type
+|-
+| colspan="2"|This rule checks the Typed Element (Part, Exchange Item Instance) has the same name as its Type (Component, Exchange Item).
+|}

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/.project
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>exchange-item-instance-and-part-model</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.polarsys.capella.project.nature</nature>
+	</natures>
+</projectDescription>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.afm
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.afm
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_u_rwkCgDEeuc881X317kNw">
+  <viewpointReferences id="_vAV34CgDEeuc881X317kNw" vpId="org.polarsys.capella.core.viewpoint" version="5.0.0"/>
+</metadata:Metadata>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.aird
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.aird
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0" xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/5.0.0" xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/5.0.0" xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/5.0.0" xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/5.0.0" xmlns:sequence="http://www.eclipse.org/sirius/diagram/sequence/2.0.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/sequence/description/2.0.0 http://www.eclipse.org/sirius/diagram/sequence/2.0.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_u_va8CgDEeuc881X317kNw" selectedViews="_vAyj0CgDEeuc881X317kNw _vBiKsCgDEeuc881X317kNw _vW4IkCgDEeuc881X317kNw _vf2eYCgDEeuc881X317kNw _vmLI0CgDEeuc881X317kNw _vmpC4CgDEeuc881X317kNw _voO-UCgDEeuc881X317kNw" version="14.3.1.202003261200">
+    <semanticResources>exchange-item-instance-and-part-model.afm</semanticResources>
+    <semanticResources>exchange-item-instance-and-part-model.capella</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vAyj0CgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vBiKsCgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vW4IkCgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vf2eYCgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_YcwgwCgEEeuc881X317kNw" name="[CDB] Data" repPath="#_YcjscCgEEeuc881X317kNw" changeId="12cb9135-4d74-4e77-971a-7fe7f13177eb">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="exchange-item-instance-and-part-model.capella#105cd58a-1e0a-4f14-be59-88fcd5e93a8d"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_m0RY5CgEEeuc881X317kNw" name="[IS] Capability 1" repPath="#_m0Hn4CgEEeuc881X317kNw" changeId="281306ab-3084-4883-91c7-6a125cc4c808">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#684b973d-e383-4b4a-b595-f076680fd83c"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_3Uf0hCgFEeuc881X317kNw" name="[IS] CapabilityRealization 1" repPath="#_3Ud_UCgFEeuc881X317kNw" changeId="1ff9d590-feb5-4973-939f-3d2b3dbb2bc9">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#5b60d46b-9547-4448-9b82-e20b06231b14"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_nVE4gCgHEeuc881X317kNw" name="[ES] CapabilityRealization 1" repPath="#_nVAnECgHEeuc881X317kNw" changeId="999f286d-d636-4f17-b6ee-349dadd28b0c">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#1848cbce-c339-471a-9bce-0669ca05a9a6"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vmLI0CgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_vmpC4CgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_voO-UCgDEeuc881X317kNw">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_YcjscCgEEeuc881X317kNw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Yc1ZQCgEEeuc881X317kNw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_Yc1ZQSgEEeuc881X317kNw" type="Sirius" element="_YcjscCgEEeuc881X317kNw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_cbzwQCgEEeuc881X317kNw" type="2001" element="_cbgOQCgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_cb0XUCgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_cb0XUSgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_cb0-YCgEEeuc881X317kNw" type="3003" element="_cbhcYCgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_cb0-YSgEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cb0-YigEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_cbzwQSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cbzwQigEEeuc881X317kNw" x="70" y="100" width="100" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ecToYCgEEeuc881X317kNw" type="2001" element="_ecDJsCgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_ecUPcCgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ecUPcSgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ecUPcigEEeuc881X317kNw" type="3003" element="_ecDJsSgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ecUPcygEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ecUPdCgEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ecToYSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ecToYigEEeuc881X317kNw" x="430" y="140" width="100" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ityEoCgEEeuc881X317kNw" type="2001" element="_itE6ACgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_iuVeQCgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_iuVeQSgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_iuWFUCgEEeuc881X317kNw" type="3003" element="_itFhECgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_iuWFUSgEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_iuWFUigEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ityEoSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ityEoigEEeuc881X317kNw" x="840" y="165" width="100" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_Yc1ZQigEEeuc881X317kNw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_YdWWoCgEEeuc881X317kNw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_YdWWoSgEEeuc881X317kNw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_cbgOQCgEEeuc881X317kNw" target="4b2f202d-cdc4-404e-b671-3a44ae2c98f5" name="ExchangeItem 1" semanticElements="4b2f202d-cdc4-404e-b671-3a44ae2c98f5" width="10" height="5" resizeKind="NSEW">
+      <ownedStyle xmi:type="diagram:Square" uid="_cbhcYCgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="10" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ecDJsCgEEeuc881X317kNw" name="ExchangeItem 2" width="10" height="5" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.information:ExchangeItem" href="exchange-item-instance-and-part-model.capella#a6594575-7dcf-4173-9f09-4f26fa2b275b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItem" href="exchange-item-instance-and-part-model.capella#a6594575-7dcf-4173-9f09-4f26fa2b275b"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_ecDJsSgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="10" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_itE6ACgEEeuc881X317kNw" name="ExchangeItem" width="10" height="5" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.information:ExchangeItem" href="exchange-item-instance-and-part-model.capella#8eafd9a4-15b2-4534-95c7-29582fb099a8"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItem" href="exchange-item-instance-and-part-model.capella#8eafd9a4-15b2-4534-95c7-29582fb099a8"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_itFhECgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="10" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']/@nodeMappings[name='DT_ExchangeItem']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@filters[name='hide.association.labels.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@filters[name='hide.technical.interfaces.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_YckTgCgEEeuc881X317kNw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Class%20Diagram%20Blank']/@additionalLayers[name='Communication%20Model']"/>
+    <target xmi:type="org.polarsys.capella.core.data.information:DataPkg" href="exchange-item-instance-and-part-model.capella#105cd58a-1e0a-4f14-be59-88fcd5e93a8d"/>
+  </diagram:DSemanticDiagram>
+  <sequence:SequenceDDiagram uid="_m0Hn4CgEEeuc881X317kNw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_m0SnACgEEeuc881X317kNw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_m0SnASgEEeuc881X317kNw" type="Sirius" element="_m0Hn4CgEEeuc881X317kNw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_m0qacCgEEeuc881X317kNw" type="2001" element="_m0VqUCgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_m0rokCgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_m0rokSgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_m0rokigEEeuc881X317kNw" type="3001" element="_m0Z7wSgEEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_m0sPoCgEEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_m0sPoSgEEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_m0s2sCgEEeuc881X317kNw" type="3003" element="_m0Z7wigEEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_m0s2sSgEEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0s2sigEEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_m0tdwCgEEeuc881X317kNw" type="3001" element="_m0bw8CgEEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_m0tdwygEEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_m0tdxCgEEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_m0uE0CgEEeuc881X317kNw" type="3005" element="_m0cYACgEEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_m0uE0SgEEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0uE0igEEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_m0tdwSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0tdwigEEeuc881X317kNw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_m0rokygEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0rolCgEEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_m0sPoigEEeuc881X317kNw" type="3003" element="_m0ZUsCgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_m0sPoygEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0sPpCgEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_m0qacSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_m0rBgCgEEeuc881X317kNw" x="50" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_qJPJkCgEEeuc881X317kNw" type="2001" element="_qIydoCgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_qJPJkygEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJlCgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJPJnygEEeuc881X317kNw" type="3001" element="_qIydoygEEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_qJPJoigEEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJoygEEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJPJpygEEeuc881X317kNw" type="3003" element="_qIydpCgEEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJqCgEEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJqSgEEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJPJqigEEeuc881X317kNw" type="3001" element="_qIydpSgEEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_qJPJrSgEEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJrigEEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_qJPJrygEEeuc881X317kNw" type="3005" element="_qIydpigEEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJsCgEEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJsSgEEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJqygEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJrCgEEeuc881X317kNw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJoCgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJoSgEEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJPJpCgEEeuc881X317kNw" type="3003" element="_qIydoSgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJpSgEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJpigEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJkSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJkigEEeuc881X317kNw" x="568" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_qJPJlSgEEeuc881X317kNw" type="2001" element="_qIpTtygEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_qJPJmCgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJmSgEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJPJsigEEeuc881X317kNw" type="3001" element="_qIpTuigEEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_qJPJtSgEEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJtigEEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJPJuigEEeuc881X317kNw" type="3003" element="_qIpTuygEEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJuygEEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJvCgEEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJY6kCgEEeuc881X317kNw" type="3001" element="_qIpTvCgEEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_qJY6kygEEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_qJY6lCgEEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_qJY6lSgEEeuc881X317kNw" type="3005" element="_qIpTvSgEEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6ligEEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6lygEEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6kSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6kigEEeuc881X317kNw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJsygEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJtCgEEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJPJtygEEeuc881X317kNw" type="3003" element="_qIpTuCgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJuCgEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJuSgEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJligEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJlygEEeuc881X317kNw" x="407" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_qJPJmigEEeuc881X317kNw" type="2001" element="_qIpTsCgEEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_qJPJnSgEEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_qJPJnigEEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJY6mCgEEeuc881X317kNw" type="3001" element="_qIpTsygEEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_qJY6mygEEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_qJY6nCgEEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJY6oCgEEeuc881X317kNw" type="3003" element="_qIpTtCgEEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6oSgEEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6oigEEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJY6oygEEeuc881X317kNw" type="3001" element="_qIpTtSgEEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_qJY6pigEEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_qJY6pygEEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_qJY6qCgEEeuc881X317kNw" type="3005" element="_qIpTtigEEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6qSgEEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6qigEEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6pCgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6pSgEEeuc881X317kNw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6mSgEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6migEEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJY6nSgEEeuc881X317kNw" type="3003" element="_qIpTsSgEEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJY6nigEEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJY6nygEEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_qJPJmygEEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJPJnCgEEeuc881X317kNw" x="244" y="50" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_m0SnAigEEeuc881X317kNw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_m0pzYCgEEeuc881X317kNw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_m0pzYSgEEeuc881X317kNw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_m0VqUCgEEeuc881X317kNw" name="System" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#cd3b0d7a-77b3-427e-8113-83211d850293"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="exchange-item-instance-and-part-model.capella#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_m3V7ACgEEeuc881X317kNw" x="50" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_m0Z7wSgEEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#cd3b0d7a-77b3-427e-8113-83211d850293"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="exchange-item-instance-and-part-model.capella#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_m0bw8CgEEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#03465a89-5993-43ff-9c35-753a17f421f5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#cd3b0d7a-77b3-427e-8113-83211d850293"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:SystemComponent" href="exchange-item-instance-and-part-model.capella#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_m0cYACgEEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_m0Z7wigEEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_m0ZUsCgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_qIpTsCgEEeuc881X317kNw" name="ExchangeItem 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_qIydpygEEeuc881X317kNw" x="244" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIpTsygEEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIpTtSgEEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#d0de2024-3ff0-4df2-8e94-20efe5de11d3"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qIpTtigEEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_qIpTtCgEEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_qIpTsSgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="15" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_qIpTtygEEeuc881X317kNw" name="ExchangeItem 2" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_qIydqCgEEeuc881X317kNw" x="407" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIpTuigEEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIpTvCgEEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#c8124936-287d-4029-a4ac-47fa65784d1d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qIpTvSgEEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_qIpTuygEEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_qIpTuCgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="15" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_qIydoCgEEeuc881X317kNw" name="ExchangeItem" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#a31d4905-1834-4546-95a0-25ea02f4319d"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_qIydqSgEEeuc881X317kNw" x="568" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIydoygEEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#a31d4905-1834-4546-95a0-25ea02f4319d"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIydpSgEEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#4f82961b-9153-4432-923c-b1b9d112f9f0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#a31d4905-1834-4546-95a0-25ea02f4319d"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qIydpigEEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_qIydpCgEEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_qIydoSgEEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="15" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_m0NugCgEEeuc881X317kNw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#684b973d-e383-4b4a-b595-f076680fd83c"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_3Ud_UCgFEeuc881X317kNw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_3UhCoCgFEeuc881X317kNw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_3UhCoSgFEeuc881X317kNw" type="Sirius" element="_3Ud_UCgFEeuc881X317kNw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_uUWXwCgHEeuc881X317kNw" type="2001" element="_tJwM4CgHEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_uUW-0CgHEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_uUW-0SgHEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_uUW-0igHEeuc881X317kNw" type="3001" element="_uSn5cCgHEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_uUXl4CgHEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_uUXl4SgHEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_uUYM8CgHEeuc881X317kNw" type="3003" element="_uSn5cSgHEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_uUYM8SgHEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUYM8igHEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_uUYM8ygHEeuc881X317kNw" type="3001" element="_uSoggCgHEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_uUY0ACgHEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_uUY0ASgHEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_uUZbECgHEeuc881X317kNw" type="3005" element="_uSoggSgHEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_uUZbESgHEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUZbEigHEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_uUYM9CgHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUYM9SgHEeuc881X317kNw" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_uUW-0ygHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUW-1CgHEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_uUXl4igHEeuc881X317kNw" type="3003" element="_uSmrUCgHEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_uUXl4ygHEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUXl5CgHEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_uUWXwSgHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uUWXwigHEeuc881X317kNw" x="158" y="50" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_3UhCoigFEeuc881X317kNw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_3UnwUCgFEeuc881X317kNw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_3UnwUSgFEeuc881X317kNw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_tJwM4CgHEeuc881X317kNw" name="ExchangeItem1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_uSpHkCgHEeuc881X317kNw" x="158" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_uSn5cCgHEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_uSoggCgHEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#7040e34f-7e06-4b79-9140-0136bb76aa42"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance" href="exchange-item-instance-and-part-model.capella#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_uSoggSgHEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_uSn5cSgHEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_uSmrUCgHEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="124,61,61" labelPosition="node" width="15" height="5" color="246,235,235">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_3UemYCgFEeuc881X317kNw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#5b60d46b-9547-4448-9b82-e20b06231b14"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_nVAnECgHEeuc881X317kNw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_nVFfkCgHEeuc881X317kNw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_nVFfkSgHEeuc881X317kNw" type="Sirius" element="_nVAnECgHEeuc881X317kNw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_qJHGYCgHEeuc881X317kNw" type="2001" element="_ni3c4CgHEeuc881X317kNw">
+          <children xmi:type="notation:Node" xmi:id="_qJHtcCgHEeuc881X317kNw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_qJHtcSgHEeuc881X317kNw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJIUgCgHEeuc881X317kNw" type="3001" element="_qIO8oCgHEeuc881X317kNw">
+            <children xmi:type="notation:Node" xmi:id="_qJI7kCgHEeuc881X317kNw" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_qJI7kSgHEeuc881X317kNw" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJJioCgHEeuc881X317kNw" type="3003" element="_qIPjsCgHEeuc881X317kNw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJJioSgHEeuc881X317kNw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJJioigHEeuc881X317kNw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_qJJioygHEeuc881X317kNw" type="3001" element="_qIPjsSgHEeuc881X317kNw">
+              <children xmi:type="notation:Node" xmi:id="_qJLX0CgHEeuc881X317kNw" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_qJLX0SgHEeuc881X317kNw" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_qJLX0igHEeuc881X317kNw" type="3005" element="_qIPjsigHEeuc881X317kNw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_qJLX0ygHEeuc881X317kNw" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJLX1CgHEeuc881X317kNw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_qJJipCgHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJJipSgHEeuc881X317kNw" x="2" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJIUgSgHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJIUgigHEeuc881X317kNw" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_qJI7kigHEeuc881X317kNw" type="3003" element="_qINugCgHEeuc881X317kNw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_qJI7kygHEeuc881X317kNw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJI7lCgHEeuc881X317kNw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_qJHGYSgHEeuc881X317kNw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qJHGYigHEeuc881X317kNw" x="135" y="50" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_nVFfkigHEeuc881X317kNw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_nVUwICgHEeuc881X317kNw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_nVUwISgHEeuc881X317kNw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ni3c4CgHEeuc881X317kNw" name="LC 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#7ba0c519-1570-4d6a-b38a-e04afc30a622"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="exchange-item-instance-and-part-model.capella#a576a905-d888-41c5-b453-3547174079a8"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_qIQKwCgHEeuc881X317kNw" x="135" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIO8oCgHEeuc881X317kNw" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#7ba0c519-1570-4d6a-b38a-e04afc30a622"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="exchange-item-instance-and-part-model.capella#a576a905-d888-41c5-b453-3547174079a8"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_qIPjsSgHEeuc881X317kNw" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="exchange-item-instance-and-part-model.capella#92466845-a6a2-411a-a8fd-39b53f9d86dc"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="exchange-item-instance-and-part-model.capella#7ba0c519-1570-4d6a-b38a-e04afc30a622"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="exchange-item-instance-and-part-model.capella#a576a905-d888-41c5-b453-3547174079a8"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_qIPjsigHEeuc881X317kNw" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.png">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_qIPjsCgHEeuc881X317kNw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_qINugCgHEeuc881X317kNw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.4/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_nVBOICgHEeuc881X317kNw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="exchange-item-instance-and-part-model.capella#1848cbce-c339-471a-9bce-0669ca05a9a6"/>
+  </sequence:SequenceDDiagram>
+</xmi:XMI>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/exchange-item-instance-and-part-model/exchange-item-instance-and-part-model.capella
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_5.0.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/5.0.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/5.0.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/5.0.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/5.0.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/5.0.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/5.0.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/5.0.0"
+    xmlns:org.polarsys.capella.core.data.interaction="http://www.polarsys.org/capella/core/interaction/5.0.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/5.0.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/5.0.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/5.0.0"
+    id="03f35389-a96c-405c-9f91-9561999424c1"
+    name="exchange-item-instance-and-part-model">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="2d7d5a9f-57e1-4e8f-afc3-a541dee94bd6"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="c5677a15-3fe1-4108-aaa8-42e4a66bc746" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="33f3f250-d8cf-45f2-8c5b-02ac0e695cab" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="5719dfcd-84b9-4ab6-beb8-065123405883" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="e6acffed-be65-4c97-b9af-d169e3a2ccf7" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="ee4f2280-ffed-4f0e-a9bb-e811e0ed35ad" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="cc179ce1-5f75-44b3-9940-41090c9442e9" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="68fe1d94-ce5c-4ad5-957d-679d4d7a5f13" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="91e4a182-bfca-4c62-bf6c-0f2e5cb105b2"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="6c5871f1-f372-4ffc-9742-dc86645173aa" name="exchange-item-instance-and-part-model">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="39253150-22cc-44b5-8b0b-3061b981d932" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="a329f37c-b54b-43e1-939c-82650a6634de" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="9c7016cc-3ba2-471e-99f7-04440cf963cb" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="4b5920a3-ced9-4457-a669-db3d7a342f62" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="afdfb437-44d1-4ee4-a8dd-3d0d8191054a" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="105cd58a-1e0a-4f14-be59-88fcd5e93a8d" name="Data">
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="a6594575-7dcf-4173-9f09-4f26fa2b275b" name="ExchangeItem1">
+          <ownedExchangeItemInstances xsi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance"
+              id="4f7a6106-ee35-4dc0-87e2-74b67f2b5aae" name="ExchangeItem1" abstractType="#a6594575-7dcf-4173-9f09-4f26fa2b275b"/>
+        </ownedExchangeItems>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="8eafd9a4-15b2-4534-95c7-29582fb099a8" name="ExchangeItem" exchangeMechanism="SHARED_DATA">
+          <ownedExchangeItemInstances xsi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance"
+              id="a31d4905-1834-4546-95a0-25ea02f4319d" name="ExchangeItemInstance1"
+              abstractType="#8eafd9a4-15b2-4534-95c7-29582fb099a8"/>
+          <ownedExchangeItemInstances xsi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance"
+              id="d6647703-10c2-4abf-9e69-ce45fa12b7f3" name="ExchangeItemInstance2"
+              abstractType="#8eafd9a4-15b2-4534-95c7-29582fb099a8"/>
+        </ownedExchangeItems>
+        <ownedExchangeItems xsi:type="org.polarsys.capella.core.data.information:ExchangeItem"
+            id="ca6d7e0a-aa4b-43d1-a631-89b24a090c64" name="ExchangeItem3">
+          <ownedExchangeItemInstances xsi:type="org.polarsys.capella.core.data.information:ExchangeItemInstance"
+              id="d6c9f791-0287-4be8-ae7a-31c4af18de84" name="ExchangeItem XXX" abstractType="#ca6d7e0a-aa4b-43d1-a631-89b24a090c64"/>
+        </ownedExchangeItems>
+      </ownedDataPkg>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="37111b38-ed7d-4e71-a618-41f96f8d4f01"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="5ce28625-dfc9-45e1-ab61-8f1dd09fc11a"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="6643ab4f-f174-4e60-9385-516ea6624f68" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="e7f0a06c-5037-4cd2-a97d-dda8f2a4f174" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="b98c7b50-4fc0-45c7-9335-ad977817d9bd" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="92b30f81-e430-4ade-a02b-417135e03a6e" targetElement="#9c7016cc-3ba2-471e-99f7-04440cf963cb"
+              sourceElement="#b98c7b50-4fc0-45c7-9335-ad977817d9bd"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="ad1d63f9-690e-4008-99b1-d29a667f1a07" name="Capabilities">
+        <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
+            id="de0125aa-b316-4468-9ee6-f3a8c5ee8e8f" name="Capability 1">
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="684b973d-e383-4b4a-b595-f076680fd83c" name="[IS] Capability 1" kind="INTERFACE">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="03465a89-5993-43ff-9c35-753a17f421f5" name="System" representedInstance="#cd3b0d7a-77b3-427e-8113-83211d850293"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="d0de2024-3ff0-4df2-8e94-20efe5de11d3" name="ExchangeItem 1"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="c8124936-287d-4029-a4ac-47fa65784d1d" name="ExchangeItem1" representedInstance="#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="4f82961b-9153-4432-923c-b1b9d112f9f0" name="ExchangeItemInstance1"
+                representedInstance="#a31d4905-1834-4546-95a0-25ea02f4319d"/>
+          </ownedScenarios>
+          <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
+              id="bb9ef96e-c954-4cdc-be4f-785795311de1" involved="#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"/>
+        </ownedCapabilities>
+      </ownedAbstractCapabilityPkg>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="c01552d2-6c12-47f5-aa1f-8681c5df1d59" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="ad3f8b40-090b-4c63-96ec-993e44810e28" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="90007423-5efc-447f-9fa0-65a319251338" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="9f03851e-4913-42b2-a955-93423c5773ca" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="807e98bc-4893-435d-ad2a-4030439ddd9b" name="True" abstractType="#9f03851e-4913-42b2-a955-93423c5773ca"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="c8de3b21-f595-4868-9a8d-7df3e2c090f4" name="False" abstractType="#9f03851e-4913-42b2-a955-93423c5773ca"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="4d6d2cbe-27b3-4b10-9ece-5ac5af781b52" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="b55256be-d0b7-4b43-867f-f439f68ac461" name="" abstractType="#4d6d2cbe-27b3-4b10-9ece-5ac5af781b52"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="5dfccd88-df6b-4f10-9e88-41f876b182ea" name="" abstractType="#4d6d2cbe-27b3-4b10-9ece-5ac5af781b52"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="7b63d893-d1f9-4e40-b22a-f8ccd2d3f62d" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="6f329ae4-5cdd-40cb-89a3-5b17f3051fab" name="" abstractType="#ef933a76-dd51-47d7-a7fc-39cb67ac2252"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="8aba6e69-ddc3-45ad-a1bd-7f9bbbd495a5" name="" abstractType="#ef933a76-dd51-47d7-a7fc-39cb67ac2252"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="184d82f4-d946-4b31-a718-2014a30cd73b" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="abf05c98-b80a-4972-92d9-a8b10f3c0c40" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="832d1d8e-d7a6-42b5-93f4-b8593e7a004d" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="f294dcb9-7008-4f69-be10-4440860deea6" name="" abstractType="#832d1d8e-d7a6-42b5-93f4-b8593e7a004d"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="98b6663b-d716-4b38-8e4a-0a009dc656bd" abstractType="#832d1d8e-d7a6-42b5-93f4-b8593e7a004d"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="3289cd75-4367-4c03-9f0d-8be61bd7d8fb" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="11d26fd0-b915-40f1-a5f5-5dffe995313b" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="85d026cc-b96f-43aa-b5cd-28d84e04b463" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="cfd48348-c42a-45bb-9339-ccd5118dbd62" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="381d9e99-042f-46e7-8bce-2e4a93abcf8f" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="84fe2d62-3b2f-4193-b6fe-19ed6efdd286" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="8362520b-d244-4eaa-ba63-6d1ec5437785" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="d6ed0e60-d87c-4e7d-8cf4-598701a21dfc" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="3e721311-15ac-4d03-9cdc-ccf8156f4586" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="3454eb69-60ed-4f9e-993b-435c019dda2d" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a7f0a316-8fea-47ef-ad5e-15c269f981b0" name="" abstractType="#3454eb69-60ed-4f9e-993b-435c019dda2d"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="ef933a76-dd51-47d7-a7fc-39cb67ac2252" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="4780f4d8-0680-444d-a29c-c80eadb166a6" name="" abstractType="#ef933a76-dd51-47d7-a7fc-39cb67ac2252"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="11c9268f-f5df-4bbd-8107-ed55f3e68cfa" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a1dbe278-b27b-4b5e-a409-794e0c7f48fa" name="" abstractType="#11c9268f-f5df-4bbd-8107-ed55f3e68cfa"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="5a089754-2e05-46a0-b79e-139364fe2e28" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="0713ef04-f660-4de4-a123-21315aa33c32" name="" abstractType="#5a089754-2e05-46a0-b79e-139364fe2e28"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="b9905811-ec61-44be-86f3-36b884224567" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="cd3b0d7a-77b3-427e-8113-83211d850293"
+            name="System" abstractType="#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="78aabbe6-82e0-49e0-9f4c-9be0f0fcc430" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="480da3a3-7fd3-463c-bdca-7ce62c836b89" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="3404c5f5-fa96-4bd6-8b41-6f97ec317b51" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="f71f5497-2928-4150-92ea-56f16a274294"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="3867c542-5ea2-483e-84d7-2b1bfe6abed8" targetElement="#39253150-22cc-44b5-8b0b-3061b981d932"
+          sourceElement="#6643ab4f-f174-4e60-9385-516ea6624f68"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="38e06288-db99-4c1e-82ee-6a895e734558" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="6df54028-2ae3-4d32-904c-affffb10c35c" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="73309549-094d-492e-815f-c7a1db621d81" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="3ae15f87-649a-42e9-8599-404d398e05d9" targetElement="#b98c7b50-4fc0-45c7-9335-ad977817d9bd"
+              sourceElement="#73309549-094d-492e-815f-c7a1db621d81"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="122a7adb-aa5b-44e3-99d8-2851394b406e" name="Capabilities">
+        <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
+            id="40513538-22df-4811-b4d2-a03177118bd3" name="CapabilityRealization 1">
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="5b60d46b-9547-4448-9b82-e20b06231b14" name="[IS] CapabilityRealization 1"
+              kind="INTERFACE">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="7040e34f-7e06-4b79-9140-0136bb76aa42" name="ExchangeItem1" representedInstance="#4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"/>
+          </ownedScenarios>
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="1848cbce-c339-471a-9bce-0669ca05a9a6" name="[ES] CapabilityRealization 1"
+              kind="DATA_FLOW">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="92466845-a6a2-411a-a8fd-39b53f9d86dc" name="LC 1" representedInstance="#7ba0c519-1570-4d6a-b38a-e04afc30a622"/>
+          </ownedScenarios>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="c0a2ca3d-521d-43d8-a2bf-8d080658c24f" involved="#a576a905-d888-41c5-b453-3547174079a8"/>
+        </ownedCapabilityRealizations>
+      </ownedAbstractCapabilityPkg>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="94773acd-c17f-419d-b053-7a1f497ef5c1" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="d4ecdbb6-4113-4b1a-bc79-3c3d2ce05537" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="aa6a762d-34ff-4d77-9095-99875a553068" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="c9a719c7-23b8-4006-b34d-d70fddbff1cc"
+            name="Logical System" abstractType="#b92d6429-54c0-4f31-a33a-cd1148483fab"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="b92d6429-54c0-4f31-a33a-cd1148483fab" name="Logical System">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="7ba0c519-1570-4d6a-b38a-e04afc30a622"
+              name="LC 1" abstractType="#a576a905-d888-41c5-b453-3547174079a8"/>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="44394260-1494-487b-94f1-659ace72ab84"
+              name="LC XXX" abstractType="#3db263f8-bace-480f-9338-06d1727ff895"/>
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="2552dee7-8dd0-4ad3-9fc7-73e8f44f38c5" targetElement="#78aabbe6-82e0-49e0-9f4c-9be0f0fcc430"
+              sourceElement="#b92d6429-54c0-4f31-a33a-cd1148483fab"/>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="a576a905-d888-41c5-b453-3547174079a8" name="LC 1"/>
+          <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+              id="3db263f8-bace-480f-9338-06d1727ff895" name="LC 2"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="659fcf47-faee-43be-8dbd-3724ac1826f6" targetElement="#6643ab4f-f174-4e60-9385-516ea6624f68"
+          sourceElement="#38e06288-db99-4c1e-82ee-6a895e734558"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="ae71905d-4ffe-4bb9-93b5-f67d5b52da62" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="03604a7f-12c1-483a-8871-29535c9fcb5a" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="d2fb4f43-3432-46d7-b788-52b9957e01de" name="Root Physical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="d5c37a04-7957-4c08-b0ba-eebd35bbb2ab" targetElement="#73309549-094d-492e-815f-c7a1db621d81"
+              sourceElement="#d2fb4f43-3432-46d7-b788-52b9957e01de"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="6961d7d8-8978-490a-b08e-49350d01a761" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="b2240308-5949-4323-b7bd-d115b09e7903" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="d9fe6f7d-584c-4d1d-890c-ca10dd67c661" name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="5fd7b418-9848-4348-94e9-998c5904e9a3" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="d3597333-a2e7-483a-b38d-0d0423dd75bd"
+            name="Physical System" abstractType="#ed0ef69c-427f-47b1-9dd3-7c1ef8bd4b5f"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="ed0ef69c-427f-47b1-9dd3-7c1ef8bd4b5f" name="Physical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="4d8852cb-00c2-43f2-a5bd-144e91fa876b" targetElement="#b92d6429-54c0-4f31-a33a-cd1148483fab"
+              sourceElement="#ed0ef69c-427f-47b1-9dd3-7c1ef8bd4b5f"/>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="a6ac3f0b-30f8-44b5-bdc5-4b50189ee89e" targetElement="#38e06288-db99-4c1e-82ee-6a895e734558"
+          sourceElement="#ae71905d-4ffe-4bb9-93b5-f67d5b52da62"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="bb603005-6618-4aa0-a363-73b8add7a343" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="9347c452-c0ef-46dd-aafa-60928af28721" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="ae36aeba-244d-4620-801e-7ca6ef4a508c" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="f1dcf987-d0d1-4ae7-9915-e4a98527a872"
+            name="System" abstractType="#ca1aba60-00e6-404a-b5c9-c82ae63e9cd3"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="ca1aba60-00e6-404a-b5c9-c82ae63e9cd3" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="2ab06ebc-8baf-448e-b8f8-d75f57dca1a4" targetElement="#ed0ef69c-427f-47b1-9dd3-7c1ef8bd4b5f"
+              sourceElement="#ca1aba60-00e6-404a-b5c9-c82ae63e9cd3"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="51fd1eb4-b53c-4747-82fb-2201769cc59d" targetElement="#ae71905d-4ffe-4bb9-93b5-f67d5b52da62"
+          sourceElement="#bb603005-6618-4aa0-a363-73b8add7a343"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/i/IRulesTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/i/IRulesTestSuite.java
@@ -69,7 +69,8 @@ public class IRulesTestSuite extends BasicTestSuite {
     tests.add(new Rule_I_40_OnCapability());
     tests.add(new Rule_I_40_OnMission());
     tests.add(new Rule_I_43_ElementReferencesAirdOrProxyElement());
-    
+    tests.add(new Rule_I_45());
+
     return tests;
   }
 

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/i/Rule_I_45.java
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/i/Rule_I_45.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.validation.rules.ju.testcases.i;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EClass;
+import org.polarsys.capella.common.data.modellingcore.ModellingcorePackage;
+import org.polarsys.capella.test.framework.api.OracleDefinition;
+import org.polarsys.capella.test.validation.rules.ju.testcases.ValidationRulePartialTestCase;
+
+public class Rule_I_45 extends ValidationRulePartialTestCase {
+
+  public static final String VALID_EXCHANGE_ITEM_1 = "4f7a6106-ee35-4dc0-87e2-74b67f2b5aae"; //$NON-NLS-1$
+  public static final String VALID_EXCHANGE_ITEM_INSTANCE_1 = "a31d4905-1834-4546-95a0-25ea02f4319d"; //$NON-NLS-1$
+  public static final String VALID_EXCHANGE_ITEM_INSTANCE_2 = "d6647703-10c2-4abf-9e69-ce45fa12b7f3"; //$NON-NLS-1$
+  public static final String INVALID_EXCHANGE_ITEM = "d6c9f791-0287-4be8-ae7a-31c4af18de84"; //$NON-NLS-1$
+
+  public static final String VALID_LC1_PART = "7ba0c519-1570-4d6a-b38a-e04afc30a622"; //$NON-NLS-1$
+  public static final String INVALID_LC2_PART = "44394260-1494-487b-94f1-659ace72ab84"; //$NON-NLS-1$
+
+  @Override
+  protected List<String> getScopeDefinition() {
+    return Arrays.asList(VALID_EXCHANGE_ITEM_1, VALID_EXCHANGE_ITEM_INSTANCE_1, VALID_EXCHANGE_ITEM_INSTANCE_2,
+        VALID_EXCHANGE_ITEM_INSTANCE_2, INVALID_EXCHANGE_ITEM, VALID_LC1_PART, INVALID_LC2_PART);
+  }
+
+  @Override
+  protected EClass getTargetedEClass() {
+    return ModellingcorePackage.Literals.ABSTRACT_TYPED_ELEMENT;
+  }
+
+  @Override
+  protected String getRuleID() {
+    return "org.polarsys.capella.core.data.core.validation.I_45";
+  }
+
+  @Override
+  protected List<OracleDefinition> getOracleDefinitions() {
+    return Arrays.asList(new OracleDefinition(VALID_EXCHANGE_ITEM_1, 0),
+        new OracleDefinition(VALID_EXCHANGE_ITEM_INSTANCE_1, 0),
+        new OracleDefinition(VALID_EXCHANGE_ITEM_INSTANCE_2, 0), new OracleDefinition(INVALID_EXCHANGE_ITEM, 1),
+        new OracleDefinition(VALID_LC1_PART, 0), new OracleDefinition(INVALID_LC2_PART, 1));
+  }
+
+  @Override
+  protected String getRequiredTestModel() {
+    return "exchange-item-instance-and-part-model";
+  }
+
+}


### PR DESCRIPTION
Abstract Type

Abstract Type Elements should have the same name as their Abstract Type
in the following cases:

- **Part**: In singleton component mode
- **Exchange Item Instance**:  If the Exchange Item has a single Exchange Item Instance

Work done:
- Add name synchronization between Exchange Item and Exchange Item
Instance
- Add validation rule
- Add quick fix
- Add JUnit
- Update embedded documentation

Change-Id: I427313bf5c67be4af9c64f77e0b5361a49892dac
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>