### PR TITLE
#2413 Add a quick fix to replace all image paths

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.properties
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.properties
@@ -22,5 +22,8 @@ quickFix.I_23_Resolver.desc = Delete all hyperLink to non existing capella eleme
 quickFix.ImagePath_Resolver.label = Select a new image
 quickFix.ImagePath_Resolver.desc = Select a new image to replace the current non reachable one
 
+quickFix.ImagePath_MassResolver.label = Change all image paths
+quickFix.ImagePath_MassResolver.desc = Replace the first segments of image paths by new ones for diagram nodes and rich text description.
+
 providerName = Eclipse.org
 pluginName = Capella Sirius Sirius Validation Plug-in

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/plugin.xml
@@ -49,6 +49,22 @@
                ruleId="I_47">
          </rules>
       </resolver>
+      <resolver
+            class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathMassResolver"
+            desc="%quickFix.ImagePath_MassResolver.desc"
+            label="%quickFix.ImagePath_MassResolver.label">
+         <rules
+               ruleId="I_46">
+         </rules>
+      </resolver>
+      <resolver
+            class="org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.ImagePathMassResolver"
+            desc="%quickFix.ImagePath_MassResolver.desc"
+            label="%quickFix.ImagePath_MassResolver.label">
+         <rules
+               ruleId="I_47">
+         </rules>
+      </resolver>
    </extension>
    <extension point="org.eclipse.emf.validation.constraintProviders">
       <constraintProvider>

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathMassResolver.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/ImagePathMassResolver.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.common.tools.api.resource.FileProvider;
+import org.eclipse.sirius.diagram.tools.internal.validation.constraints.ImagePathWrappingStatus;
+import org.eclipse.sirius.diagram.ui.internal.quickfix.ImageMarkerMassResolution;
+import org.eclipse.sirius.viewpoint.DRepresentation;
+import org.eclipse.sirius.viewpoint.DSemanticDecorator;
+import org.polarsys.capella.common.helpers.validation.ConstraintStatusDiagnostic;
+import org.polarsys.capella.common.tools.report.appenders.reportlogview.MarkerViewHelper;
+import org.polarsys.capella.common.tools.report.config.registry.ReportManagerRegistry;
+import org.polarsys.capella.common.tools.report.util.IReportManagerDefaultComponents;
+import org.polarsys.capella.core.validation.ui.ide.quickfix.AbstractCapellaMarkerResolution;
+
+/**
+ * This class represents a marker resolution to replace all the image paths.
+ * 
+ * @author lfasani
+ */
+@SuppressWarnings("restriction")
+public class ImagePathMassResolver extends AbstractCapellaMarkerResolution {
+
+  protected Logger _logger = ReportManagerRegistry.getInstance().subscribe(IReportManagerDefaultComponents.VALIDATION);
+
+  @Override
+  public void run(IMarker marker_p) {
+    final List<EObject> modelElements = getModelElements(marker_p);
+    if (modelElements.size() < 1)
+      return;
+    EObject target = modelElements.get(0);
+    Optional<Session> sessionOpt = Session.of(target);
+
+    Diagnostic diagnostic = MarkerViewHelper.getDiagnostic(marker_p);
+    ImagePathWrappingStatus imagePathStatus = null;
+    if (diagnostic instanceof ConstraintStatusDiagnostic
+        && ((ConstraintStatusDiagnostic) diagnostic).getConstraintStatus() instanceof ImagePathWrappingStatus) {
+      imagePathStatus = (ImagePathWrappingStatus) ((ConstraintStatusDiagnostic) diagnostic).getConstraintStatus();
+    }
+
+    if (imagePathStatus != null && sessionOpt.isPresent()) {
+      String notReachableImagePath = imagePathStatus.getNotReachableImagePath();
+      boolean fixSucceeded = FileProvider.getDefault().exists(new Path(notReachableImagePath));
+
+      if (!fixSucceeded) {
+        fixSucceeded = ImageMarkerMassResolution.fixImagePathMassively(sessionOpt.get(), notReachableImagePath);
+      }
+
+      if (fixSucceeded) {
+        try {
+          marker_p.delete();
+        } catch (CoreException exception_p) {
+          _logger.error("Exception while deleting marker : " + exception_p.toString()); //$NON-NLS-1$
+        }
+      }
+    }
+  }
+
+  /**
+   * Browse the model upward (from the leaf to the root) and return the first representation found.
+   * 
+   * @return the representation if found, null otherwise.
+   */
+  private DRepresentation getRepresentation(DSemanticDecorator dSemanticDecorator) {
+    EObject current = dSemanticDecorator;
+    while (current != null) {
+      if (current instanceof DRepresentation) {
+        return (DRepresentation) current;
+      }
+      current = current.eContainer();
+    }
+    return null;
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/Messages.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/Messages.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * I18n support.
+ */
+public class Messages extends NLS {
+  private static final String BUNDLE_NAME = "org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.messages"; //$NON-NLS-1$
+
+  public static String ImagePathMassResolver_restartValidation;
+
+  static {
+    // initialize resource bundle
+    NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+  }
+
+  private Messages() {
+    // Do nothing.
+  }
+}

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/messages.properties
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/ddiagram/messages.properties
@@ -1,0 +1,13 @@
+#===============================================================================
+# Copyright (c) 2022 THALES GLOBAL SERVICES.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#    Thales - initial API and implementation
+#===============================================================================
+ImagePathMassResolver_restartValidation=The validation must be restarted so that the validation markers are cleaned.

--- a/doc/plugins/org.polarsys.capella.ui.doc/.settings/org.eclipse.core.resources.prefs
+++ b/doc/plugins/org.polarsys.capella.ui.doc/.settings/org.eclipse.core.resources.prefs
@@ -3,6 +3,7 @@ encoding//html/01.\ Overview/1.1.\ Introduction\ to\ Capella.html=UTF-8
 encoding//html/01.\ Overview/1.2.\ Ecosystem.html=UTF-8
 encoding//html/02.\ Workbench\ Basics/2.1.\ Definitions.html=UTF-8
 encoding//html/02.\ Workbench\ Basics/2.2.\ Understanding\ the\ difference\ between\ Models\ Projects\ and\ Workspaces.html=UTF-8
+encoding//html/02.\ Workbench\ Basics/2.3.\ Managing\ images.html=UTF-8
 encoding//html/02.\ Workbench\ Basics/6.1.\ Configurability\ and\ Validation\ Profile.html=UTF-8
 encoding//html/04.\ User\ Interface/4.01.\ Capella\ Perspective.html=UTF-8
 encoding//html/04.\ User\ Interface/4.02.\ Tips\ and\ Tricks.html=UTF-8

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/02. Workbench Basics/2.3. Managing images.html
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/02. Workbench Basics/2.3. Managing images.html
@@ -13,7 +13,7 @@
 			<li>insert in the rich text editor</li>
 		</ul>
 		<h2 id="Selection_dialog">Selection dialog</h2>
-		<p>The image can be selected only from the workspace.</p>
+		<p>The image can be selected only from the project in the workspace (nevertheless the project can be either physically located in the workspace or located in other folder in the file system).</p>
 		<p>
 			<img border="0" src="Images/imageSelectionDialog.png"/>
 		</p>

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/02. Workbench Basics/2.3. Managing images.mediawiki
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/02. Workbench Basics/2.3. Managing images.mediawiki
@@ -7,7 +7,7 @@ Capella allows to use images to:
 
 == Selection dialog ==
 
-The image can be selected only from the workspace.
+The image can be selected only from the project in the workspace (nevertheless the project can be either physically located in the workspace or located in other folder in the file system).
 
 [[Image:Images/imageSelectionDialog.png]]
 

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/First steps with Capella/3.7. How to rename a Capella Project.html
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/First steps with Capella/3.7. How to rename a Capella Project.html
@@ -38,16 +38,32 @@
 					<p>The same process can be applied on Library projects.</p>
 				</td>
 			</tr>
-		</table>
-		<table border="1">
 			<tr>
 				<td>
 					<p>
-						<img height="34" width="34" border="0" src="Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png"/>
+						<img height="44" width="44" border="0" src="Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png"/>
 					</p>
 				</td>
 				<td>
 					<p>If you rename a Library project, all the references to this library will be lost. Libraries renaming must be done very carefully.</p>
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<p>
+						<img height="44" width="44" border="0" src="Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png"/>
+					</p>
+				</td>
+				<td>
+					<p>About images used in diagrams and in rich text editor
+						<br/>
+					</p>
+					<p>In the same way, assuming that a referencing Capella project or a Library project is using images that are located in a referenced project (Capella project, a Library project or any project) then renaming the referenced project will break the images (images will not be seen anymore) in the referencing project.</p>
+					<p>More information about the 
+						<a href="/wiki/../help/topic/org.polarsys.capella.validation.doc/html/Validation%20Rules/integrity/ValidationRules.html" title="../help/topic/org.polarsys.capella.validation.doc/html/Validation%20Rules/integrity/ValidationRules.html">validation for images</a> or about the  
+						<a href="/wiki/../help/topic/org.polarsys.capella.ui.doc/html/First%20steps%20with%20Capella/3.5.%20How%20to%20migrate%20Capella%20projects.html#Special_attention_to_image_used_in_the_project" title="../help/topic/org.polarsys.capella.ui.doc/html/First%20steps%20with%20Capella/3.5.%20How%20to%20migrate%20Capella%20projects.html#Special_attention_to_image_used_in_the_project">Capella project migration for images.</a>
+					</p>
+					<p>Note that the images used in the renamed project and located in the renamed project will be properly migrated and will be properly displayed.</p>
 				</td>
 			</tr>
 		</table>

--- a/doc/plugins/org.polarsys.capella.ui.doc/html/First steps with Capella/3.7. How to rename a Capella Project.mediawiki
+++ b/doc/plugins/org.polarsys.capella.ui.doc/html/First steps with Capella/3.7. How to rename a Capella Project.mediawiki
@@ -17,17 +17,20 @@ The following sequence must be respected:
 [[Image:Images/3.5.%20How%20to%20migrate%20Melody%20Advance%20projects_html_3c78e109.png|48x48px]]
 | 
 The same process can be applied on Library projects.
-|} 
-
-
-{| border="1"
 |-
 | 
-[[Image:Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png|34x34px]]
-
-
+[[Image:Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png|44x44px]]
 | 
 If you rename a Library project, all the references to this library will be lost. Libraries renaming must be done very carefully.
+|-
+| 
+[[Image:Images/3.7.%20How%20to%20rename%20a%20Melody%20Advance%20Project_html_723ed3f9.png|44x44px]]
+| 
+About images used in diagrams and in rich text editor<br/>
 
+In the same way, assuming that a referencing Capella project or a Library project is using images that are located in a referenced project (Capella project, a Library project or any project) then renaming the referenced project will break the images (images will not be seen anymore) in the referencing project.
 
-|}  
+More information about the [[../help/topic/org.polarsys.capella.validation.doc/html/Validation%20Rules/integrity/ValidationRules.html| validation for images]] or about the  [[../help/topic/org.polarsys.capella.ui.doc/html/First%20steps%20with%20Capella/3.5.%20How%20to%20migrate%20Capella%20projects.html#Special_attention_to_image_used_in_the_project|Capella project migration for images.]]
+
+Note that the images used in the renamed project and located in the renamed project will be properly migrated and will be properly displayed.
+|} 

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.html
@@ -588,7 +588,15 @@
 			</tr>
 			<tr>
 				<td colspan="2">This rule ensures that images, used in rich text editor, for attributes such as Capella elements description or diagram description, can be found.
-					<p>Tip: If some cases are detected (validation markers), it is recommended to check the existence of the image and move it in the right folder according to the used expected image path location. Once done, you can restart the validation. If you have still validation markers, then use the "Quick fix" tool to select a new image.</p>
+					<p>Tip: If some cases are detected (validation markers), it is recommended to check the existence of the image and move it in the right folder according to the used expected image path location. Once done, you can restart the validation.
+						<br/>
+						If you still have validation markers, then use the "Quick fix" tools. There are two "quick fix"
+<ul>
+<li>select a new image to replace the broken image</li>
+<li>replace all broken path by a new one. 
+						<b>This "quick fix" will impact the whole model</b> and not only the object associated to the marker</li>
+</ul>
+					</p>
 				</td>
 			</tr>
 		</table>

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/integrity/ValidationRules.mediawiki
@@ -303,5 +303,10 @@ Tip: If some cases are detected (validation markers), it is recommended to check
 |-
 | colspan="2"|This rule ensures that images, used in rich text editor, for attributes such as Capella elements description or diagram description, can be found.
 
-Tip: If some cases are detected (validation markers), it is recommended to check the existence of the image and move it in the right folder according to the used expected image path location. Once done, you can restart the validation. If you have still validation markers, then use the "Quick fix" tool to select a new image.
+Tip: If some cases are detected (validation markers), it is recommended to check the existence of the image and move it in the right folder according to the used expected image path location. Once done, you can restart the validation.<br/>
+If you still have validation markers, then use the "Quick fix" tools. There are two "quick fix"
+<ul>
+<li>select a new image to replace the broken image</li>
+<li>replace all broken path by a new one. '''This "quick fix" will impact the whole model''' and not only the object associated to the marker</li>
+</ul>
 |}

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -12,7 +12,7 @@
  *******************************************************************************/
 target "Capella"
 
-include "https://download.eclipse.org/sirius/updates/milestones/7.0.1rc3/2021-06/targets/modules/gmf-runtime-1.14.tpd"
+include "https://download.eclipse.org/sirius/updates/milestones/7.0.2rc2/2021-06/targets/modules/gmf-runtime-1.14.tpd"
 
 with source, requirements
 
@@ -43,7 +43,7 @@ location eclipse "http://download.eclipse.org/releases/2021-06" {
 	com.google.guava
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/milestones/7.0.1rc3/2021-06" {
+location sirius "https://download.eclipse.org/sirius/updates/milestones/7.0.2rc2/2021-06" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group
@@ -62,7 +62,7 @@ location Orbit "https://download.eclipse.org/tools/orbit/downloads/drops/R202106
 	ch.qos.logback.slf4j
 }
 
-location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/6.0.0.S202205250955/" {
+location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/updates/stable/runtime/6.0.0.S202207151131/" {
 	org.polarsys.kitalpha.ad.runtime.feature.source.feature.group
 	org.polarsys.kitalpha.cadence.feature.source.feature.group
 	org.polarsys.kitalpha.common.feature.source.feature.group
@@ -87,7 +87,7 @@ location kitalpha-runtime-core-master "https://download.eclipse.org/kitalpha/upd
 	org.polarsys.kitalpha.sirius.rotativeimage.feature.feature.group
 }
 
-location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202205250955/" {
+location kitalpha-sdk-master "https://download.eclipse.org/kitalpha/updates/stable/sdk/6.0.0.S202207151131/" {
 	org.polarsys.kitalpha.doc.feature.feature.group
 	org.polarsys.kitalpha.emde.sdk.feature.source.feature.group
 }


### PR DESCRIPTION
It also updates the doc.

Bug: https://github.com/eclipse/capella/issues/2413
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>