### PR TITLE
#2269 Add validation rules for wrong image path

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.polarsys.capella.core.validation,
  org.eclipse.sirius,
  org.polarsys.capella.core.validation.ui.ide,
  org.polarsys.capella.shared.id.handler,
- org.eclipse.sirius.diagram
+ org.eclipse.sirius.diagram,
+ org.eclipse.sirius.diagram.ui
 Export-Package: org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.properties
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.properties
@@ -18,5 +18,9 @@ quickFix.I_22_Resolver.desc = Update all hyperLink to capella element or diagram
 
 quickFix.I_23_Resolver.label = Delete all hyperLink to non existing capella element or diagram
 quickFix.I_23_Resolver.desc = Delete all hyperLink to non existing capella element or diagram
+
+quickFix.ImagePath_Resolver.label = Select a new image
+quickFix.ImagePath_Resolver.desc = Select a new image to replace the current non reachable one
+
 providerName = Eclipse.org
 pluginName = Capella Sirius Sirius Validation Plug-in

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.xml
@@ -33,6 +33,22 @@
                ruleId="I_23">
          </rules>
       </resolver>
+      <resolver
+            class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathResolver"
+            desc="%quickFix.ImagePath_Resolver.desc"
+            label="%quickFix.ImagePath_Resolver.label">
+         <rules
+               ruleId="I_46">
+         </rules>
+      </resolver>
+      <resolver
+            class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathResolver"
+            desc="%quickFix.ImagePath_Resolver.desc"
+            label="%quickFix.ImagePath_Resolver.label">
+         <rules
+               ruleId="I_47">
+         </rules>
+      </resolver>
    </extension>
    <extension point="org.eclipse.emf.validation.constraintProviders">
       <constraintProvider>
@@ -96,6 +112,44 @@
                </target>
                <description>
                   This rule ensures that hyperLinks to non existing capella element or diagram are removed from the description.
