### PR TITLE
#2396 Avoid the description tab to be refreshed twice

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/CapellaDescriptionPropertySection.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/CapellaDescriptionPropertySection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2017, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -120,11 +120,13 @@ public class CapellaDescriptionPropertySection extends DescriptionPropertySectio
    */
   @Override
   public void loadData(EObject descriptorOrCapellaElement) {
-    super.loadData(descriptorOrCapellaElement);
-    mapDescriptionSectionToEObject.put(CapellaDescriptionPropertySection.this, descriptorOrCapellaElement);
+    if (descriptorOrCapellaElement != null && !descriptorOrCapellaElement.equals(job.current)) {
+      super.loadData(descriptorOrCapellaElement);
+      mapDescriptionSectionToEObject.put(CapellaDescriptionPropertySection.this, descriptorOrCapellaElement);
 
-    job.current = descriptorOrCapellaElement;
-    job.schedule(100);
+      job.current = descriptorOrCapellaElement;
+      job.schedule();
+    }
   }
 
   /**


### PR DESCRIPTION
Waiting 100ms before scheduling the description tab is not sufficient.
So it is now refreshed immediately if the element has changed only.

Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>