### PR TITLE
[releng] Update Sirius version to 6.5.0 RC2 (respin of Sirius IT3)

### DIFF
--- a/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
+++ b/releng/plugins/org.polarsys.capella.settings/oomph/Capella.setup
@@ -365,7 +365,7 @@
           <repository
               url="http://download.eclipse.org/egf/updates/1.6.2/2019-06"/>
           <repository
-              url="https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210430-052046/2020-06/"/>
+              url="https://download.eclipse.org/sirius/updates/milestones/6.5.0rc2/2020-06/"/>
           <repository
               url="https://download.eclipse.org/diffmerge/stable/0.13.0-M4/emf-diffmerge-site"/>
           <repository

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2021 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210430-052046/2020-06/targets/modules/gmf-runtime-1.13.tpd"
+include "https://download.eclipse.org/sirius/updates/milestones/6.5.0rc2/2020-06/targets/modules/gmf-runtime-1.13.tpd"
 
 with source, requirements
 
@@ -44,7 +44,7 @@ location eclipse "http://download.eclipse.org/releases/2020-06" {
 	com.google.guava
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/6.5.0-S20210430-052046/2020-06" {
+location sirius "https://download.eclipse.org/sirius/updates/milestones/6.5.0rc2/2020-06" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
https://download.eclipse.org/sirius/updates/milestones/6.5.0rc2/2020-06/

Just 2 changes since the last Sirius version:
* one to fix a problem, for bugzilla 571115, detected during validation
phase,
* one to avoid a random failure on Collab automatic tests.

Change-Id: I81d3104594c34a39e32dd3c9dfddfbbb76443fd5
Signed-off-by: Laurent Redor <laurent.redor@obeo.fr>