### PR TITLE
#2024 Constraints on OEntities and OActors should be displayed in

### DIFF
--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/ModelElementConstraints.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/ModelElementConstraints.java
@@ -77,6 +77,9 @@ public class ModelElementConstraints implements IQuery {
       for (AbstractConstraint constraint : part.getConstraints())
         result.add(constraint);
     }
+    for (AbstractConstraint constraint : component.getConstraints()) {
+      result.add(constraint);
+    }
 
     return result;
   }


### PR DESCRIPTION
referencing elements inside the Semantic Browser view