### PR TITLE
#2160 Remove Diagram tab from aird properties page

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/plugin.xml
@@ -634,7 +634,8 @@
             category="org.polarsys.capella.core.platform.sirius.ui.actions.Capella.page"
             class="org.polarsys.capella.core.commands.preferences.ui.AbstractCapellaCommandsPreferencePage"
             id="org.polarsys.capella.common.ui.preferences.diagram"
-            name="%Diagram_Page_Name">
+            name="%Diagram_Page_Name"
+            objectClass="org.eclipse.core.resources.IProject">
     </page>
     <page
           category="org.polarsys.capella.common.ui.preferences.diagram"


### PR DESCRIPTION
I added the missing `objectClass="org.eclipse.core.resources.IProject"` in `org.polarsys.capella.core.sirius.analysis/plugin.xml` to delete the Diagram tab.

Change-Id: I2537a502723decfd4d23e5818cc3deb68201d694
Signed-off-by: Glenn Plouhinec <glenn.plouhinec@obeo.fr>