### PR TITLE
#2057 Re-add siblings resolver + refactor

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/plugin.xml
@@ -25,7 +25,16 @@
          </rules>
       </resolver>
       <resolver
-            class="org.polarsys.capella.core.data.common.ui.quickfix.resolver.DWF_SM_06Resolver"
+            class="org.polarsys.capella.core.data.common.ui.quickfix.resolver.DWF_SM_06SiblingResolver"
+            desc="Delete all siblings mixed States/Modes "
+            icon="icons/delete_element.gif"
+            label="Delete all siblings mixed States/Modes ">
+         <rules
+               ruleId="DWF_SM_06">
+         </rules>
+      </resolver>
+      <resolver
+            class="org.polarsys.capella.core.data.common.ui.quickfix.resolver.DWF_SM_06ChildrenResolver"
             desc="Delete all children mixed States/Modes "
             icon="icons/delete_element.gif"
             label="Delete all children mixed States/Modes ">

--- a/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06ChildrenResolver.java
+++ b/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06ChildrenResolver.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.data.common.ui.quickfix.resolver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
+import org.polarsys.capella.core.data.capellacommon.AbstractState;
+import org.polarsys.capella.core.data.capellacommon.Region;
+import org.polarsys.capella.core.data.capellacommon.State;
+
+public class DWF_SM_06ChildrenResolver extends DWF_SM_06Resolver {
+
+  @Override
+  protected List<AbstractState> getMixedStates(Object obj) {
+    // get mixed children states
+    List<AbstractState> lstStates = new ArrayList<>();
+    if (obj instanceof State) {
+      EList<Region> regions = ((State) obj).getOwnedRegions();
+      for (Region region : regions) {
+        for (AbstractState state : region.getOwnedStates()) {
+          if (areMixedStateMode(obj, state)) {
+            lstStates.add(state);
+          }
+        }
+      }
+    }
+    return lstStates;
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06Resolver.java
+++ b/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06Resolver.java
@@ -12,23 +12,17 @@
  *******************************************************************************/
 package org.polarsys.capella.core.data.common.ui.quickfix.resolver;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.polarsys.capella.core.data.capellacommon.AbstractState;
 import org.polarsys.capella.core.data.capellacommon.FinalState;
 import org.polarsys.capella.core.data.capellacommon.Pseudostate;
-import org.polarsys.capella.core.data.capellacommon.Region;
-import org.polarsys.capella.core.data.capellacommon.State;
-import org.polarsys.capella.core.data.capellacommon.impl.ModeImpl;
-import org.polarsys.capella.core.data.capellacommon.impl.StateImpl;
 import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractDeleteCommandResolver;
 
-public class DWF_SM_06Resolver extends AbstractDeleteCommandResolver {
+public abstract class DWF_SM_06Resolver extends AbstractDeleteCommandResolver {
 
   /**
    * {@inheritDoc}
@@ -36,7 +30,7 @@ public class DWF_SM_06Resolver extends AbstractDeleteCommandResolver {
   @Override
   public Object getElementToDelete(Object obj) {
     if (obj != null) {
-      return getChildrenMixedStates(obj);
+      return getMixedStates(obj);
     }
     return null;
   }
@@ -46,33 +40,20 @@ public class DWF_SM_06Resolver extends AbstractDeleteCommandResolver {
     for (IMarker marker : markers) {
       EObject modelElement = getModelElements(marker).get(0);
       if ((null != modelElement) && (modelElement instanceof AbstractState)) {
-        return getChildrenMixedStates(modelElement).size() > 0;
+        return getMixedStates(modelElement).size() > 0;
       }
     }
     return false;
   }
 
-  private List<AbstractState> getChildrenMixedStates(Object obj) {
-    List<AbstractState> lstStates = new ArrayList<>();
-    if (obj instanceof State) {
-      EList<Region> regions = ((State) obj).getOwnedRegions();
-      for (Region region : regions) {
-        for (AbstractState state : region.getOwnedStates()) {
-          if (areMixedStateMode(obj, state)) {
-            lstStates.add(state);
-          }
-        }
-      }
+  protected abstract List<AbstractState> getMixedStates(Object obj);
+
+  protected boolean areMixedStateMode(Object object, AbstractState state) {
+    if ((state instanceof Pseudostate) || (state instanceof FinalState)) {
+      return false;
     }
-    return lstStates;
+
+    return !object.getClass().equals(state.getClass());
   }
-  
-  private boolean areMixedStateMode(Object object, AbstractState state) {
-      if ((state instanceof Pseudostate) || (state instanceof FinalState)) {
-        return false;
-      }
-       
-      return !object.getClass().equals(state.getClass());
-    }
-  
+
 }

--- a/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06SiblingResolver.java
+++ b/core/plugins/org.polarsys.capella.core.data.common.ui.quickfix/src/org/polarsys/capella/core/data/common/ui/quickfix/resolver/DWF_SM_06SiblingResolver.java
@@ -16,37 +16,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.polarsys.capella.core.data.capellacommon.AbstractState;
-import org.polarsys.capella.core.data.capellacommon.Mode;
+import org.polarsys.capella.core.data.capellacommon.Region;
 import org.polarsys.capella.core.data.capellacommon.State;
-import org.polarsys.capella.core.data.capellacommon.impl.ModeImpl;
-import org.polarsys.capella.core.data.capellacommon.impl.StateImpl;
-import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractDeleteCommandResolver;
 
-public class DWF_SM_06SiblingResolver extends AbstractDeleteCommandResolver {
+public class DWF_SM_06SiblingResolver extends DWF_SM_06Resolver {
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public Object getElementToDelete(Object obj) {
-    if (obj != null) {
-      if (obj instanceof Mode) {
-        List<State> lstStates = new ArrayList<State>();
-        for (AbstractState state : ((Mode) obj).getInvolverRegions().get(0).getOwnedStates()) {
-          if (state.getClass() == StateImpl.class)
-            lstStates.add((State) state);
+  protected List<AbstractState> getMixedStates(Object obj) {
+    // get mixed siblings states
+    List<AbstractState> lstStates = new ArrayList<>();
+    if (obj instanceof State && !((State) obj).getInvolverRegions().isEmpty()) {
+      Region region = ((State) obj).getInvolverRegions().get(0);
+      for (AbstractState state : region.getOwnedStates()) {
+        if (areMixedStateMode(obj, state)) {
+          lstStates.add(state);
         }
-        return lstStates;
       }
-
-      List<Mode> lstModes = new ArrayList<Mode>();
-      for (AbstractState mode : ((State) obj).getInvolverRegions().get(0).getOwnedStates()) {
-        if (mode.getClass() == ModeImpl.class)
-          lstModes.add((Mode) mode);
-      }
-      return lstModes;
     }
-
-    return null;
+    return lstStates;
   }
 }


### PR DESCRIPTION
Fixes #2057

- [x] re-add the QF to delete siblings and fix the delete to work (as fixed for delete childs)

Change-Id: Ib105ef9cbe8a15e92ed3ce5278f8f8abd848414d
Signed-off-by: MalinaStefaniaStoicanescu <malina.stoicanescu@thalesgroup.com>