+               </description>
+            </constraint>
+            <constraint
+                  class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathInDiagramCheck"
+                  id="I_46"
+                  isEnabledByDefault="false"
+                  lang="java"
+                  mode="Batch"
+                  name="I_46 - Check that the image used for diagram nodes is found"
+                  severity="ERROR"
+                  statusCode="1">
+               <message>
+                  {0}
+               </message>
+               <target
+                     class="CapellaElement">
+               </target>
+               <description>
+                  Warning: This rule applies on diagrams elements of diagram associated to the Capella element and will load the diagram. 
+It is recommended to uncheck this rule by default.
+
+This rule ensures that images, used as background of diagram elements, can be found.
+               </description>
+            </constraint>
+            <constraint
+                  class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathOnRichTextAttributeCheck"
+                  id="I_47"
+                  isEnabledByDefault="true"
+                  lang="java"
+                  mode="Batch"
+                  name="I_47 - Check that images used in rich text is found (Capella and diagram descriptions etc)"
+                  severity="ERROR"
+                  statusCode="1">
+               <message>
+                  {0}
+               </message>
+               <description>
+                  This rule ensures that images, used in rich text editor, for attributes such as Capella elements description or diagram description, can be found.
                </description>
             </constraint>
          </constraints>

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathInDiagramCheck.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathInDiagramCheck.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.emf.validation.model.ConstraintStatus;
+import org.eclipse.sirius.business.api.dialect.DialectManager;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.diagram.WorkspaceImage;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathConstraint;
+import org.eclipse.sirius.viewpoint.DRepresentation;
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.model.handler.validation.CapellaDiagnostician;
+
+/**
+ * Check if the images used on diagram elements, can be found.</br>
+ * Warning: This rule will load all representation associated to the validation context(Capella element)
+ * 
+ * @author lfasani
+ */
+public class ImagePathInDiagramCheck extends ImagePathConstraint {
+
+  @Override
+  public IStatus validate(final IValidationContext ctx) {
+    // Ugly code to check only if called by the Capella Validation
+    // Indeed, otherwise, this code is called many times by Sirius and it is too impacting to change Sirius.
+    boolean calledByCapella = Stream.of(Thread.currentThread().getStackTrace())
+        .filter(ste -> ste.getClassName().equals(CapellaDiagnostician.class.getName())).findFirst().isPresent();
+    if (!calledByCapella) {
+      return ctx.createSuccessStatus();
+    }
+
+    EObject target = ctx.getTarget();
+
+    List<IStatus> failureStatuses = new ArrayList<>();
+    if (target instanceof CapellaElement) {
+      Session.of(target).ifPresent(session -> {
+        // This will load the representation.
+        Collection<DRepresentation> representations = DialectManager.INSTANCE.getRepresentations(target, session);
+        for (DRepresentation dRepresentation : representations) {
+          Iterable<EObject> iterable = () -> dRepresentation.eAllContents();
+          List<WorkspaceImage> workspaceImages = StreamSupport.stream(iterable.spliterator(), false)
+              .filter(WorkspaceImage.class::isInstance).map(WorkspaceImage.class::cast).collect(Collectors.toList());
+
+          for (WorkspaceImage workspaceImage : workspaceImages) {
+            validateWorkspaceImagePath(workspaceImage, ctx, failureStatuses);
+          }
+        }
+      });
+    }
+
+    IStatus returnedStatus = null;
+    if (failureStatuses.isEmpty()) {
+      returnedStatus = ctx.createSuccessStatus();
+    } else {
+      if (failureStatuses.size() == 1) {
+        returnedStatus = failureStatuses.get(0);
+      } else {
+        returnedStatus = ConstraintStatus.createMultiStatus(ctx, failureStatuses);
+      }
+    }
+    return returnedStatus;
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathOnRichTextAttributeCheck.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathOnRichTextAttributeCheck.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.validation.IValidationContext;
+import org.eclipse.emf.validation.model.ConstraintStatus;
+import org.eclipse.sirius.business.api.dialect.DialectManager;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathConstraint;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathWrappingStatus;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.model.handler.validation.CapellaDiagnostician;
+
+/**
+ * Check if images can be found for images used in the rich text description of the capella element, diagram description
+ * or other rich text attributes.
+ * 
+ * @author lfasani
+ */
+@SuppressWarnings("restriction")
+public class ImagePathOnRichTextAttributeCheck extends ImagePathConstraint {
+
+  @Override
+  public IStatus validate(final IValidationContext ctx) {
+    // Ugly code to check only if called by the Capella Validation
+    // Indeed, otherwise, this code is called many times by Sirius and it is too impacting to change Sirius.
+    boolean calledByCapella = Stream.of(Thread.currentThread().getStackTrace())
+        .filter(ste -> ste.getClassName().equals(CapellaDiagnostician.class.getName())).findFirst().isPresent();
+    if (!calledByCapella) {
+      return ctx.createSuccessStatus();
+    }
+
+    EObject target = ctx.getTarget();
+    List<IStatus> failureStatuses = new ArrayList<>();
+
+    // Check the DRepresentationDescriptor.description
+    if (target instanceof CapellaElement) {
+      Session.of(target).ifPresent(session -> {
+        Collection<DRepresentationDescriptor> representationDescriptors = DialectManager.INSTANCE
+            .getRepresentationDescriptors(target, session);
+        for (DRepresentationDescriptor dRepresentationDescriptor : representationDescriptors) {
+          failureStatuses.addAll(validateImagePathInRichText(dRepresentationDescriptor, ctx,
+              ImagePathWrappingStatus.ImagePathTarget.DREPRESENTATION_DESCRIPTOR));
+        }
+      });
+    }
+
+    // check the element itself (may not be a Capella element)
+    failureStatuses
+        .addAll(validateImagePathInRichText(target, ctx, ImagePathWrappingStatus.ImagePathTarget.SEMANTIC_TARGET));
+
+    IStatus returnedStatus = null;
+    if (failureStatuses.isEmpty()) {
+      returnedStatus = ctx.createSuccessStatus();
+    } else {
+      if (failureStatuses.size() == 1) {
+        returnedStatus = failureStatuses.get(0);
+      } else {
+        returnedStatus = ConstraintStatus.createMultiStatus(ctx, failureStatuses);
+      }
+    }
+    return returnedStatus;
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathResolver.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathResolver.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.common.tools.api.resource.FileProvider;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathWrappingStatus;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathWrappingStatus.ImagePathTarget;
+import org.eclipse.sirius.diagram.ui.internal.quickfix.ImageMarkerResolution;
+import org.eclipse.sirius.ui.business.api.dialect.DialectUIManager;
+import org.eclipse.sirius.viewpoint.DRepresentation;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
+import org.eclipse.sirius.viewpoint.DSemanticDecorator;
+import org.polarsys.capella.common.helpers.validation.ConstraintStatusDiagnostic;
+import org.polarsys.capella.common.tools.report.appenders.reportlogview.MarkerViewHelper;
+import org.polarsys.capella.common.tools.report.config.registry.ReportManagerRegistry;
+import org.polarsys.capella.common.tools.report.util.IReportManagerDefaultComponents;
+import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractCapellaMarkerResolution;
+
+@SuppressWarnings("restriction")
+public class ImagePathResolver extends AbstractCapellaMarkerResolution {
+
+  protected Logger _logger = ReportManagerRegistry.getInstance().subscribe(IReportManagerDefaultComponents.VALIDATION);
+
+  @Override
+  public void run(IMarker marker_p) {
+    final List<EObject> modelElements = getModelElements(marker_p);
+    if (modelElements.size() < 1)
+      return;
+    EObject target = modelElements.get(0);
+    Optional<Session> sessionOpt = Session.of(target);
+
+    Diagnostic diagnostic = MarkerViewHelper.getDiagnostic(marker_p);
+    ImagePathWrappingStatus imagePathStatus = null;
+    if (diagnostic instanceof ConstraintStatusDiagnostic
+        && ((ConstraintStatusDiagnostic) diagnostic).getConstraintStatus() instanceof ImagePathWrappingStatus) {
+      imagePathStatus = (ImagePathWrappingStatus) ((ConstraintStatusDiagnostic) diagnostic).getConstraintStatus();
+    }
+
+    if (imagePathStatus != null && sessionOpt.isPresent()) {
+      TransactionalEditingDomain ted = sessionOpt.get().getTransactionalEditingDomain();
+
+      String notReachableImagePath = imagePathStatus.getNotReachableImagePath();
+      boolean fixSucceeded = FileProvider.getDefault().exists(new Path(notReachableImagePath));
+
+      if (!fixSucceeded) {
+        ImagePathTarget imagePathTarget = imagePathStatus.getImagePathTarget();
+        EAttribute eAttribute = imagePathStatus.getEAttribute();
+        if (ImagePathTarget.DREPRESENTATION_DESCRIPTOR.equals(imagePathTarget) && eAttribute != null
+            && target instanceof DRepresentationDescriptor) {
+
+          // open the editor and fix the image issue
+          DRepresentationDescriptor representationDescriptor = (DRepresentationDescriptor) target;
+          DialectUIManager.INSTANCE.openEditor(sessionOpt.get(), representationDescriptor.getRepresentation(),
+              new NullProgressMonitor());
+          fixSucceeded = ImageMarkerResolution.fixImagePathInRichText(representationDescriptor, eAttribute.getName(),
+              notReachableImagePath, ted);
+
+        } else if (ImagePathTarget.SEMANTIC_TARGET.equals(imagePathTarget) && eAttribute != null) {
+
+          // fix the image path for the semantic object
+          fixSucceeded = ImageMarkerResolution.fixImagePathInRichText(target, eAttribute.getName(),
+              notReachableImagePath, ted);
+
+        } else if (ImagePathTarget.WORKSPACE_IMAGE.equals(imagePathTarget) && target instanceof DSemanticDecorator) {
+
+          DRepresentation dRepresentation = getRepresentation((DSemanticDecorator) target);
+          if (dRepresentation != null) {
+            DialectUIManager.INSTANCE.openEditor(sessionOpt.get(), dRepresentation, new NullProgressMonitor());
+            fixSucceeded = ImageMarkerResolution.fixWorkspaceImagePath(target, notReachableImagePath, ted);
+          }
+        }
+      }
+
+      if (fixSucceeded) {
+        try {
+          marker_p.delete();
+        } catch (CoreException exception_p) {
+          _logger.error("Exception while deleting marker : " + exception_p.toString()); //$NON-NLS-1$
+        }
+      }
+    }
+  }
+
+  /**
+   * Browse the model upward (from the leaf to the root) and return the first representation found.
+   * 
+   * @return the representation if found, null otherwise.
+   */
+  private DRepresentation getRepresentation(DSemanticDecorator dSemanticDecorator) {
+    EObject current = dSemanticDecorator;
+    while (current != null) {
+      if (current instanceof DRepresentation) {
+        return (DRepresentation) current;
+      }
+      current = current.eContainer();
+    }
+    return null;
+  }
+}

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
@@ -557,5 +557,37 @@
 				<td colspan="2">This rule checks the Typed Element (Part, Exchange Item Instance) has the same name as its Type (Component, Exchange Item).</td>
 			</tr>
 		</table>
+		<p>
+			<br/>
+		</p>
+		<table class="VALIDATION-RULE">
+			<tr>
+				<th>
+					<img title="ERROR" alt="ERROR" border="0" src="../../Images/error.gif"/>
+				</th>
+				<td>I_46 - Check that the image used for diagram nodes is found</td>
+			</tr>
+			<tr>
+				<td colspan="2">
+					<img title="WARNING" alt="WARNING" border="0" src="../../Images/warning.gif"/> This rule applies on diagrams elements of diagram associated to the Capella element and will load the diagram. 
+					<p>It is recommended to uncheck this rule by default.</p>
+					<p>This rule ensures that images, used as background of diagram elements, can be found.</p>
+				</td>
+			</tr>
+		</table>
+		<p>
+			<br/>
+		</p>
+		<table class="VALIDATION-RULE">
+			<tr>
+				<th>
+					<img title="ERROR" alt="ERROR" border="0" src="../../Images/error.gif"/>
+				</th>
+				<td>I_47 - Check that images used in rich text is found (Capella and diagram descriptions etc)</td>
+			</tr>
+			<tr>
+				<td colspan="2">This rule ensures that images, used in rich text editor, for attributes such as Capella elements description or diagram description, can be found.</td>
+			</tr>
+		</table>
 	</body>
 </html>

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
@@ -284,3 +284,20 @@ Its existence does not add any corruption risk to your model, but it does repres
 |-
 | colspan="2"|This rule checks the Typed Element (Part, Exchange Item Instance) has the same name as its Type (Component, Exchange Item).
 |}
+<br>
+{| class="VALIDATION-RULE"
+!|[[Image:../../Images/error.gif|ERROR]]
+|I_46 - Check that the image used for diagram nodes is found
+|-
+| colspan="2"|[[Image:../../Images/warning.gif|WARNING]] This rule applies on diagrams elements of diagram associated to the Capella element and will load the diagram. 
+It is recommended to uncheck this rule by default.
+
+This rule ensures that images, used as background of diagram elements, can be found.
+|}
+<br>
+{| class="VALIDATION-RULE"
+!|[[Image:../../Images/error.gif|ERROR]]
+|I_47 - Check that images used in rich text is found (Capella and diagram descriptions etc)
+|-
+| colspan="2"|This rule ensures that images, used in rich text editor, for attributes such as Capella elements description or diagram description, can be found.
+|}

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20211221-113506/2021-06/targets/modules/gmf-runtime-1.14.tpd"
+include "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20220131-123510/2021-06/targets/modules/gmf-runtime-1.14.tpd"
 
 with source, requirements
 
@@ -43,7 +43,7 @@ location eclipse "http://download.eclipse.org/releases/2021-06" {
 	com.google.guava
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20211221-113506/2021-06" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20220131-123510/2021-06" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
Two new validation rules are added:
* I_46 - Check that the image used for diagram nodes is found
* I_47 - Check that images used in rich text is found (Capella and
diagram descriptions etc)

The corresponding quick fix is also added.

Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>