### PR TITLE
#2208 Hide "Modeling Project" from Capella perspective exclusively

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.perspective/plugin.xml
@@ -70,7 +70,6 @@
           categoryId="org.polarsys.capella.activities.categories.advanced">
      </categoryActivityBinding>
      
-	 <activityPatternBinding activityId="org.polarsys.capella.core.hidden.activity" pattern=".*/org.eclipse.sirius.ui.modelingproject.wizard"/>
 	 <activityPatternBinding activityId="org.polarsys.capella.core.hidden.activity" pattern=".*/org.eclipse.sirius.ui.specificationproject.wizard"/>
      <activityPatternBinding activityId="org.polarsys.capella.core.hidden.activity" pattern=".*/org.eclipse.ui.wizards.export.Preferences"/>
      
@@ -99,6 +98,8 @@
 			</with>
 		</enabledWhen>
 	 </activity>
+	 
+	 <activityPatternBinding activityId="org.polarsys.capella.core.perspective.hidden.activity" pattern=".*/org.eclipse.sirius.ui.modelingproject.wizard"/>
 	 
      <!-- Hide Sirius close contextual menu in Capella perspective -->
 	 <activityPatternBinding activityId="org.polarsys.capella.core.perspective.hidden.activity" isEqualityPattern="true" pattern="org.eclipse.sirius.ui.editor/org.eclipse.sirius.ui.closeSessionMenuContribution"/>


### PR DESCRIPTION
The "Modeling Project" action is now hidden from the Capella perspective.

Change-Id: I0f116bb49f53b98d47a920a2ec3c37b4e94544b8
Signed-off-by: Glenn Plouhinec <glenn.plouhinec@obeo.fr>