### PR TITLE
[2278] Enable Migration from 1.4.x to 5.2

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/af/ViewpointMigrationContribution.java
+++ b/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/af/ViewpointMigrationContribution.java
@@ -153,7 +153,7 @@ public class ViewpointMigrationContribution extends AbstractMigrationContributio
 
     if (!isMigrationPossible(fileVersion, currentVersion)) {
       String formattedMessage = NLS.bind(Messages.MigrationAction_ErrorDialog_TooOldMessage,
-          new String[] { context.getResourceName(), currentVersion.toString() });
+          new String[] { context.getResourceName(), currentVersion.toString(), fileVersion.toString() });
       return new Status(IStatus.ERROR, Activator.PLUGIN_ID, formattedMessage);
     }
 
@@ -194,17 +194,17 @@ public class ViewpointMigrationContribution extends AbstractMigrationContributio
   /**
    * Returns whether the file with the given version can be migrated towards to current version. Only n-1 version can be
    * migrated
+   * The migration of the Capella model 1.4.x to 5 is managed is a deticated case.
+   * @param fileVersion the version of the Capella model
+   * @param currentVersion the version of Capella platform
+   * @return <code>true</code> if the migration is allowed, <code>false</code> otherwise
    */
   private boolean isMigrationPossible(Version fileVersion, Version currentVersion) {
-    boolean sameMajor = (currentVersion.getMajor() == fileVersion.getMajor());
-
-    if (sameMajor) {
-      // Only n-1 to n migrations are handled
-      if ((currentVersion.getMinor() - fileVersion.getMinor()) <= 1) {
-        return true;
-      }
-    }
-
-    return false;
+	// This allow migration from any 1.4.x version to 5.0, 5.1 and 5.2 to support the change of the versioning strategy (Issue #2278)
+	// This behavior should be removed from the migration process starting from the version 6.0
+	if ((fileVersion.getMajor() == 1 && fileVersion.getMinor() == 4) && (currentVersion.getMajor() == 5 && currentVersion.getMinor() <= 2)) {
+		return true;
+	}
+	return currentVersion.getMajor() - fileVersion.getMajor() <= 1;
   }
 }

--- a/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/capella/messages.properties
+++ b/core/plugins/org.polarsys.capella.core.data.migration/src/org/polarsys/capella/core/data/migration/capella/messages.properties
@@ -13,7 +13,7 @@
 ECore2ECoreMigrationAction_Migration_OutOfMemoryError_Title=Migration Error
 ECore2ECoreMigrationAction_Migration_OutOfMemoryError_Description=Migration failed because of RAM configuration issues. 
 
-MigrationAction_ErrorDialog_TooOldMessage=Model file ''{0}'' is too old to be migrated to ''{1}''
+MigrationAction_ErrorDialog_TooOldMessage=Model file ''{0}'' (version: ''{2}'') is too old to be migrated to ''{1}''
 MigrationAction_ErrorDialog_CorruptedMessage=Model file ''{0}'' seems to be corrupted (cannot retrieve version information).\nPlease check and fix your model.\n
 MigrationAction_ErrorDialog_LibrariesNotMigratedMessage=Libraries: ''{0}'' must be migrate first.
 


### PR DESCRIPTION
- update the prevent migration process
- enhance the error message when the model version is too old, the model version is shown in the message

Change-Id: I11a35c68c4203c4e834cd0c78221afabdbf90dae
Signed-off-by: Boubekeur Zendagui <boubekeur.zendagui@thalesgroup.com>