### PR TITLE
 #2326 Fix startup errors while using JRE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,15 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.9.0</version>
+				<configuration>
+					<release></release>
+					<useProjectSettings>false</useProjectSettings>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
 				<version>${tycho-version}</version>


### PR DESCRIPTION
Force maven.compiler.release version to prevent the rt.sym loading error.
Remove use of project specific settings.

Change-Id: I0000000000000000000000000000000000000000
Signed-off-by: Arnaud Dieumegard <arnaud.dieumegard@obeo.fr>