### PR TITLE
[releng] Update Sirius version to 6.5.0-S20210326-125830

### DIFF
--- a/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
+++ b/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
@@ -365,7 +365,7 @@
           <repository
               url="http://download.eclipse.org/egf/updates/1.6.2/2019-06"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06/"/>
+              url="https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210326-125830/2020-06/"/>
           <repository
               url="https://download.eclipse.org/diffmerge/stable/0.13.0-M4/emf-diffmerge-site"/>
           <repository

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06/targets/modules/gmf-runtime-1.13.tpd"
+include "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210326-125830/2020-06/targets/modules/gmf-runtime-1.13.tpd"
 
 with source, requirements
 
@@ -44,7 +44,7 @@ location eclipse "http://download.eclipse.org/releases/2020-06" {
 	com.google.guava
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210225-102754/2020-06" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210326-125830/2020-06" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210326-125830/2020-06/

Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>