### PR TITLE
#2261 Handle selection of transformation handlers

### DIFF
--- a/common/plugins/org.polarsys.capella.common.transition/src/org/polarsys/capella/core/transition/common/handlers/traceability/config/ExtendedTraceabilityConfiguration.java
+++ b/common/plugins/org.polarsys.capella.common.transition/src/org/polarsys/capella/core/transition/common/handlers/traceability/config/ExtendedTraceabilityConfiguration.java
@@ -109,6 +109,9 @@ public abstract class ExtendedTraceabilityConfiguration extends TraceabilityConf
     if (result) {
       for (ITraceabilityConfiguration configuration : getDefinedConfigurations(context)) {
         result = configuration.useHandlerForAttachment(source, target, handler, context);
+        if (!result) {
+          return false;
+        }
       }
     }
     return result;
@@ -124,6 +127,9 @@ public abstract class ExtendedTraceabilityConfiguration extends TraceabilityConf
     if (result) {
       for (ITraceabilityConfiguration configuration : getDefinedConfigurations(context)) {
         result = configuration.useHandlerForTracedElements(source, handler, context);
+        if (!result) {
+          return false;
+        }
       }
     }
     return result;
@@ -139,6 +145,9 @@ public abstract class ExtendedTraceabilityConfiguration extends TraceabilityConf
     if (result) {
       for (ITraceabilityConfiguration configuration : getDefinedConfigurations(context)) {
         result = configuration.useHandlerForSourceElements(source, handler, context);
+        if (!result) {
+          return false;
+        }
       }
     }
     return result;


### PR DESCRIPTION
If multiple vp extend TraceabilityConfiguration, it is not clear which
handler is used.

Change-Id: I0c379c044601c142824c504c1ca1b3bc3ee1a1dd
Signed-off-by: Georgiana Ecobici <georgiana-elena.ecobici@thalesgroup.com>