### PR TITLE
#2045 Adapt code according to Sirius Preferences change

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/cmdline/MigrationCommandLine.java
+++ b/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/cmdline/MigrationCommandLine.java
@@ -53,8 +53,6 @@ import org.polarsys.capella.core.model.handler.command.CapellaResourceHelper;
 public class MigrationCommandLine extends DefaultCommandLine {
 
   private Display display;
-  private boolean initialValue_RefreshOnOpening;
-  private boolean initialValue_AutoRefresh;
 
   /**
    * {@inheritDoc}
@@ -74,9 +72,7 @@ public class MigrationCommandLine extends DefaultCommandLine {
       public void postStartup() {
         super.postStartup();
 
-        setRefreshPrefs();
         migrateAllImportedProjects(display.getActiveShell());
-        resetRefreshPrefs();
 
         PlatformUI.getWorkbench().close();
       }
@@ -103,35 +99,6 @@ public class MigrationCommandLine extends DefaultCommandLine {
     }
   }
 
-  /**
-   * Set the refresh preference to true for diagrams
-   *
-   */
-  public void setRefreshPrefs() {
-    IPreferenceStore preferenceStore = SiriusEditPlugin.getPlugin().getPreferenceStore();
-    initialValue_RefreshOnOpening = preferenceStore
-        .getBoolean(SiriusUIPreferencesKeys.PREF_REFRESH_ON_REPRESENTATION_OPENING.name());
-    preferenceStore = SiriusEditPlugin.getPlugin().getCorePreferenceStore();
-    initialValue_AutoRefresh = preferenceStore.getBoolean(SiriusPreferencesKeys.PREF_AUTO_REFRESH.name());
-
-    doSetSiriusPrefs(true, true);
-
-    return;
-  }
-
-  private void resetRefreshPrefs() {
-    doSetSiriusPrefs(initialValue_RefreshOnOpening, initialValue_AutoRefresh);
-  }
-
-  private void doSetSiriusPrefs(boolean refreshOnOpening, boolean autoRefresh) {
-    IEclipsePreferences siriusUIPluginPreferences = InstanceScope.INSTANCE.getNode(SiriusEditPlugin.ID);
-    siriusUIPluginPreferences.putBoolean(SiriusUIPreferencesKeys.PREF_REFRESH_ON_REPRESENTATION_OPENING.name(),
-        refreshOnOpening);
-
-    IEclipsePreferences siriusPluginPreferences = InstanceScope.INSTANCE.getNode(SiriusPlugin.ID);
-    siriusPluginPreferences.putBoolean(SiriusPreferencesKeys.PREF_AUTO_REFRESH.name(), autoRefresh);
-  }
-  
   @Override
   public void printHelp() {
     super.printHelp();

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/CapellaServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2021 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -42,6 +42,7 @@ import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sirius.business.api.dialect.DialectManager;
 import org.eclipse.sirius.business.api.helper.task.DeleteEObjectTask;
+import org.eclipse.sirius.business.api.query.DRepresentationQuery;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.business.api.session.danalysis.DAnalysisSession;
@@ -441,7 +442,7 @@ public class CapellaServices {
   }
 
   public EObject forceRefresh(DDiagram diagram) {
-    if (null != diagram && !RefreshHelper.isAutoRefresh()) {
+    if (null != diagram && !new DRepresentationQuery(diagram).isAutoRefresh()) {
 
       if (!diagram.getActivatedFilters().isEmpty()) {
         CompositeFilterApplicationBuilder builder = new CompositeFilterApplicationBuilder(diagram);

--- a/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
+++ b/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
@@ -365,7 +365,7 @@
           <repository
               url="http://download.eclipse.org/egf/updates/1.6.2/2019-06"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/stable/6.4.0-S20201119-043506/2020-06/"/>
+              url="https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06/"/>
           <repository
               url="https://download.eclipse.org/diffmerge/stable/0.13.0-M4/emf-diffmerge-site"/>
           <repository

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/stable/6.4.0-S20201119-043506/2020-06/targets/modules/gmf-runtime-1.13.tpd"
+include "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06/targets/modules/gmf-runtime-1.13.tpd"
 
 with source, requirements
 
@@ -44,7 +44,7 @@ location eclipse "http://download.eclipse.org/releases/2020-06" {
 	com.google.guava
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/6.4.0-S20201119-043506/2020-06" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
The migration is only based on XML file migration. Sirius API are never
used so SiriusUIPreferencesKeys.PREF_REFRESH_ON_REPRESENTATION_OPENING
and SiriusPreferencesKeys.PREF_AUTO_REFRESH preference are useless for
the migration.

Change-Id: Idef7ef963ca3071e4c53361032ee5820c146d9a2
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>