### PR TITLE
#2241 Ignore non-LibrariesPackage related UnresolvedReferenceException

### DIFF
--- a/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/LibrarySAXXMIHandler.java
+++ b/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/LibrarySAXXMIHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2021 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,14 +12,19 @@
  *******************************************************************************/
 package org.polarsys.capella.core.libraries.provider;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EFactory;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
+import org.eclipse.emf.ecore.xmi.UnresolvedReferenceException;
 import org.eclipse.emf.ecore.xmi.XMLHelper;
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.SAXXMIHandler;
 import org.polarsys.capella.common.libraries.LibrariesFactory;
+import org.polarsys.capella.common.libraries.LibrariesPackage;
 import org.polarsys.capella.core.data.capellamodeller.CapellamodellerPackage;
 
 /**
@@ -53,5 +58,17 @@ public class LibrarySAXXMIHandler extends SAXXMIHandler {
   @Override
   protected void validateCreateObjectFromFactory(EFactory factory, String typeName, EObject newObject) {
     //don't raise an error
+  }
+
+  @Override
+  protected void handleForwardReferences(boolean isEndDocument) {
+      super.handleForwardReferences(isEndDocument);
+      List<Diagnostic> diagnosticToIgnore = new ArrayList<>();
+      for (Diagnostic diagnostic : xmlResource.getErrors()) {
+          if (diagnostic instanceof UnresolvedReferenceException && !(LibrariesPackage.eNS_URI.equals(((UnresolvedReferenceException) diagnostic).getFeature().eResource().getURI().toString()))) {
+              diagnosticToIgnore.add(diagnostic);
+          }
+      }
+      xmlResource.getErrors().removeAll(diagnosticToIgnore);
   }
 }


### PR DESCRIPTION
Importing a shared Capella project where the root element (Project) has
a status leads to an UnresolvedReferenceException that can be ignored in
LibrarySAXXMIHandler.handleForwardReferences

Bug:2241
Change-Id: I5295d0fed0b247acf38aa2d5fcc3e6c29cb70d3d
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>