### PR TITLE
#2106 Use ScenarioCache in Operand and Fragment computation

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/SequenceDiagramServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/SequenceDiagramServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2021 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -62,6 +62,7 @@ import org.polarsys.capella.core.model.helpers.SequenceMessageExt;
 import org.polarsys.capella.core.platform.sirius.ui.commands.CapellaDeleteCommand;
 import org.polarsys.capella.core.sirius.analysis.activator.SiriusViewActivator;
 import org.polarsys.capella.core.sirius.analysis.cache.ScenarioCache;
+import org.polarsys.capella.core.sirius.analysis.cache.ScenarioCache.OperandContext;
 import org.polarsys.capella.core.sirius.analysis.cache.ScenarioCache.SemanticCandidateContext;
 
 public class SequenceDiagramServices {
@@ -587,15 +588,8 @@ public class SequenceDiagramServices {
     }
     if (context instanceof InteractionOperand) {
       // Search the CF that contains the InteractionOperand
-      Scenario scenario = (Scenario) context.eContainer();
-      for (TimeLapse tl : scenario.getOwnedTimeLapses()) {
-        if (tl instanceof CombinedFragment) {
-          CombinedFragment cf = (CombinedFragment) tl;
-          if (cf.getReferencedOperands().contains(context)) {
-            return cf;
-          }
-        }
-      }
+      OperandContext operandContext = ScenarioCache.getInstance().getOperandContext((InteractionOperand) context);
+      return operandContext.getCombinedFragment();
     }
     return null;
   }


### PR DESCRIPTION
On some specific use cases with only Frames (4) and Operands (37), a 43%
reduction of the refresh has been observed.

Change-Id: I752b227a8d93ceca6d7f0e2e76575ec3e78ee15b
Signed-off-by: Nathalie Lepine <nathalie.lepine@obeo.fr>
Signed-off-by: Maxime Porhel <maxime.porhel@obeo.fr>