### PR TITLE
#2163 Export Representation queries from org.polarsys.capella.core.semantic.queries

### DIFF
--- a/core/plugins/org.polarsys.capella.core.semantic.queries/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/META-INF/MANIFEST.MF
@@ -14,6 +14,9 @@ Require-Bundle: org.polarsys.capella.core.model.handler,
 Bundle-ActivationPolicy: lazy
 Export-Package: org.polarsys.capella.core.semantic.queries,
  org.polarsys.capella.core.semantic.queries.basic.queries,
- org.polarsys.capella.core.semantic.queries.basic.queries.utils
+ org.polarsys.capella.core.semantic.queries.basic.queries.utils,
+ org.polarsys.capella.core.semantic.queries.sirius.annotation,
+ org.polarsys.capella.core.semantic.queries.sirius.annotation.eoi,
+ org.polarsys.capella.core.semantic.queries.sirius.diagram
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin


### PR DESCRIPTION
…c.queries.

  - org.polarsys.capella.core.semantic.queries.sirius.annotation
  - org.polarsys.capella.core.semantic.queries.sirius.annotation.eoi
  - org.polarsys.capella.core.semantic.queries.sirius.diagram

Change-Id: I752b347a8d93ceca6d7f0e2e76575ec3e78ee14c
Signed-off-by: Yvan Lussaud <yvan.lussaud@obeo.fr>