### PR TITLE
#2034 D&D and Copy-Paste disable Mix of Mode and State in Hierarchy

### DIFF
--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/StateMachineExt.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/helpers/StateMachineExt.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.polarsys.capella.core.data.cs.Block;
 import org.polarsys.capella.core.data.cs.Component;
@@ -91,6 +92,24 @@ public class StateMachineExt {
     List<Region> regions = getAllStateMachinesRegions(comp);
     if (!regions.isEmpty()) {
       return regions.get(0);
+    }
+    return null;
+  }
+  
+  /**
+   * Get the first region (the "root" region = first region under StateMachine) of a State or a Region
+   * 
+   * @param object
+   *          Region or State
+   * @return the root region or null
+   */
+  public static Region getRootRegion(EObject object) {
+    if (object.eContainer() != null) {
+      if (!(object.eContainer() instanceof StateMachine)) {
+        return getRootRegion(object.eContainer());
+      }
+      if (object instanceof Region)
+        return (Region) object;
     }
     return null;
   }

--- a/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.capella
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/model/miscmodel/miscmodel.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_5.0.0-->
+<!--Capella_Version_null-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/5.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/5.0.0"
@@ -334,6 +334,28 @@
                   </ownedSpecification>
                 </ownedConstraints>
               </ownedTransitions>
+            </ownedRegions>
+          </ownedStateMachines>
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="199c547f-bbc4-4777-95dd-d394e2dd514b" name="StateMachine 2">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="de5cfc64-9f52-41c4-8883-132dcaa37d6d" name="Default Region" involvedStates="#6b01bdc1-096a-4cc2-9329-fe9b0ddd8bc5">
+              <ownedStates xsi:type="org.polarsys.capella.core.data.capellacommon:State"
+                  id="6b01bdc1-096a-4cc2-9329-fe9b0ddd8bc5" name="State 1">
+                <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                    id="b341f231-2f15-4343-a9ec-e11172e98df3" name="region"/>
+              </ownedStates>
+            </ownedRegions>
+          </ownedStateMachines>
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="2bd00e18-a03b-46b1-8acf-a1f0d3d8fc58" name="StateMachine 3">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="540670b4-1cd2-4dad-9c25-39e8da85ab89" name="Default Region" involvedStates="#0da70fc6-efc8-4645-a854-67d7fcb37feb">
+              <ownedStates xsi:type="org.polarsys.capella.core.data.capellacommon:Mode"
+                  id="0da70fc6-efc8-4645-a854-67d7fcb37feb" name="Mode 1">
+                <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                    id="09873d88-fc70-43c1-a0fa-473a4e5eb1b9" name="region"/>
+              </ownedStates>
             </ownedRegions>
           </ownedStateMachines>
         </ownedSystemComponents>

--- a/tests/plugins/org.polarsys.capella.test.model.ju/src/org/polarsys/capella/test/model/ju/dnd/DnDMixedStatesModes.java
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/src/org/polarsys/capella/test/model/ju/dnd/DnDMixedStatesModes.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.model.ju.dnd;
+
+import java.util.Arrays;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.business.api.session.Session;
+import org.polarsys.capella.core.model.preferences.IModeAndStateManagementPreferences;
+import org.polarsys.capella.test.framework.context.SessionContext;
+import org.polarsys.capella.test.framework.helpers.GuiActions;
+import org.polarsys.capella.test.model.ju.model.MiscModel;
+
+public class DnDMixedStatesModes extends MiscModel {
+  private final String REGION_ID = "540670b4-1cd2-4dad-9c25-39e8da85ab89";
+  private final String STATE_ID = "6b01bdc1-096a-4cc2-9329-fe9b0ddd8bc5";
+  private final String STATE_MACHINE_ID = "199c547f-bbc4-4777-95dd-d394e2dd514b";
+  
+  @Override
+  public void test() throws Exception {
+    Session session = getSessionForTestModel(getRequiredTestModels().get(0));
+    SessionContext context = new SessionContext(session);
+    EObject region = context.getSemanticElement(REGION_ID);
+    EObject stateContainer = context.getSemanticElement(STATE_ID);
+    EObject stateMachineContainer = context.getSemanticElement(STATE_MACHINE_ID);
+    
+    context.setPreference(IModeAndStateManagementPreferences.PREFS_MIXED_MODE_STATE_ALLOWED, false);
+    assertFalse(GuiActions.canDnD(stateContainer, Arrays.asList(region)));
+    assertFalse(GuiActions.canDnD(stateMachineContainer, Arrays.asList(region)));
+  
+    context.setPreference(IModeAndStateManagementPreferences.PREFS_MIXED_MODE_STATE_ALLOWED, true);
+    assertTrue(GuiActions.canDnD(stateContainer, Arrays.asList(region)));
+    assertTrue(GuiActions.canDnD(stateMachineContainer, Arrays.asList(region)));
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.model.ju/src/org/polarsys/capella/test/model/ju/dnd/DnDTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.model.ju/src/org/polarsys/capella/test/model/ju/dnd/DnDTestSuite.java
@@ -36,6 +36,7 @@ public class DnDTestSuite extends BasicTestSuite {
   protected List<BasicTestArtefact> getTests() {
     List<BasicTestArtefact> tests = new ArrayList<>();
     tests.add(new DnDComponentAndPart());
+    tests.add(new DnDMixedStatesModes());
     return tests;
   }
 


### PR DESCRIPTION
- [x] drag and drop of region should not be possible in statemachine with modes in it.
- [x]  update JUnits

Fixes #2034 
Change-Id: I05f9d72e26af0406d34f1f1b0d2392497b9306d9
Signed-off-by: MalinaStefaniaStoicanescu <malina.stoicanescu@thalesgroup.com>