### PR TITLE
#2453 Added semantic queries on External Referenced Elements

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.interaction.validation/src/org/polarsys/capella/core/data/interaction/validation/abstractCapability/MDCHK_Capability_FunctionalChains_Involvement.java
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.validation/src/org/polarsys/capella/core/data/interaction/validation/abstractCapability/MDCHK_Capability_FunctionalChains_Involvement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,18 +16,19 @@ package org.polarsys.capella.core.data.interaction.validation.abstractCapability
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.validation.EMFEventType;
 import org.eclipse.emf.validation.IValidationContext;
 import org.eclipse.emf.validation.model.ConstraintStatus;
 import org.polarsys.capella.common.helpers.EObjectLabelProviderHelper;
+import org.polarsys.capella.core.data.fa.FaPackage;
 import org.polarsys.capella.core.data.fa.FunctionalChain;
 import org.polarsys.capella.core.data.interaction.AbstractCapability;
-import org.polarsys.capella.core.model.helpers.AbstractCapabilityExt;
+import org.polarsys.capella.core.model.helpers.FunctionalChainExt;
 import org.polarsys.capella.core.validation.rule.AbstractValidationRule;
 
 public class MDCHK_Capability_FunctionalChains_Involvement extends AbstractValidationRule {
@@ -44,12 +45,17 @@ public class MDCHK_Capability_FunctionalChains_Involvement extends AbstractValid
       if (eObj instanceof AbstractCapability) {
 
         AbstractCapability capability = (AbstractCapability) eObj;
-        List<FunctionalChain> functionalChains = capability.getOwnedFunctionalChains();
-        Set<FunctionalChain> functionalChainsInvolved = new HashSet<FunctionalChain>(
-            AbstractCapabilityExt.getFunctionalChains(capability));
-        for (FunctionalChain functionalChain : functionalChains) {
+        Set<EObject> relatedFCs = new HashSet<EObject>();
+        EList<FunctionalChain> functionalChainsInvolved = capability.getInvolvedFunctionalChains();
+        EList<FunctionalChain> ownedFCs = capability.getOwnedFunctionalChains();
+        relatedFCs.addAll(ownedFCs);
+        for (FunctionalChain ownedFC : ownedFCs) {
+          relatedFCs.addAll(FunctionalChainExt.getFlatInvolvedElements(ownedFC, FaPackage.Literals.FUNCTIONAL_CHAIN));
+        }
+
+        for (EObject functionalChain : relatedFCs) {
           if (!functionalChainsInvolved.contains(functionalChain)) {
-            addCtxStatus(statuses, ctx, eObj, capability, functionalChain);
+            addCtxStatus(statuses, ctx, eObj, capability, (FunctionalChain) functionalChain);
           }
         }
       }

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/plugin.xml
@@ -6475,6 +6475,22 @@
          </categoryQuery>
       </category>
       <category
+            id="org.polarsys.capella.core.semantic.queries.OperationalCapabilityExternalReferencedOperationalProcesses"
+            isTopLevel="true"
+            name="External Referenced Operational Processes">
+         <availableForType
+               class="org.polarsys.capella.core.data.interaction.AbstractCapability">
+         </availableForType>
+         <targetBrowserId
+               id="ReferencedElementBrowser">
+         </targetBrowserId>
+         <categoryQuery>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.OperationalCapability_ExternalReferencedOperationalProcesses">
+            </basicQuery>
+         </categoryQuery>
+      </category>
+      <category
             id="----------- Capability ----------">
       </category>
       <category
@@ -6539,6 +6555,38 @@
          <categoryQuery>
             <basicQuery
                   class="org.polarsys.capella.core.semantic.queries.basic.queries.AbstractCapabilityInvolvedFunctions">
+            </basicQuery>
+         </categoryQuery>
+      </category>
+      <category
+            id="org.polarsys.capella.core.semantic.queries.AbstractCapabilityExternalReferencedFunctionalChains"
+            isTopLevel="true"
+            name="External Referenced Functional Chains">
+         <availableForType
+               class="org.polarsys.capella.core.data.interaction.AbstractCapability">
+         </availableForType>
+         <targetBrowserId
+               id="ReferencedElementBrowser">
+         </targetBrowserId>
+         <categoryQuery>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.AbstractCapability_ExternalReferencedFunctionalChains">
+            </basicQuery>
+         </categoryQuery>
+      </category>
+      <category
+            id="org.polarsys.capella.core.semantic.queries.AbstractCapabilityExternalReferencedScenarios"
+            isTopLevel="true"
+            name="External Referenced Scenarios">
+         <availableForType
+               class="org.polarsys.capella.core.data.interaction.AbstractCapability">
+         </availableForType>
+         <targetBrowserId
+               id="ReferencedElementBrowser">
+         </targetBrowserId>
+         <categoryQuery>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.AbstractCapability_ExternalReferencedScenarios">
             </basicQuery>
          </categoryQuery>
       </category>
@@ -8108,8 +8156,49 @@
             </basicQuery>
          </categoryQuery>
       </category>
-   </extension>
-   
+      <category
+            id="org.polarsys.capella.core.semantic.queries.basic.queries.FunctionalChainExternalReferencedFunctionalChains"
+            isTopLevel="true"
+            name="External Referenced Functional Chains">
+         <availableForType
+               class="org.polarsys.capella.core.data.fa.FunctionalChain">
+         </availableForType>
+         <targetBrowserId
+               id="ReferencedElementBrowser">
+         </targetBrowserId>
+         <categoryQuery>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.FunctionalChain_ExternalReferencedFunctionalChains">
+            </basicQuery>
+         </categoryQuery>
+         <itemQueries>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.CapellaRelationshipsInvolvementTarget">
+            </basicQuery>
+         </itemQueries>
+      </category>
+      <category
+            id="org.polarsys.capella.core.semantic.queries.basic.queries.OperationalProcessExternalReferencedOperationalProcesses"
+            isTopLevel="true"
+            name="External Referenced Operational Processes">
+         <availableForType
+               class="org.polarsys.capella.core.data.fa.FunctionalChain">
+         </availableForType>
+         <targetBrowserId
+               id="ReferencedElementBrowser">
+         </targetBrowserId>
+         <categoryQuery>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.OperationalProcess_ExternalReferencedOperationalProcesses">
+            </basicQuery>
+         </categoryQuery>
+         <itemQueries>
+            <basicQuery
+                  class="org.polarsys.capella.core.semantic.queries.basic.queries.CapellaRelationshipsInvolvementTarget">
+            </basicQuery>
+         </itemQueries>
+      </category>
+   </extension>         
    <extension
          point="org.polarsys.capella.common.ui.toolkit.browser.contentProviderCategory">
       <category

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/AbstractCapability_ExternalReferencedFunctionalChains.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/AbstractCapability_ExternalReferencedFunctionalChains.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.fa.FaPackage;
+import org.polarsys.capella.core.data.fa.FunctionalChain;
+import org.polarsys.capella.core.data.interaction.AbstractCapability;
+import org.polarsys.capella.core.data.oa.OperationalCapability;
+import org.polarsys.capella.core.model.helpers.FunctionalChainExt;
+
+public class AbstractCapability_ExternalReferencedFunctionalChains implements IQuery {
+
+  public AbstractCapability_ExternalReferencedFunctionalChains() {
+  }
+
+  @Override
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (isValidType(object)) {
+      if (object instanceof AbstractCapability) {
+        AbstractCapability c = (AbstractCapability) object;
+        for (FunctionalChain ownedFC : c.getOwnedFunctionalChains()) {
+          result.addAll(FunctionalChainExt.getFlatInvolvedElements(ownedFC, FaPackage.Literals.FUNCTIONAL_CHAIN));
+        }
+        result.removeAll(c.getInvolvedFunctionalChains());
+      }
+    }
+    return result;
+  }
+
+  protected boolean isValidType(Object object) {
+    return (!(object instanceof OperationalCapability) && (object instanceof AbstractCapability));
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/AbstractCapability_ExternalReferencedScenarios.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/AbstractCapability_ExternalReferencedScenarios.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.helpers.ctx.services.CapabilityExt;
+import org.polarsys.capella.core.data.interaction.AbstractCapability;
+
+public class AbstractCapability_ExternalReferencedScenarios implements IQuery {
+
+  public AbstractCapability_ExternalReferencedScenarios() {
+  }
+
+  @Override
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (object instanceof AbstractCapability) {
+      AbstractCapability c = (AbstractCapability) object;
+      result.addAll(CapabilityExt.getAllRelatedScenarios(c));
+    }
+    return result;
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/FunctionalChain_ExternalReferencedFunctionalChains.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/FunctionalChain_ExternalReferencedFunctionalChains.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.fa.FaPackage;
+import org.polarsys.capella.core.data.fa.FunctionalChain;
+import org.polarsys.capella.core.data.oa.OperationalProcess;
+import org.polarsys.capella.core.model.helpers.FunctionalChainExt;
+
+public class FunctionalChain_ExternalReferencedFunctionalChains implements IQuery {
+
+  public FunctionalChain_ExternalReferencedFunctionalChains() {
+  }
+
+  @Override
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (isValidType(object)) {
+      if (object instanceof FunctionalChain) {
+        FunctionalChain fc = (FunctionalChain) object;
+        result.addAll(FunctionalChainExt.getFlatInvolvementsOf(fc, FaPackage.Literals.FUNCTIONAL_CHAIN));
+        result.removeAll(fc.getOwnedFunctionalChainInvolvements());
+      }
+    }
+    return result;
+  }
+
+  protected boolean isValidType(Object object) {
+    return (!(object instanceof OperationalProcess) && (object instanceof FunctionalChain));
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/OperationalCapability_ExternalReferencedOperationalProcesses.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/OperationalCapability_ExternalReferencedOperationalProcesses.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.fa.FunctionalChain;
+import org.polarsys.capella.core.data.oa.OaPackage;
+import org.polarsys.capella.core.data.oa.OperationalCapability;
+import org.polarsys.capella.core.model.helpers.FunctionalChainExt;
+
+public class OperationalCapability_ExternalReferencedOperationalProcesses implements IQuery {
+
+  public OperationalCapability_ExternalReferencedOperationalProcesses() {
+  }
+
+  @Override
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (object instanceof OperationalCapability) {
+      OperationalCapability c = (OperationalCapability) object;
+      for (FunctionalChain ownedFC : c.getOwnedFunctionalChains()) {
+        result.addAll(FunctionalChainExt.getFlatInvolvedElements(ownedFC, OaPackage.Literals.OPERATIONAL_PROCESS));
+      }
+      result.removeAll(c.getInvolvedFunctionalChains());
+    }
+
+    return result;
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/OperationalProcess_ExternalReferencedOperationalProcesses.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/OperationalProcess_ExternalReferencedOperationalProcesses.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales - initial API and implementation
+ *******************************************************************************/
+
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.oa.OaPackage;
+import org.polarsys.capella.core.data.oa.OperationalProcess;
+import org.polarsys.capella.core.model.helpers.FunctionalChainExt;
+
+public class OperationalProcess_ExternalReferencedOperationalProcesses implements IQuery {
+
+  public OperationalProcess_ExternalReferencedOperationalProcesses() {
+  }
+
+  @Override
+  public List<Object> compute(Object object) {
+    List<Object> result = new ArrayList<Object>();
+    if (object instanceof OperationalProcess) {
+      OperationalProcess op = (OperationalProcess) object;
+      result.addAll(FunctionalChainExt.getFlatInvolvementsOf(op, OaPackage.Literals.OPERATIONAL_PROCESS));
+      result.removeAll(op.getOwnedFunctionalChainInvolvements());
+    }
+    return result;
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.aird
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.aird
@@ -40,6 +40,22 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Entity%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.oa:EntityPkg" href="SemanticQueries.capella#9c1c3e07-e7b8-4009-9ac1-524d23716d9f"/>
       </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BCowwDTMEe2eTd6pLvlqSg" name="[OPD] OperationalProcess OA8" repPath="#_BCmUgDTMEe2eTd6pLvlqSg" changeId="340afc90-f238-4a4b-a9ea-df4c52bde670">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Iud0ADTMEe2eTd6pLvlqSg" name="[OPD] OperationalProcess OA7" repPath="#_Iucl4DTMEe2eTd6pLvlqSg" changeId="813be81a-b2e3-4ecc-ae97-5ba1e7e1777d">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="__8nR8DTNEe2g6rtd7Hf7cA" name="[OPD] OP1" repPath="#__8jAgDTNEe2g6rtd7Hf7cA" changeId="5c0753d3-ec20-4186-92d0-f8798a9aec04">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Ch5csDTPEe2g6rtd7Hf7cA" name="[OPD] OperationalProcess 1" repPath="#_Ch3ngDTPEe2g6rtd7Hf7cA" changeId="6ae0cf10-2416-44be-bfee-2f50085a98a6">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#0268e41f-4013-4bb4-a719-c5a253e6ec04"/>
+      </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="_c8HEQOVJEeWC_cpFfVotog">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
@@ -143,9 +159,49 @@
         <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
         <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#26667d53-7601-4fed-bfd1-8e15f4b6bad1"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_ErwKwKQ4Eey1dYif9iaz1A" name="[FS] [OAS] OperationalCapability 2" repPath="#_EruVkKQ4Eey1dYif9iaz1A" changeId="33fd59b7-c194-4bbf-a183-f7cd3da17394">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_ErwKwKQ4Eey1dYif9iaz1A" name="[FS] [OAS] OperationalCapability 2" repPath="#_EruVkKQ4Eey1dYif9iaz1A" changeId="b3d05712-94d0-4d3a-8f23-668962ecbd99">
         <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']"/>
         <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#6fc72d95-1691-4057-a17d-1b6de8499fdb"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_XhltQDTQEe2g6rtd7Hf7cA" name="[SFCD] FunctionalChain SF8" repPath="#_Xhj4EDTQEe2g6rtd7Hf7cA" changeId="87caf190-cc81-42a0-995f-746cefaeecdd">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_aU8lsDTQEe2g6rtd7Hf7cA" name="[SFCD] FunctionalChain SF7" repPath="#_aU7XkDTQEe2g6rtd7Hf7cA" changeId="4372925b-0a1a-47ec-9e05-c53e497a5ee2">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_jYwIgDTQEe2g6rtd7Hf7cA" name="[SFCD] FunctionalChain Capability 1" repPath="#_jYvhcDTQEe2g6rtd7Hf7cA" changeId="5c80fa45-8eda-47d0-8d6e-c2d732d2bdc5">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#099fa717-2bb7-458b-a14a-5b692e96da1b"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_jLAVgDTSEe2g6rtd7Hf7cA" name="[PFCD] FunctionalChain PF2" repPath="#_jK_ucDTSEe2g6rtd7Hf7cA" changeId="e2a94ea9-2edf-43aa-a0eb-4422318c7511">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_k9BswDTSEe2g6rtd7Hf7cA" name="[PFCD] FunctionalChain PF1" repPath="#_k9BFsDTSEe2g6rtd7Hf7cA" changeId="20a98bd2-befe-4ac6-8b94-4d7c4314a3d9">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_DeK64DTTEe2g6rtd7Hf7cA" name="[PFCD] FunctionalChain Capability 1" repPath="#_DeKT0DTTEe2g6rtd7Hf7cA" changeId="adc92849-5902-46bb-a0bc-ce72687fd25f">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#3c9bb195-0cf8-4c6c-a815-53fabe987c38"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_RgggUDTrEe2g6rtd7Hf7cA" name="[FCD] FunctionalChain 1" repPath="#_Rgf5QDTrEe2g6rtd7Hf7cA" changeId="458e2ec4-6bb0-4494-9229-1610777def24">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#b6239773-1e55-4328-b538-21701efb4ab2"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_Xl0xYDTuEe2g6rtd7Hf7cA" name="[ES] Scenario 1" repPath="#_XlzjQDTuEe2g6rtd7Hf7cA" changeId="4f277f9c-e3ce-4709-b4f7-82bed3f77e84">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#3cdd1abf-7b78-4f5e-af72-54c4bf6c9a93"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_2mZRADTvEe2g6rtd7Hf7cA" name="[IS] CapabilityRealization 2" repPath="#_2mYC4DTvEe2g6rtd7Hf7cA" changeId="baa555c7-bcfd-4707-8c99-d05c8d6767a1">
+        <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+        <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#05c76287-4dde-4a87-a188-239716b96604"/>
+      </ownedRepresentationDescriptors>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_h6uDcDUAEe2NlKJvtNxasw" name="[FCD] FunctionalChain 2" repPath="#_h6YFMDUAEe2NlKJvtNxasw" changeId="1bd62d53-de4a-467b-b3c1-0033147a4a90">
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#ea4a267a-bb4c-442b-a78b-bb0b7d9d6586"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
     <ownedViews xmi:type="viewpoint:DView" uid="_c8jwMOVJEeWC_cpFfVotog">
@@ -176,7 +232,7 @@
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Data%20Flow%20Blank']"/>
         <target xmi:type="org.polarsys.capella.core.data.la:LogicalFunction" href="SemanticQueries.capella#e6a86efd-1b45-416c-80e7-1e424788b0ec"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_RDtOwN6dEem-ItbQX6Y5xA" name="[LAB] Logical Architecture Diagram" repPath="#_RDaT0N6dEem-ItbQX6Y5xA" changeId="2aef6572-4777-4f77-ac95-afb91261e74f">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_RDtOwN6dEem-ItbQX6Y5xA" name="[LAB] Logical Architecture Diagram" repPath="#_RDaT0N6dEem-ItbQX6Y5xA" changeId="e7bac28f-bb5b-4b64-b00a-cb66c0a31100">
         <eAnnotations xmi:type="description:DAnnotation" uid="_RFpIct6dEem-ItbQX6Y5xA" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_RFpIc96dEem-ItbQX6Y5xA" key="hide.computed.component.exchanges.filter" value="true"/>
           <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_RFpIdN6dEem-ItbQX6Y5xA" key="hide.computed.physical.links.filter" value="true"/>
@@ -4979,6 +5035,37 @@
           <styles xmi:type="notation:ShapeStyle" xmi:id="_nao0gd6dEem-ItbQX6Y5xA" fontName="Segoe UI" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nao0gt6dEem-ItbQX6Y5xA" x="280" y="150"/>
         </children>
+        <children xmi:type="notation:Node" xmi:id="_C-710DUCEe2NlKJvtNxasw" type="2002" element="_C-aRYDUCEe2NlKJvtNxasw">
+          <children xmi:type="notation:Node" xmi:id="_C-9D8DUCEe2NlKJvtNxasw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_C-9D8TUCEe2NlKJvtNxasw" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_C-9D8jUCEe2NlKJvtNxasw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_C-9D8zUCEe2NlKJvtNxasw"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_C--SEDUCEe2NlKJvtNxasw" type="3012" element="_C-cGkDUCEe2NlKJvtNxasw">
+            <children xmi:type="notation:Node" xmi:id="_C--5IDUCEe2NlKJvtNxasw" visible="false" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_C--5ITUCEe2NlKJvtNxasw" x="11" y="-5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_C_daQDUCEe2NlKJvtNxasw" type="3005" element="_C-cGkTUCEe2NlKJvtNxasw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_C_daQTUCEe2NlKJvtNxasw" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C_daQjUCEe2NlKJvtNxasw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_C--SETUCEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C--SEjUCEe2NlKJvtNxasw" x="-2" width="10" height="10"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_C-710TUCEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_C-710jUCEe2NlKJvtNxasw" x="1200" y="150"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_NewqsDUCEe2NlKJvtNxasw" type="2001" element="_NeCR8DUCEe2NlKJvtNxasw">
+          <children xmi:type="notation:Node" xmi:id="_NexRwDUCEe2NlKJvtNxasw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_NexRwTUCEe2NlKJvtNxasw" x="21" y="2"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Nex40DUCEe2NlKJvtNxasw" type="3003" element="_NeRigDUCEe2NlKJvtNxasw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Nex40TUCEe2NlKJvtNxasw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Nex40jUCEe2NlKJvtNxasw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_NewqsTUCEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NewqsjUCEe2NlKJvtNxasw" x="1040" y="450" width="20" height="20"/>
+        </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_RDtOw96dEem-ItbQX6Y5xA"/>
         <edges xmi:type="notation:Edge" xmi:id="_gfVhYKUzEeyCyLi54fprLg" type="4001" element="_ge-VAKUzEeyCyLi54fprLg" source="_R4Wp4qUzEeyCyLi54fprLg" target="_gfItEKUzEeyCyLi54fprLg">
           <children xmi:type="notation:Node" xmi:id="_gfVhZKUzEeyCyLi54fprLg" type="6001">
@@ -5078,7 +5165,9 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']/@borderedNodeMappings[name='LAB%20Flow%20Port%20on%20Logical%20Function']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" uid="_R4MR0KUzEeyCyLi54fprLg" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+        <ownedStyle xmi:type="diagram:Square" uid="_R4MR0KUzEeyCyLi54fprLg" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
           <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']"/>
@@ -5116,7 +5205,9 @@
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']/@borderedNodeMappings[name='LAB%20Flow%20Port%20on%20Logical%20Function']"/>
         </ownedBorderedNodes>
-        <ownedStyle xmi:type="diagram:Square" uid="_gea7YKUzEeyCyLi54fprLg" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" color="197,255,166">
+        <ownedStyle xmi:type="diagram:Square" uid="_gea7YKUzEeyCyLi54fprLg" labelColor="9,92,46" borderSize="4" borderSizeComputationExpression="1" borderColor="24,114,248" labelPosition="node" color="197,255,166">
+          <customFeatures>borderColor</customFeatures>
+          <customFeatures>borderSize</customFeatures>
           <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@subNodeMappings[name='LAB%20Logical%20Function']"/>
@@ -5149,7 +5240,9 @@
     <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ge-VAKUzEeyCyLi54fprLg" name="FunctionalExchange 1" sourceNode="_R4MR0aUzEeyCyLi54fprLg" targetNode="_gea7YaUzEeyCyLi54fprLg">
       <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#32e7eb00-a4b4-4c59-b8db-f4a956b5dd32"/>
       <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#32e7eb00-a4b4-4c59-b8db-f4a956b5dd32"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ge-8EKUzEeyCyLi54fprLg" description="_ge-VAaUzEeyCyLi54fprLg" targetArrow="NoDecoration" centered="Both" strokeColor="9,92,46">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ge-8EKUzEeyCyLi54fprLg" description="_ge-VAaUzEeyCyLi54fprLg" targetArrow="NoDecoration" size="4" centered="Both" strokeColor="24,114,248">
+        <customFeatures>strokeColor</customFeatures>
+        <customFeatures>size</customFeatures>
         <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_ge-8EaUzEeyCyLi54fprLg"/>
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ge-8E6UzEeyCyLi54fprLg" labelColor="9,92,46"/>
         <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_ge-8EqUzEeyCyLi54fprLg"/>
@@ -5182,6 +5275,33 @@
         <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_jup9EaUzEeyCyLi54fprLg" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@edgeMappings[name='LAB%20PortRealization%20FlowPort%20to%20ComponentPort']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_C-aRYDUCEe2NlKJvtNxasw" name="Logical System">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#873d5d36-8c0f-40ec-9db3-b1354dde3242"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#873d5d36-8c0f-40ec-9db3-b1354dde3242"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:LogicalComponent" href="SemanticQueries.capella#096703b9-355f-4722-ac4b-e98d582fe114"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_C-cGkDUCEe2NlKJvtNxasw" name="CP 1" width="1" height="1">
+        <target xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="SemanticQueries.capella#e1a0ca3c-9e83-431f-8ca2-3b4b91ed5fb0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:ComponentPort" href="SemanticQueries.capella#e1a0ca3c-9e83-431f-8ca2-3b4b91ed5fb0"/>
+        <graphicalFilters xmi:type="diagram:HideLabelFilter" uid="_C-d7wDUCEe2NlKJvtNxasw"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_C-cGkTUCEe2NlKJvtNxasw" showIcon="false" hideLabelByDefault="true" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/OutFlowPort.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@borderedNodeMappings[name='LAB%20ComponentPort']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_C-a4cDUCEe2NlKJvtNxasw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='LAB%20Logical%20Component']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_NeCR8DUCEe2NlKJvtNxasw" name="FunctionalChain 1" width="2" height="2" resizeKind="NSEW">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#776631b3-a5f6-4163-af86-4c4a11e2b2c0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#776631b3-a5f6-4163-af86-4c4a11e2b2c0"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_NeRigDUCEe2NlKJvtNxasw" borderSize="1" borderSizeComputationExpression="1" width="2" height="2" color="24,114,248">
+        <customFeatures>color</customFeatures>
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='LAB_FunctionalChainEnd']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@defaultLayer/@nodeMappings[name='LAB_FunctionalChainEnd']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']"/>
     <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']/@ownedRepresentations[name='Logical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
@@ -14082,12 +14202,21 @@
             <styles xmi:type="notation:ShapeStyle" xmi:id="_EsET0aQ4Eey1dYif9iaz1A" fontName="Segoe UI" fontHeight="8"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EsET0qQ4Eey1dYif9iaz1A" y="42" width="10" height="395"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_EsET1aQ4Eey1dYif9iaz1A" type="3003" element="_ErxY4qQ4Eey1dYif9iaz1A">
-            <styles xmi:type="notation:ShapeStyle" xmi:id="_EsET1qQ4Eey1dYif9iaz1A" fontName="Segoe UI"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EsET16Q4Eey1dYif9iaz1A"/>
+          <children xmi:type="notation:Node" xmi:id="_UuemQDTtEe2g6rtd7Hf7cA" type="3003" element="_UuXRgTTtEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_UuemQTTtEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UuemQjTtEe2g6rtd7Hf7cA"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_Er24caQ4Eey1dYif9iaz1A" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Er24cqQ4Eey1dYif9iaz1A" x="180" y="50" width="100" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Wr0csDTtEe2g6rtd7Hf7cA" type="2002" element="_WqqmIDTtEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Wr1DwDTtEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_Wr1DwTTtEe2g6rtd7Hf7cA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_Wr1DwjTtEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_Wr1DwzTtEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Wr0csTTtEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Wr0csjTtEe2g6rtd7Hf7cA" x="50" y="271" width="100" height="50"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_ErwKx6Q4Eey1dYif9iaz1A"/>
       </data>
@@ -14146,10 +14275,21 @@
         </ownedStyle>
         <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20FS']/@borderedNodeMappings[name='default%20execution%20FS']"/>
       </ownedBorderedNodes>
-      <ownedStyle xmi:type="diagram:Square" uid="_ErxY4qQ4Eey1dYif9iaz1A" labelColor="9,92,46" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
-        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20FS']/@style"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_UuXRgTTtEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="10" height="5" color="198,230,255">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20FS']/@conditionnalStyles.0/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20FS']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_WqqmIDTtEe2g6rtd7Hf7cA" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#e1d3ac27-efa6-4e19-9465-f763a6f68b1a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#e1d3ac27-efa6-4e19-9465-f763a6f68b1a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#c9e7fcef-b20f-4e34-b485-24cbcd82f41a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.ctx:Capability" href="SemanticQueries.capella#c25c6355-166e-4d53-ba1d-627b047d7f9b"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_WqsbUDTtEe2g6rtd7Hf7cA" x="50" y="271" height="50" width="100"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_WqqmITTtEe2g6rtd7Hf7cA" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseFS']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseFS']"/>
     </ownedDiagramElements>
     <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']"/>
     <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
@@ -14157,4 +14297,3558 @@
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Scenario']/@defaultLayer"/>
     <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#6fc72d95-1691-4057-a17d-1b6de8499fdb"/>
   </sequence:SequenceDDiagram>
+  <diagram:DSemanticDiagram uid="_BCmUgDTMEe2eTd6pLvlqSg">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BCtpQDTMEe2eTd6pLvlqSg" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_BCtpQTTMEe2eTd6pLvlqSg" type="Sirius" element="_BCmUgDTMEe2eTd6pLvlqSg" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_HkZNkDTMEe2eTd6pLvlqSg" type="2002" element="_HkO1gDTMEe2eTd6pLvlqSg">
+          <children xmi:type="notation:Node" xmi:id="_HkabsDTMEe2eTd6pLvlqSg" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_HkabsTTMEe2eTd6pLvlqSg" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_HkbCwDTMEe2eTd6pLvlqSg" type="3008" element="_HkWxUjTMEe2eTd6pLvlqSg">
+              <children xmi:type="notation:Node" xmi:id="_HkbCwzTMEe2eTd6pLvlqSg" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_HkbCxDTMEe2eTd6pLvlqSg" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_KiNCgDTMEe2eTd6pLvlqSg" type="3008" element="_KiFGsDTMEe2eTd6pLvlqSg">
+                  <children xmi:type="notation:Node" xmi:id="_KiOQoDTMEe2eTd6pLvlqSg" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_KiOQoTTMEe2eTd6pLvlqSg" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_KiO3sjTMEe2eTd6pLvlqSg" type="3008" element="_KiFtwjTMEe2eTd6pLvlqSg">
+                      <children xmi:type="notation:Node" xmi:id="_KiO3tTTMEe2eTd6pLvlqSg" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_KiQF0DTMEe2eTd6pLvlqSg" type="7002">
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_KiQF0TTMEe2eTd6pLvlqSg"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_KiQF0jTMEe2eTd6pLvlqSg"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_KiQF0zTMEe2eTd6pLvlqSg"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_KiO3szTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="12"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KiO3tDTMEe2eTd6pLvlqSg"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_KiO3sDTMEe2eTd6pLvlqSg"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_KiO3sTTMEe2eTd6pLvlqSg"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_KiNCgTTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KiNCgjTMEe2eTd6pLvlqSg" x="70" y="40"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_HkbCxTTMEe2eTd6pLvlqSg"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_HkbCxjTMEe2eTd6pLvlqSg"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_HkbCxzTMEe2eTd6pLvlqSg"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_HkbCwTTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HkbCwjTMEe2eTd6pLvlqSg"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_HkabsjTMEe2eTd6pLvlqSg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_HkabszTMEe2eTd6pLvlqSg"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_HkZNkTTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_HkZNkjTMEe2eTd6pLvlqSg" x="450" y="440"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_BCtpQjTMEe2eTd6pLvlqSg"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BCx6sDTMEe2eTd6pLvlqSg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_BCx6sTTMEe2eTd6pLvlqSg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HkO1gDTMEe2eTd6pLvlqSg" name="OperationalProcess OA7" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#4990d9e6-461d-4b41-98c6-2091c71454de"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#4990d9e6-461d-4b41-98c6-2091c71454de"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HkTG8DTMEe2eTd6pLvlqSg" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_HkWxUjTMEe2eTd6pLvlqSg">
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_HkWxUzTMEe2eTd6pLvlqSg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_KiFGsDTMEe2eTd6pLvlqSg" name="OP1" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_KiFtwDTMEe2eTd6pLvlqSg" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_KiFtwjTMEe2eTd6pLvlqSg">
+            <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_KiFtwzTMEe2eTd6pLvlqSg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_BCm7kDTMEe2eTd6pLvlqSg"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_Iucl4DTMEe2eTd6pLvlqSg">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_IuebEDTMEe2eTd6pLvlqSg" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_IuebETTMEe2eTd6pLvlqSg" type="Sirius" element="_Iucl4DTMEe2eTd6pLvlqSg" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_KiIKADTMEe2eTd6pLvlqSg" type="2002" element="_Kh5ggDTMEe2eTd6pLvlqSg">
+          <children xmi:type="notation:Node" xmi:id="_KiIxEDTMEe2eTd6pLvlqSg" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_KiIxETTMEe2eTd6pLvlqSg" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_KiIxFDTMEe2eTd6pLvlqSg" type="3008" element="_Kh_nIDTMEe2eTd6pLvlqSg">
+              <children xmi:type="notation:Node" xmi:id="_KiJYIDTMEe2eTd6pLvlqSg" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_KiJYITTMEe2eTd6pLvlqSg" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_BWHbgDTOEe2g6rtd7Hf7cA" type="3008" element="_BU3eUDTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BWHbgzTOEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_BWICkDTOEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_BWIpoDTOEe2g6rtd7Hf7cA" type="3008" element="_BU4scTTOEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_BWIpozTOEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_BWIppDTOEe2g6rtd7Hf7cA" type="7002">
+                        <children xmi:type="notation:Node" xmi:id="_BWIpqDTOEe2g6rtd7Hf7cA" type="3007" element="_BU5TgDTOEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_BWJQsjTOEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_BWJQszTOEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_BWLF4DTOEe2g6rtd7Hf7cA" type="3003" element="_BU5TgTTOEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_BWLF4TTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWLF4jTOEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_BWJQsDTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWJQsTTOEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_BWJQtDTOEe2g6rtd7Hf7cA" type="3007" element="_BU56kDTOEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_BWJQtzTOEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_BWJQuDTOEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_BWLF4zTOEe2g6rtd7Hf7cA" type="3003" element="_BU56kTTOEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_BWLF5DTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWLF5TTOEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_BWJQtTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWJQtjTOEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_BWJ3wDTOEe2g6rtd7Hf7cA" type="3007" element="_BU56kzTOEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_BWJ3wzTOEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_BWJ3xDTOEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_BWLF5jTOEe2g6rtd7Hf7cA" type="3003" element="_BU6hoDTOEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_BWLF5zTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWLF6DTOEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_BWJ3wTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWJ3wjTOEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_BWJ3xTTOEe2g6rtd7Hf7cA" type="3007" element="_BU6hojTOEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_BWKe0DTOEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_BWKe0TTOEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_BWLs8DTOEe2g6rtd7Hf7cA" type="3003" element="_BU6hozTOEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_BWLs8TTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWLs8jTOEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_BWJ3xjTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWJ3xzTOEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_BWKe0jTOEe2g6rtd7Hf7cA" type="3007" element="_BU7IsTTOEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_BWKe1TTOEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_BWKe1jTOEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_BWLs8zTOEe2g6rtd7Hf7cA" type="3003" element="_BU7IsjTOEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_BWLs9DTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWLs9TTOEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_BWKe0zTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWKe1DTOEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_BWIppTTOEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_BWIppjTOEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_BWIppzTOEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_BWIpoTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWIpojTOEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_BWICkTTOEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_BWICkjTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BWHbgTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWHbgjTOEe2g6rtd7Hf7cA" x="160" y="50"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_KiJYIjTMEe2eTd6pLvlqSg"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_KiJYIzTMEe2eTd6pLvlqSg"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_KiJYJDTMEe2eTd6pLvlqSg"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_KiIxFTTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KiIxFjTMEe2eTd6pLvlqSg"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_KiIxEjTMEe2eTd6pLvlqSg"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_KiIxEzTMEe2eTd6pLvlqSg"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_KiIKATTMEe2eTd6pLvlqSg" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KiIKAjTMEe2eTd6pLvlqSg" x="770" y="490"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_IuebEjTMEe2eTd6pLvlqSg"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BWMUADTOEe2g6rtd7Hf7cA" type="4001" element="_BU8W0DTOEe2g6rtd7Hf7cA" source="_BWIpqDTOEe2g6rtd7Hf7cA" target="_BWJQtDTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BWMUBDTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWMUBTTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWMUBjTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWMUBzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWM7EDTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWM7ETTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BWMUATTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BWMUAjTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWMUAzTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWM7EjTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWM7EzTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BWNiIDTOEe2g6rtd7Hf7cA" type="4001" element="_BU895DTOEe2g6rtd7Hf7cA" source="_BWJ3xTTOEe2g6rtd7Hf7cA" target="_BWKe0jTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BWNiJDTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWNiJTTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWNiJjTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWNiJzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWNiKDTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWNiKTTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BWNiITTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BWNiIjTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWNiIzTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWOJMDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWOJMTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BWOJMjTOEe2g6rtd7Hf7cA" type="4001" element="_BU9k9DTOEe2g6rtd7Hf7cA" source="_BWJQtDTOEe2g6rtd7Hf7cA" target="_BWJ3wDTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BWOJNjTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJNzTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWOJODTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJOTTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWOJOjTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJOzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BWOJMzTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BWOJNDTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWOJNTTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWOJPDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWOJPTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BWOJPjTOEe2g6rtd7Hf7cA" type="4001" element="_BVABMDTOEe2g6rtd7Hf7cA" source="_BWJQtDTOEe2g6rtd7Hf7cA" target="_BWJ3xTTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BWOJQjTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJQzTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWOJRDTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJRTTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BWOJRjTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BWOJRzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BWOJPzTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BWOJQDTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BWOJQTTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWPXUDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BWPXUTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_IugQQDTMEe2eTd6pLvlqSg" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_IugQQTTMEe2eTd6pLvlqSg"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Kh5ggDTMEe2eTd6pLvlqSg" name="OP1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Kh78wDTMEe2eTd6pLvlqSg" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_Kh_nIDTMEe2eTd6pLvlqSg">
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Kh_nITTMEe2eTd6pLvlqSg" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BU3eUDTOEe2g6rtd7Hf7cA" name="OperationalProcess 2" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BU4FYDTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BU4scTTOEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BU4scjTOEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_BU5TgDTOEe2g6rtd7Hf7cA" name="OperationalActivity 9" outgoingEdges="_BU8W0DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#4a202fcf-5872-4d21-ae2f-97ebeae0b4e7"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_BU5TgTTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_BU56kDTOEe2g6rtd7Hf7cA" name="OperationalActivity 10" outgoingEdges="_BU9k9DTOEe2g6rtd7Hf7cA _BVABMDTOEe2g6rtd7Hf7cA" incomingEdges="_BU8W0DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#40483782-12b2-4999-82af-4ecc9822da0f"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_BU56kTTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_BU56kzTOEe2g6rtd7Hf7cA" name="OperationalActivity 11" incomingEdges="_BU9k9DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#e1e05c57-edc5-4380-b71f-479ca0f53d75"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_BU6hoDTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_BU6hojTOEe2g6rtd7Hf7cA" name="OperationalActivity 12" outgoingEdges="_BU895DTOEe2g6rtd7Hf7cA" incomingEdges="_BVABMDTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#1224ff74-9db5-4568-8055-1d72dbd03a58"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_BU6hozTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_BU7IsTTOEe2g6rtd7Hf7cA" name="OperationalActivity 13" incomingEdges="_BU895DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#9e8a1ec4-5d0b-425a-823b-4abf2efc263f"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_BU7IsjTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BU8W0DTOEe2g6rtd7Hf7cA" name="Interaction 1" sourceNode="_BU5TgDTOEe2g6rtd7Hf7cA" targetNode="_BU56kDTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#247de160-a79d-4326-b56f-19de24d0342a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BU894DTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BU894TTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BU895DTOEe2g6rtd7Hf7cA" name="Interaction 5" sourceNode="_BU6hojTOEe2g6rtd7Hf7cA" targetNode="_BU7IsTTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#7bb37ad8-0468-40ab-9764-560ced5fed17"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BU9k8DTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BU9k8TTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BU9k9DTOEe2g6rtd7Hf7cA" name="Interaction 3" sourceNode="_BU56kDTOEe2g6rtd7Hf7cA" targetNode="_BU56kzTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#a5022be5-7fdf-4fb9-ba5e-59bc3f242eca"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BU-MADTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BU-MATTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BVABMDTOEe2g6rtd7Hf7cA" name="Interaction 2" sourceNode="_BU56kDTOEe2g6rtd7Hf7cA" targetNode="_BU6hojTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#3ebb4439-7850-4302-b230-2a217a5afc8d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BVBPUDTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BVBPUTTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Iucl4TTMEe2eTd6pLvlqSg"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="__8jAgDTNEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="__81UYDTNEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="__81UYTTNEe2g6rtd7Hf7cA" type="Sirius" element="__8jAgDTNEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_BVJLIDTOEe2g6rtd7Hf7cA" type="2002" element="_BUQaUDTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BVTjMDTOEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_BVUKQDTOEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_BVV_cDTOEe2g6rtd7Hf7cA" type="3008" element="_BUcAgTTOEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_BVV_czTOEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_BVYbsDTOEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_BVaQ4DTOEe2g6rtd7Hf7cA" type="3007" element="_BUcnkDTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BVbfADTOEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_BVbfATTOEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_BVizwDTOEe2g6rtd7Hf7cA" type="3003" element="_BUfD0DTOEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_BVizwTTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVizwjTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BVaQ4TTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVaQ4jTOEe2g6rtd7Hf7cA" x="130" y="20" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_BVeiUDTOEe2g6rtd7Hf7cA" type="3007" element="_BUgR8DTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BVeiUzTOEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_BVeiVDTOEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_BVja0DTOEe2g6rtd7Hf7cA" type="3003" element="_BUgR8TTOEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_BVja0TTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVja0jTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BVeiUTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVeiUjTOEe2g6rtd7Hf7cA" x="140" y="30" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_BVfJYDTOEe2g6rtd7Hf7cA" type="3007" element="_BUiuMTTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BVfJYzTOEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_BVfJZDTOEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_BVja0zTOEe2g6rtd7Hf7cA" type="3003" element="_BUiuMjTOEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_BVja1DTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVja1TTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BVfJYTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVfJYjTOEe2g6rtd7Hf7cA" x="150" y="40" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_BVfJZTTOEe2g6rtd7Hf7cA" type="3007" element="_BUiuNDTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BVfwcDTOEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_BVfwcTTOEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_BVkB4DTOEe2g6rtd7Hf7cA" type="3003" element="_BUjVQDTOEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_BVkB4TTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVkB4jTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BVfJZjTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVfJZzTOEe2g6rtd7Hf7cA" x="160" y="50" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_BVfwcjTOEe2g6rtd7Hf7cA" type="3007" element="_BUj8UTTOEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_BVfwdTTOEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_BVfwdjTOEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_BVkB4zTOEe2g6rtd7Hf7cA" type="3003" element="_BUj8UjTOEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_BVkB5DTOEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVkB5TTOEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_BVfwczTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVfwdDTOEe2g6rtd7Hf7cA" x="170" y="60" width="100" height="50"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_BVYbsTTOEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_BVYbsjTOEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_BVYbszTOEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_BVV_cTTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVV_cjTOEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_BVUKQTTOEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_BVUKQjTOEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_BVJLITTOEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVJLIjTOEe2g6rtd7Hf7cA" x="740" y="380"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="__81UYjTNEe2g6rtd7Hf7cA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_BVnFMDTOEe2g6rtd7Hf7cA" type="4001" element="_BUo00DTOEe2g6rtd7Hf7cA" source="_BVaQ4DTOEe2g6rtd7Hf7cA" target="_BVeiUDTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BVoTUDTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVoTUTTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BVtL0DTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVtL0TTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BVvoEDTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BVvoETTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BVnFMTTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BVnFMjTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BVnFMzTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV5ZEDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV5ZETTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BV6AIDTOEe2g6rtd7Hf7cA" type="4001" element="_BUwwoDTOEe2g6rtd7Hf7cA" source="_BVfJZTTOEe2g6rtd7Hf7cA" target="_BVfwcjTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BV6nMzTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV6nNDTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV6nNTTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV6nNjTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV6nNzTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV6nODTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BV6nMDTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BV6nMTTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BV6nMjTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OQDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OQTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BV7OQjTOEe2g6rtd7Hf7cA" type="4001" element="_BUxXsjTOEe2g6rtd7Hf7cA" source="_BVeiUDTOEe2g6rtd7Hf7cA" target="_BVfJYDTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BV7ORjTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7ORzTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV7OSDTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7OSTTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV7OSjTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7OSzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BV7OQzTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BV7ORDTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BV7ORTTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OTDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OTTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_BV7OTjTOEe2g6rtd7Hf7cA" type="4001" element="_BUx-xDTOEe2g6rtd7Hf7cA" source="_BVeiUDTOEe2g6rtd7Hf7cA" target="_BVfJZTTOEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_BV7OUjTOEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7OUzTOEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV7OVDTOEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7OVTTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_BV7OVjTOEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BV7OVzTOEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_BV7OTzTOEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_BV7OUDTOEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_BV7OUTTOEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OWDTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_BV7OWTTOEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="__85l0DTNEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="__85l0TTNEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BUQaUDTOEe2g6rtd7Hf7cA" name="OperationalProcess 2" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BUSPgDTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BUcAgTTOEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BUcAgjTOEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BUcnkDTOEe2g6rtd7Hf7cA" name="OperationalActivity 9" outgoingEdges="_BUo00DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#4a202fcf-5872-4d21-ae2f-97ebeae0b4e7"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_BUfD0DTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BUgR8DTOEe2g6rtd7Hf7cA" name="OperationalActivity 10" outgoingEdges="_BUxXsjTOEe2g6rtd7Hf7cA _BUx-xDTOEe2g6rtd7Hf7cA" incomingEdges="_BUo00DTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#40483782-12b2-4999-82af-4ecc9822da0f"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_BUgR8TTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BUiuMTTOEe2g6rtd7Hf7cA" name="OperationalActivity 11" incomingEdges="_BUxXsjTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#e1e05c57-edc5-4380-b71f-479ca0f53d75"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_BUiuMjTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BUiuNDTOEe2g6rtd7Hf7cA" name="OperationalActivity 12" outgoingEdges="_BUwwoDTOEe2g6rtd7Hf7cA" incomingEdges="_BUx-xDTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#1224ff74-9db5-4568-8055-1d72dbd03a58"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_BUjVQDTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BUj8UTTOEe2g6rtd7Hf7cA" name="OperationalActivity 13" incomingEdges="_BUwwoDTOEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#9e8a1ec4-5d0b-425a-823b-4abf2efc263f"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_BUj8UjTOEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BUo00DTOEe2g6rtd7Hf7cA" name="Interaction 1" sourceNode="_BUcnkDTOEe2g6rtd7Hf7cA" targetNode="_BUgR8DTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#247de160-a79d-4326-b56f-19de24d0342a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BUuUYDTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BUuUYTTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BUwwoDTOEe2g6rtd7Hf7cA" name="Interaction 5" sourceNode="_BUiuNDTOEe2g6rtd7Hf7cA" targetNode="_BUj8UTTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#7bb37ad8-0468-40ab-9764-560ced5fed17"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BUwwoTTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BUwwojTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BUxXsjTOEe2g6rtd7Hf7cA" name="Interaction 3" sourceNode="_BUgR8DTOEe2g6rtd7Hf7cA" targetNode="_BUiuMTTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#a5022be5-7fdf-4fb9-ba5e-59bc3f242eca"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BUx-wDTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BUx-wTTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BUx-xDTOEe2g6rtd7Hf7cA" name="Interaction 2" sourceNode="_BUgR8DTOEe2g6rtd7Hf7cA" targetNode="_BUiuNDTOEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#3ebb4439-7850-4302-b230-2a217a5afc8d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BUx-xTTOEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BUx-xjTOEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="__8kOoDTNEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_Ch3ngDTPEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Ch5csjTPEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_Ch5cszTPEe2g6rtd7Hf7cA" type="Sirius" element="_Ch3ngDTPEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_ENCv4DTPEe2g6rtd7Hf7cA" type="2002" element="_EMjnsDTPEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ENDW8DTPEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_ENDW8TTPEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_ENDW9DTPEe2g6rtd7Hf7cA" type="3008" element="_EMmrADTPEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_END-ADTPEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_ENElEDTPEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_ENFMIDTPEe2g6rtd7Hf7cA" type="3008" element="_EMmrAzTPEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_ENFMIzTPEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_ENFMJDTPEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_ENFzMDTPEe2g6rtd7Hf7cA" type="3008" element="_EMnSETTPEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_ENFzMzTPEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_ENFzNDTPEe2g6rtd7Hf7cA" type="7002">
+                        <children xmi:type="notation:Node" xmi:id="_ENFzODTPEe2g6rtd7Hf7cA" type="3008" element="_EMnSFDTPEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_ENGaQDTPEe2g6rtd7Hf7cA" type="5005"/>
+                          <children xmi:type="notation:Node" xmi:id="_ENGaQTTPEe2g6rtd7Hf7cA" type="7002">
+                            <children xmi:type="notation:Node" xmi:id="_ENGaRDTPEe2g6rtd7Hf7cA" type="3008" element="_EMn5IDTPEe2g6rtd7Hf7cA">
+                              <children xmi:type="notation:Node" xmi:id="_ENGaRzTPEe2g6rtd7Hf7cA" type="5005"/>
+                              <children xmi:type="notation:Node" xmi:id="_ENGaSDTPEe2g6rtd7Hf7cA" type="7002">
+                                <children xmi:type="notation:Node" xmi:id="_ENGaTDTPEe2g6rtd7Hf7cA" type="3008" element="_EMn5IzTPEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_ENHBUDTPEe2g6rtd7Hf7cA" type="5005"/>
+                                  <children xmi:type="notation:Node" xmi:id="_ENHBUTTPEe2g6rtd7Hf7cA" type="7002">
+                                    <children xmi:type="notation:Node" xmi:id="_ENHBVDTPEe2g6rtd7Hf7cA" type="3008" element="_EMn5JjTPEe2g6rtd7Hf7cA">
+                                      <children xmi:type="notation:Node" xmi:id="_ENHBVzTPEe2g6rtd7Hf7cA" type="5005"/>
+                                      <children xmi:type="notation:Node" xmi:id="_ENHBWDTPEe2g6rtd7Hf7cA" type="7002">
+                                        <children xmi:type="notation:Node" xmi:id="_ENHBXDTPEe2g6rtd7Hf7cA" type="3007" element="_EMogMjTPEe2g6rtd7Hf7cA">
+                                          <children xmi:type="notation:Node" xmi:id="_ENHoYDTPEe2g6rtd7Hf7cA" type="5003">
+                                            <layoutConstraint xmi:type="notation:Location" xmi:id="_ENHoYTTPEe2g6rtd7Hf7cA" y="5"/>
+                                          </children>
+                                          <children xmi:type="notation:Node" xmi:id="_ENI2jDTPEe2g6rtd7Hf7cA" type="3003" element="_EMogMzTPEe2g6rtd7Hf7cA">
+                                            <styles xmi:type="notation:ShapeStyle" xmi:id="_ENI2jTTPEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENI2jjTPEe2g6rtd7Hf7cA"/>
+                                          </children>
+                                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENHBXTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENHBXjTPEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                        </children>
+                                        <children xmi:type="notation:Node" xmi:id="_ENIPcDTPEe2g6rtd7Hf7cA" type="3007" element="_EMpHQTTPEe2g6rtd7Hf7cA">
+                                          <children xmi:type="notation:Node" xmi:id="_ENIPczTPEe2g6rtd7Hf7cA" type="5003">
+                                            <layoutConstraint xmi:type="notation:Location" xmi:id="_ENIPdDTPEe2g6rtd7Hf7cA" y="5"/>
+                                          </children>
+                                          <children xmi:type="notation:Node" xmi:id="_ENJdkDTPEe2g6rtd7Hf7cA" type="3003" element="_EMpHQjTPEe2g6rtd7Hf7cA">
+                                            <styles xmi:type="notation:ShapeStyle" xmi:id="_ENJdkTTPEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENJdkjTPEe2g6rtd7Hf7cA"/>
+                                          </children>
+                                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENIPcTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENIPcjTPEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                        </children>
+                                        <children xmi:type="notation:Node" xmi:id="_ENIPdTTPEe2g6rtd7Hf7cA" type="3007" element="_EMpHRDTPEe2g6rtd7Hf7cA">
+                                          <children xmi:type="notation:Node" xmi:id="_ENI2gDTPEe2g6rtd7Hf7cA" type="5003">
+                                            <layoutConstraint xmi:type="notation:Location" xmi:id="_ENI2gTTPEe2g6rtd7Hf7cA" y="5"/>
+                                          </children>
+                                          <children xmi:type="notation:Node" xmi:id="_ENJdkzTPEe2g6rtd7Hf7cA" type="3003" element="_EMpuUDTPEe2g6rtd7Hf7cA">
+                                            <styles xmi:type="notation:ShapeStyle" xmi:id="_ENJdlDTPEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENJdlTTPEe2g6rtd7Hf7cA"/>
+                                          </children>
+                                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENIPdjTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENIPdzTPEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                        </children>
+                                        <children xmi:type="notation:Node" xmi:id="_ENI2gjTPEe2g6rtd7Hf7cA" type="3007" element="_EMpuUjTPEe2g6rtd7Hf7cA">
+                                          <children xmi:type="notation:Node" xmi:id="_ENI2hTTPEe2g6rtd7Hf7cA" type="5003">
+                                            <layoutConstraint xmi:type="notation:Location" xmi:id="_ENI2hjTPEe2g6rtd7Hf7cA" y="5"/>
+                                          </children>
+                                          <children xmi:type="notation:Node" xmi:id="_ENJdljTPEe2g6rtd7Hf7cA" type="3003" element="_EMpuUzTPEe2g6rtd7Hf7cA">
+                                            <styles xmi:type="notation:ShapeStyle" xmi:id="_ENJdlzTPEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENJdmDTPEe2g6rtd7Hf7cA"/>
+                                          </children>
+                                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENI2gzTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENI2hDTPEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                        </children>
+                                        <children xmi:type="notation:Node" xmi:id="_ENI2hzTPEe2g6rtd7Hf7cA" type="3007" element="_EMpuVTTPEe2g6rtd7Hf7cA">
+                                          <children xmi:type="notation:Node" xmi:id="_ENI2ijTPEe2g6rtd7Hf7cA" type="5003">
+                                            <layoutConstraint xmi:type="notation:Location" xmi:id="_ENI2izTPEe2g6rtd7Hf7cA" y="5"/>
+                                          </children>
+                                          <children xmi:type="notation:Node" xmi:id="_ENJdmTTPEe2g6rtd7Hf7cA" type="3003" element="_EMqVYDTPEe2g6rtd7Hf7cA">
+                                            <styles xmi:type="notation:ShapeStyle" xmi:id="_ENJdmjTPEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENJdmzTPEe2g6rtd7Hf7cA"/>
+                                          </children>
+                                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENI2iDTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENI2iTTPEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                        </children>
+                                        <styles xmi:type="notation:SortingStyle" xmi:id="_ENHBWTTPEe2g6rtd7Hf7cA"/>
+                                        <styles xmi:type="notation:FilteringStyle" xmi:id="_ENHBWjTPEe2g6rtd7Hf7cA"/>
+                                        <styles xmi:type="notation:DrawerStyle" xmi:id="_ENHBWzTPEe2g6rtd7Hf7cA"/>
+                                      </children>
+                                      <styles xmi:type="notation:ShapeStyle" xmi:id="_ENHBVTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+                                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENHBVjTPEe2g6rtd7Hf7cA"/>
+                                    </children>
+                                    <styles xmi:type="notation:SortingStyle" xmi:id="_ENHBUjTPEe2g6rtd7Hf7cA"/>
+                                    <styles xmi:type="notation:FilteringStyle" xmi:id="_ENHBUzTPEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_ENGaTTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENGaTjTPEe2g6rtd7Hf7cA"/>
+                                </children>
+                                <styles xmi:type="notation:SortingStyle" xmi:id="_ENGaSTTPEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:FilteringStyle" xmi:id="_ENGaSjTPEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:DrawerStyle" xmi:id="_ENGaSzTPEe2g6rtd7Hf7cA"/>
+                              </children>
+                              <styles xmi:type="notation:ShapeStyle" xmi:id="_ENGaRTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+                              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENGaRjTPEe2g6rtd7Hf7cA"/>
+                            </children>
+                            <styles xmi:type="notation:SortingStyle" xmi:id="_ENGaQjTPEe2g6rtd7Hf7cA"/>
+                            <styles xmi:type="notation:FilteringStyle" xmi:id="_ENGaQzTPEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENFzOTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENFzOjTPEe2g6rtd7Hf7cA"/>
+                        </children>
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_ENFzNTTPEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_ENFzNjTPEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_ENFzNzTPEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_ENFzMTTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENFzMjTPEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_ENFMJTTPEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_ENFMJjTPEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_ENFMITTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENFMIjTPEe2g6rtd7Hf7cA" x="190" y="90"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_ENElETTPEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_ENElEjTPEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_ENElEzTPEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ENDW9TTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="12"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENDW9jTPEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_ENDW8jTPEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_ENDW8zTPEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ENCv4TTPEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENCv4jTPEe2g6rtd7Hf7cA" x="760" y="400"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_Ch5ctDTPEe2g6rtd7Hf7cA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_ENKEoDTPEe2g6rtd7Hf7cA" type="4001" element="_EMrjgDTPEe2g6rtd7Hf7cA" source="_ENHBXDTPEe2g6rtd7Hf7cA" target="_ENIPcDTPEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ENKEpDTPEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKEpTTPEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENKEpjTPEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKEpzTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENKEqDTPEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKEqTTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ENKEoTTPEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ENKEojTPEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ENKEozTPEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENKrsDTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENKrsTTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ENKrsjTPEe2g6rtd7Hf7cA" type="4001" element="_EMsxoDTPEe2g6rtd7Hf7cA" source="_ENI2gjTPEe2g6rtd7Hf7cA" target="_ENI2hzTPEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ENKrtjTPEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKrtzTPEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENKruDTPEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKruTTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENKrujTPEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENKruzTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ENKrszTPEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ENKrtDTPEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ENKrtTTPEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENL50DTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENL50TTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ENL50jTPEe2g6rtd7Hf7cA" type="4001" element="_EMtYsDTPEe2g6rtd7Hf7cA" source="_ENIPcDTPEe2g6rtd7Hf7cA" target="_ENIPdTTPEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ENMg4DTPEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENMg4TTPEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENMg4jTPEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENMg4zTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENNH8DTPEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENNH8TTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ENL50zTPEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ENL51DTPEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ENL51TTPEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENNvADTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENNvATTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_ENNvAjTPEe2g6rtd7Hf7cA" type="4001" element="_EMtYtTTPEe2g6rtd7Hf7cA" source="_ENIPcDTPEe2g6rtd7Hf7cA" target="_ENI2gjTPEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ENOWEDTPEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENOWETTPEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENOWEjTPEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENOWEzTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ENOWFDTPEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ENOWFTTPEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_ENNvAzTPEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_ENNvBDTPEe2g6rtd7Hf7cA" fontColor="4210779" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ENNvBTTPEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENO9IDTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ENO9ITTPEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Ch7R4DTPEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Ch748DTPEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMjnsDTPEe2g6rtd7Hf7cA" name="OperationalProcess OA8" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#285d6db3-ab51-4443-8afc-db9804fec6cb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#285d6db3-ab51-4443-8afc-db9804fec6cb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMjnsTTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMmrADTPEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMmrATTPEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMmrAzTPEe2g6rtd7Hf7cA" name="OperationalProcess OA7" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#4990d9e6-461d-4b41-98c6-2091c71454de"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#4990d9e6-461d-4b41-98c6-2091c71454de"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMmrBDTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMnSETTPEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMnSEjTPEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+            <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMnSFDTPEe2g6rtd7Hf7cA" name="OP1" childrenPresentation="VerticalStack">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7bfc3568-0bbf-4514-92d1-fc7ad02900d2"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+              <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMnSFTTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+                <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+              <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMn5IDTPEe2g6rtd7Hf7cA">
+                <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+                <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+                <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMn5ITTPEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+                  <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+                </ownedStyle>
+                <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+                <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMn5IzTPEe2g6rtd7Hf7cA" name="OperationalProcess 2" childrenPresentation="VerticalStack">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#c1d6f833-702f-4f96-a6fa-9a8c9447ca91"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+                  <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMn5JDTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+                    <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@conditionnalStyles.0/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+                  <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_EMn5JjTPEe2g6rtd7Hf7cA">
+                    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+                    <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+                    <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_EMogMDTPEe2g6rtd7Hf7cA" labelSize="12" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="250,239,203" foregroundColor="250,239,203">
+                      <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@conditionnalStyles.0/@style"/>
+                    </ownedStyle>
+                    <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+                    <ownedDiagramElements xmi:type="diagram:DNode" uid="_EMogMjTPEe2g6rtd7Hf7cA" name="OperationalActivity 9" outgoingEdges="_EMrjgDTPEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#6205705c-df8c-4318-b588-3336d2572b93"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#4a202fcf-5872-4d21-ae2f-97ebeae0b4e7"/>
+                      <ownedStyle xmi:type="diagram:Square" uid="_EMogMzTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+                      </ownedStyle>
+                      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                    </ownedDiagramElements>
+                    <ownedDiagramElements xmi:type="diagram:DNode" uid="_EMpHQTTPEe2g6rtd7Hf7cA" name="OperationalActivity 10" outgoingEdges="_EMtYsDTPEe2g6rtd7Hf7cA _EMtYtTTPEe2g6rtd7Hf7cA" incomingEdges="_EMrjgDTPEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#8bfd3f7c-05cd-48bd-8bfe-7fbb529044da"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#40483782-12b2-4999-82af-4ecc9822da0f"/>
+                      <ownedStyle xmi:type="diagram:Square" uid="_EMpHQjTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+                      </ownedStyle>
+                      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                    </ownedDiagramElements>
+                    <ownedDiagramElements xmi:type="diagram:DNode" uid="_EMpHRDTPEe2g6rtd7Hf7cA" name="OperationalActivity 11" incomingEdges="_EMtYsDTPEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#fa85d3db-5e06-41e4-ad13-4250fa29ab1e"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#e1e05c57-edc5-4380-b71f-479ca0f53d75"/>
+                      <ownedStyle xmi:type="diagram:Square" uid="_EMpuUDTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+                      </ownedStyle>
+                      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                    </ownedDiagramElements>
+                    <ownedDiagramElements xmi:type="diagram:DNode" uid="_EMpuUjTPEe2g6rtd7Hf7cA" name="OperationalActivity 12" outgoingEdges="_EMsxoDTPEe2g6rtd7Hf7cA" incomingEdges="_EMtYtTTPEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#75a71d10-178c-4db8-bf93-6d12225a8cc8"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#1224ff74-9db5-4568-8055-1d72dbd03a58"/>
+                      <ownedStyle xmi:type="diagram:Square" uid="_EMpuUzTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+                      </ownedStyle>
+                      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                    </ownedDiagramElements>
+                    <ownedDiagramElements xmi:type="diagram:DNode" uid="_EMpuVTTPEe2g6rtd7Hf7cA" name="OperationalActivity 13" incomingEdges="_EMsxoDTPEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#e0dad31b-0103-46b7-981e-38eba7b51aa9"/>
+                      <semanticElements xmi:type="org.polarsys.capella.core.data.oa:OperationalActivity" href="SemanticQueries.capella#9e8a1ec4-5d0b-425a-823b-4abf2efc263f"/>
+                      <ownedStyle xmi:type="diagram:Square" uid="_EMqVYDTPEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="91,64,64" labelPosition="node" width="10" height="5" color="247,218,116">
+                        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@conditionnalStyles.7/@style"/>
+                      </ownedStyle>
+                      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                    </ownedDiagramElements>
+                  </ownedDiagramElements>
+                </ownedDiagramElements>
+              </ownedDiagramElements>
+            </ownedDiagramElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_EMrjgDTPEe2g6rtd7Hf7cA" name="Interaction 1" sourceNode="_EMogMjTPEe2g6rtd7Hf7cA" targetNode="_EMpHQTTPEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#194e862c-02e3-4239-af72-048452188f09"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#247de160-a79d-4326-b56f-19de24d0342a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_EMsKkDTPEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_EMsKkTTPEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_EMsxoDTPEe2g6rtd7Hf7cA" name="Interaction 5" sourceNode="_EMpuUjTPEe2g6rtd7Hf7cA" targetNode="_EMpuVTTPEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#40a30cdb-6a34-4347-af30-5c89faed23ed"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#7bb37ad8-0468-40ab-9764-560ced5fed17"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_EMsxoTTPEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_EMsxojTPEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_EMtYsDTPEe2g6rtd7Hf7cA" name="Interaction 3" sourceNode="_EMpHQTTPEe2g6rtd7Hf7cA" targetNode="_EMpHRDTPEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#84cedcb3-d0af-4ec3-b97a-6011e8d7aa0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#a5022be5-7fdf-4fb9-ba5e-59bc3f242eca"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_EMtYsTTPEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_EMtYsjTPEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_EMtYtTTPEe2g6rtd7Hf7cA" name="Interaction 2" sourceNode="_EMpHQTTPEe2g6rtd7Hf7cA" targetNode="_EMpuUjTPEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#040dec3b-6711-4b25-ac1e-5a4ef2d334f5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#3ebb4439-7850-4302-b230-2a217a5afc8d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_EMt_wDTPEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="91,64,64">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@conditionnalStyles.1/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_EMt_wTTPEe2g6rtd7Hf7cA" labelColor="91,64,64"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Ch4OkDTPEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']/@ownedRepresentations[name='Operational%20Process%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.oa:OperationalProcess" href="SemanticQueries.capella#0268e41f-4013-4bb4-a719-c5a253e6ec04"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_Xhj4EDTQEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_XhmUUDTQEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_XhmUUTTQEe2g6rtd7Hf7cA" type="Sirius" element="_Xhj4EDTQEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_YM9lgDTQEe2g6rtd7Hf7cA" type="2002" element="_YMjV0DTQEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_YM9lgzTQEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_YM9lhDTQEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_YM-MkDTQEe2g6rtd7Hf7cA" type="3008" element="_YMz0gjTQEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_YM-MkzTQEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_YM-MlDTQEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_b0ZmQDTQEe2g6rtd7Hf7cA" type="3008" element="_b0FdNDTQEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_b0aNUDTQEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_b0aNUTTQEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_b0aNVDTQEe2g6rtd7Hf7cA" type="3008" element="_b0GrUDTQEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_b0aNVzTQEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_b0aNWDTQEe2g6rtd7Hf7cA" type="7002">
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_b0aNWTTQEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_b0aNWjTQEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_b0aNWzTQEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_b0aNVTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b0aNVjTQEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_b0aNUjTQEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_b0aNUzTQEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_b0ZmQTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b0ZmQjTQEe2g6rtd7Hf7cA" x="60" y="40"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_YM-MlTTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_YM-MljTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_YM-MlzTQEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_YM-MkTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YM-MkjTQEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_YM9lhTTQEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_YM9lhjTQEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_YM9lgTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_YM9lgjTQEe2g6rtd7Hf7cA" x="740" y="440"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_XhmUUjTQEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_XhowkDTQEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_XhowkTTQEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_YMjV0DTQEe2g6rtd7Hf7cA" name="FunctionalChain SF7" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#91c7b99b-1477-4804-8eca-7151bdd08b7d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#91c7b99b-1477-4804-8eca-7151bdd08b7d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_YMnAMDTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_YMz0gjTQEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_YM1CoDTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_b0FdNDTQEe2g6rtd7Hf7cA" name="FC1" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_b0GEQDTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_b0GrUDTQEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_b0GrUTTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_XhkfIDTQEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_aU7XkDTQEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_aU8lsjTQEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_aU8lszTQEe2g6rtd7Hf7cA" type="Sirius" element="_aU7XkDTQEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_b0Wi8DTQEe2g6rtd7Hf7cA" type="2002" element="_bzzwYDTQEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_b0XKADTQEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_b0XKATTQEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_b0XKBDTQEe2g6rtd7Hf7cA" type="3008" element="_b0Lj0TTQEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_b0YYIDTQEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_b0YYITTQEe2g6rtd7Hf7cA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_b0YYIjTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_b0YYIzTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_b0YYJDTQEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_b0XKBTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b0XKBjTQEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_b0XKAjTQEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_b0XKAzTQEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_b0Wi8TTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b0Wi8jTQEe2g6rtd7Hf7cA" x="1040" y="320"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_aU8ltDTQEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_aU-a4DTQEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_aU-a4TTQEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_bzzwYDTQEe2g6rtd7Hf7cA" name="FC1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bz2MoDTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_b0Lj0TTQEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_b0MK4DTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_aU7XkTTQEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_jYvhcDTQEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_jYwvkDTQEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_jYwvkTTQEe2g6rtd7Hf7cA" type="Sirius" element="_jYvhcDTQEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_k1Im8DTQEe2g6rtd7Hf7cA" type="2002" element="_k0ixEDTQEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_k1Im8zTQEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_k1Im9DTQEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_k1Im9zTQEe2g6rtd7Hf7cA" type="3008" element="_k1E8kTTQEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_k1JOADTQEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_k1JOATTQEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_k1JOBTTQEe2g6rtd7Hf7cA" type="3008" element="_k1FjoDTQEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_k1J1EDTQEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_k1J1ETTQEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_k1J1FDTQEe2g6rtd7Hf7cA" type="3008" element="_k1FjozTQEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_k1KcIDTQEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_k1KcITTQEe2g6rtd7Hf7cA" type="7002">
+                        <children xmi:type="notation:Node" xmi:id="_k1KcJTTQEe2g6rtd7Hf7cA" type="3008" element="_k1GxwjTQEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_k1LDMDTQEe2g6rtd7Hf7cA" type="5005"/>
+                          <children xmi:type="notation:Node" xmi:id="_k1LDMTTQEe2g6rtd7Hf7cA" type="7002">
+                            <children xmi:type="notation:Node" xmi:id="_k1LDNDTQEe2g6rtd7Hf7cA" type="3008" element="_k1GxxTTQEe2g6rtd7Hf7cA">
+                              <children xmi:type="notation:Node" xmi:id="_k1LDNzTQEe2g6rtd7Hf7cA" type="5005"/>
+                              <children xmi:type="notation:Node" xmi:id="_k1LDODTQEe2g6rtd7Hf7cA" type="7002">
+                                <styles xmi:type="notation:SortingStyle" xmi:id="_k1LDOTTQEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:FilteringStyle" xmi:id="_k1LDOjTQEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:DrawerStyle" xmi:id="_k1LDOzTQEe2g6rtd7Hf7cA"/>
+                              </children>
+                              <styles xmi:type="notation:ShapeStyle" xmi:id="_k1LDNTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1LDNjTQEe2g6rtd7Hf7cA"/>
+                            </children>
+                            <styles xmi:type="notation:SortingStyle" xmi:id="_k1LDMjTQEe2g6rtd7Hf7cA"/>
+                            <styles xmi:type="notation:FilteringStyle" xmi:id="_k1LDMzTQEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_k1KcJjTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1KcJzTQEe2g6rtd7Hf7cA"/>
+                        </children>
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_k1KcIjTQEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_k1KcIzTQEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_k1KcJDTQEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_k1J1FTTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1J1FjTQEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_k1J1EjTQEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_k1J1EzTQEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_k1JOBjTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1JOBzTQEe2g6rtd7Hf7cA" x="160" y="60"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_k1JOAjTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_k1JOAzTQEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_k1JOBDTQEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_k1Im-DTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1Im-TTQEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_k1Im9TTQEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_k1Im9jTQEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_k1Im8TTQEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k1Im8jTQEe2g6rtd7Hf7cA" x="770" y="410"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_jYwvkjTQEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_jYx9sDTQEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_jYx9sTTQEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k0ixEDTQEe2g6rtd7Hf7cA" name="FunctionalChain SF8" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7cdd0d36-5640-41c0-a583-38594cfd53e0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#7cdd0d36-5640-41c0-a583-38594cfd53e0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k0lNUDTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k1E8kTTQEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k1E8kjTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k1FjoDTQEe2g6rtd7Hf7cA" name="FunctionalChain SF7" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#91c7b99b-1477-4804-8eca-7151bdd08b7d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#91c7b99b-1477-4804-8eca-7151bdd08b7d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k1FjoTTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k1FjozTQEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k1GxwDTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+            <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k1GxwjTQEe2g6rtd7Hf7cA" name="FC1" childrenPresentation="VerticalStack">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#e2f313a9-7179-4993-83b3-22209f82e034"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+              <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k1GxwzTQEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+                <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+              <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_k1GxxTTQEe2g6rtd7Hf7cA">
+                <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+                <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+                <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_k1GxxjTQEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+                  <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+                </ownedStyle>
+                <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+              </ownedDiagramElements>
+            </ownedDiagramElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_jYvhcTTQEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#099fa717-2bb7-458b-a14a-5b692e96da1b"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_jK_ucDTSEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_jLA8kDTSEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_jLA8kTTSEe2g6rtd7Hf7cA" type="Sirius" element="_jK_ucDTSEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_kETVADTSEe2g6rtd7Hf7cA" type="2002" element="_kD0z4DTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_kET8EDTSEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_kET8ETTSEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_kEUjIDTSEe2g6rtd7Hf7cA" type="3008" element="_kEPqoTTSEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_kEUjIzTSEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_kEUjJDTSEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_l5pGADTSEe2g6rtd7Hf7cA" type="3008" element="_l5R5pDTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5ptEDTSEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_l5ptETTSEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_l5qUIDTSEe2g6rtd7Hf7cA" type="3008" element="_l5SgsjTSEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_l5qUIzTSEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_l5qUJDTSEe2g6rtd7Hf7cA" type="7002">
+                        <children xmi:type="notation:Node" xmi:id="_l5q7MDTSEe2g6rtd7Hf7cA" type="3007" element="_l5SgtTTSEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_l5q7MzTSEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_l5q7NDTSEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_l5riTDTSEe2g6rtd7Hf7cA" type="3003" element="_l5SgtjTSEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_l5riTTTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5riTjTSEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5q7MTTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5q7MjTSEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_l5q7NTTSEe2g6rtd7Hf7cA" type="3007" element="_l5SguDTSEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_l5q7ODTSEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_l5q7OTTSEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_l5sJUDTSEe2g6rtd7Hf7cA" type="3003" element="_l5THwDTSEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_l5sJUTTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5sJUjTSEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5q7NjTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5q7NzTSEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_l5q7OjTSEe2g6rtd7Hf7cA" type="3007" element="_l5THwjTSEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_l5riQDTSEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_l5riQTTSEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_l5sJUzTSEe2g6rtd7Hf7cA" type="3003" element="_l5THwzTSEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_l5sJVDTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5sJVTTSEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5q7OzTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5q7PDTSEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_l5riQjTSEe2g6rtd7Hf7cA" type="3007" element="_l5THxTTSEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_l5riRTTSEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_l5riRjTSEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_l5sJVjTSEe2g6rtd7Hf7cA" type="3003" element="_l5THxjTSEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_l5sJVzTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5sJWDTSEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5riQzTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5riRDTSEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <children xmi:type="notation:Node" xmi:id="_l5riRzTSEe2g6rtd7Hf7cA" type="3007" element="_l5THyDTSEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_l5riSjTSEe2g6rtd7Hf7cA" type="5003">
+                            <layoutConstraint xmi:type="notation:Location" xmi:id="_l5riSzTSEe2g6rtd7Hf7cA" y="5"/>
+                          </children>
+                          <children xmi:type="notation:Node" xmi:id="_l5sJWTTSEe2g6rtd7Hf7cA" type="3003" element="_l5Tu0DTSEe2g6rtd7Hf7cA">
+                            <styles xmi:type="notation:ShapeStyle" xmi:id="_l5sJWjTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5sJWzTSEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5riSDTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5riSTTSEe2g6rtd7Hf7cA" width="100" height="50"/>
+                        </children>
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_l5qUJTTSEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_l5qUJjTSEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_l5qUJzTSEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_l5qUITTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5qUIjTSEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_l5ptEjTSEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_l5ptEzTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5pGATTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5pGAjTSEe2g6rtd7Hf7cA" x="150" y="50"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_kEUjJTTSEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_kEUjJjTSEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_kEUjJzTSEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_kEUjITTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kEUjIjTSEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_kET8EjTSEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_kET8EzTSEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_kETVATTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kETVAjTSEe2g6rtd7Hf7cA" x="460" y="460"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_jLA8kjTSEe2g6rtd7Hf7cA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_l5swYDTSEe2g6rtd7Hf7cA" type="4001" element="_l5Tu0jTSEe2g6rtd7Hf7cA" source="_l5q7MDTSEe2g6rtd7Hf7cA" target="_l5q7NTTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5swZDTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5swZTTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5swZjTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5swZzTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5swaDTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5swaTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5swYTTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5swYjTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5swYzTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5swajTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5swazTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5swbDTSEe2g6rtd7Hf7cA" type="4001" element="_l5Tu1zTSEe2g6rtd7Hf7cA" source="_l5q7OjTSEe2g6rtd7Hf7cA" target="_l5riRzTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5swcDTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5swcTTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXcDTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXcTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXcjTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXczTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5swbTTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5swbjTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5swbzTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXdDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXdTTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5tXdjTSEe2g6rtd7Hf7cA" type="4001" element="_l5UV4jTSEe2g6rtd7Hf7cA" source="_l5q7OjTSEe2g6rtd7Hf7cA" target="_l5riQjTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5tXejTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXezTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXfDTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXfTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXfjTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXfzTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5tXdzTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5tXeDTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5tXeTTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXgDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXgTTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5tXgjTSEe2g6rtd7Hf7cA" type="4001" element="_l5UV5zTSEe2g6rtd7Hf7cA" source="_l5q7NTTSEe2g6rtd7Hf7cA" target="_l5q7OjTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5tXhjTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXhzTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXiDTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXiTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5tXijTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5tXizTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5tXgzTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5tXhDTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5tXhTTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXjDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5tXjTTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_jLBjoDTSEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_jLCKsDTSEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kD0z4DTSEe2g6rtd7Hf7cA" name="FunctionalChain PF1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#99518288-f8ae-4115-8241-5c8e0306ce5a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#99518288-f8ae-4115-8241-5c8e0306ce5a"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kD2pEDTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_kEPqoTTSEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kEPqojTSEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_l5R5pDTSEe2g6rtd7Hf7cA" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_l5SgsDTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_l5SgsjTSEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_l5SgszTSEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_l5SgtTTSEe2g6rtd7Hf7cA" name="PhysicalFunction 1" outgoingEdges="_l5Tu0jTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#ad5e608f-dc22-40d2-b1e6-c22e0758daf4"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_l5SgtjTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_l5SguDTSEe2g6rtd7Hf7cA" name="PhysicalFunction 2" outgoingEdges="_l5UV5zTSEe2g6rtd7Hf7cA" incomingEdges="_l5Tu0jTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#3cccea9a-ddb0-48e3-84ec-8a3f0c593803"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_l5THwDTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_l5THwjTSEe2g6rtd7Hf7cA" name="PhysicalFunction 3" outgoingEdges="_l5Tu1zTSEe2g6rtd7Hf7cA _l5UV4jTSEe2g6rtd7Hf7cA" incomingEdges="_l5UV5zTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#37e1cc57-29bc-4c64-8864-6a52e357e18f"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_l5THwzTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_l5THxTTSEe2g6rtd7Hf7cA" name="PhysicalFunction 4" incomingEdges="_l5UV4jTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#4d89ed09-6e83-4542-95a4-d32ec4d20c5b"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_l5THxjTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+            <ownedDiagramElements xmi:type="diagram:DNode" uid="_l5THyDTSEe2g6rtd7Hf7cA" name="PhysicalFunction 5" incomingEdges="_l5Tu1zTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#47447e6b-896e-4e08-af71-8087110dda1f"/>
+              <ownedStyle xmi:type="diagram:Square" uid="_l5Tu0DTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+            </ownedDiagramElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l5Tu0jTSEe2g6rtd7Hf7cA" name="FunctionalExchange 1" sourceNode="_l5SgtTTSEe2g6rtd7Hf7cA" targetNode="_l5SguDTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#6fd8df09-4eec-4b53-a6cd-38e5522c453a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l5Tu0zTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l5Tu1DTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l5Tu1zTSEe2g6rtd7Hf7cA" name="FunctionalExchange 5" sourceNode="_l5THwjTSEe2g6rtd7Hf7cA" targetNode="_l5THyDTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#80c31274-9a29-45a8-80bf-d520bc55d72d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l5Tu2DTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l5Tu2TTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l5UV4jTSEe2g6rtd7Hf7cA" name="FunctionalExchange 3" sourceNode="_l5THwjTSEe2g6rtd7Hf7cA" targetNode="_l5THxTTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#738c9f6f-dff9-44e6-8be0-c6686885b7f6"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l5UV4zTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l5UV5DTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l5UV5zTSEe2g6rtd7Hf7cA" name="FunctionalExchange 2" sourceNode="_l5SguDTSEe2g6rtd7Hf7cA" targetNode="_l5THwjTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#568784e4-2e0c-45f2-8b70-adef2e94dab3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l5UV6DTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l5UV6TTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_jK_ucTTSEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_k9BFsDTSEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_k9CT0DTSEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_k9CT0TTSEe2g6rtd7Hf7cA" type="Sirius" element="_k9BFsDTSEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_l5ZOYDTSEe2g6rtd7Hf7cA" type="2002" element="_l4wVMDTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5ZOYzTSEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_l5ZOZDTSEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_l5ZOZzTSEe2g6rtd7Hf7cA" type="3008" element="_l46tQjTSEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_l5Z1cDTSEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_l5Z1cTTSEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_l5Z1dTTSEe2g6rtd7Hf7cA" type="3007" element="_l46tRTTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5Z1eDTSEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_l5Z1eTTSEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_l5acjDTSEe2g6rtd7Hf7cA" type="3003" element="_l46tRjTSEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_l5acjTTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5acjjTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5Z1djTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5Z1dzTSEe2g6rtd7Hf7cA" x="130" y="20" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_l5Z1ejTSEe2g6rtd7Hf7cA" type="3007" element="_l47UUTTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5Z1fTTSEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_l5Z1fjTSEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_l5acjzTSEe2g6rtd7Hf7cA" type="3003" element="_l47UUjTSEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_l5ackDTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5ackTTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5Z1ezTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5Z1fDTSEe2g6rtd7Hf7cA" x="140" y="30" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_l5Z1fzTSEe2g6rtd7Hf7cA" type="3007" element="_l47UVDTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5acgDTSEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_l5acgTTSEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_l5bDkDTSEe2g6rtd7Hf7cA" type="3003" element="_l47UVTTSEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_l5bDkTTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5bDkjTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5Z1gDTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5Z1gTTSEe2g6rtd7Hf7cA" x="150" y="40" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_l5acgjTSEe2g6rtd7Hf7cA" type="3007" element="_l47UVzTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5achTTSEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_l5achjTSEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_l5bDkzTSEe2g6rtd7Hf7cA" type="3003" element="_l477YDTSEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_l5bDlDTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5bDlTTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5acgzTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5achDTSEe2g6rtd7Hf7cA" x="160" y="50" width="100" height="50"/>
+                </children>
+                <children xmi:type="notation:Node" xmi:id="_l5achzTSEe2g6rtd7Hf7cA" type="3007" element="_l477YjTSEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_l5acijTSEe2g6rtd7Hf7cA" type="5003">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_l5acizTSEe2g6rtd7Hf7cA" y="5"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_l5bDljTSEe2g6rtd7Hf7cA" type="3003" element="_l477YzTSEe2g6rtd7Hf7cA">
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_l5bDlzTSEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5bDmDTSEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_l5aciDTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5aciTTSEe2g6rtd7Hf7cA" x="170" y="60" width="100" height="50"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_l5Z1cjTSEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_l5Z1czTSEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_l5Z1dDTSEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_l5ZOaDTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5ZOaTTSEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_l5ZOZTTSEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_l5ZOZjTSEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5ZOYTTSEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5ZOYjTSEe2g6rtd7Hf7cA" x="830" y="410"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_k9CT0jTSEe2g6rtd7Hf7cA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_l5df0DTSEe2g6rtd7Hf7cA" type="4001" element="_l477ZTTSEe2g6rtd7Hf7cA" source="_l5Z1dTTSEe2g6rtd7Hf7cA" target="_l5Z1ejTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5et8DTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5et8TTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5fVADTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5fVATTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5f8EDTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5f8ETTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5df0TTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5df0jTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5df0zTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5gjIDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5hKMDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5hKMTTSEe2g6rtd7Hf7cA" type="4001" element="_l48icDTSEe2g6rtd7Hf7cA" source="_l5Z1fzTSEe2g6rtd7Hf7cA" target="_l5achzTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5hxQDTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5hxQTTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5hxQjTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5hxQzTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5hxRDTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5hxRTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5hKMjTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5hKMzTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5hKNDTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5hxRjTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5hxRzTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5hxSDTSEe2g6rtd7Hf7cA" type="4001" element="_l48idTTSEe2g6rtd7Hf7cA" source="_l5Z1fzTSEe2g6rtd7Hf7cA" target="_l5acgjTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5iYUDTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYUTTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5iYUjTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYUzTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5iYVDTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYVTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5hxSTTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5hxSjTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5hxSzTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5iYVjTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5iYVzTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_l5iYWDTSEe2g6rtd7Hf7cA" type="4001" element="_l48iejTSEe2g6rtd7Hf7cA" source="_l5Z1ejTSEe2g6rtd7Hf7cA" target="_l5Z1fzTSEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_l5iYXDTSEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYXTTSEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5iYXjTSEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYXzTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_l5iYYDTSEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5iYYTTSEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_l5iYWTTSEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_l5iYWjTSEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_l5iYWzTSEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5i_YDTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_l5i_YTTSEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_k9Dh8DTSEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_k9Dh8TTSEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_l4wVMDTSEe2g6rtd7Hf7cA" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_l4yKYDTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_l46tQjTSEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_l46tQzTSEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_l46tRTTSEe2g6rtd7Hf7cA" name="PhysicalFunction 1" outgoingEdges="_l477ZTTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#ad5e608f-dc22-40d2-b1e6-c22e0758daf4"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_l46tRjTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_l47UUTTSEe2g6rtd7Hf7cA" name="PhysicalFunction 2" outgoingEdges="_l48iejTSEe2g6rtd7Hf7cA" incomingEdges="_l477ZTTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#3cccea9a-ddb0-48e3-84ec-8a3f0c593803"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_l47UUjTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_l47UVDTSEe2g6rtd7Hf7cA" name="PhysicalFunction 3" outgoingEdges="_l48icDTSEe2g6rtd7Hf7cA _l48idTTSEe2g6rtd7Hf7cA" incomingEdges="_l48iejTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#37e1cc57-29bc-4c64-8864-6a52e357e18f"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_l47UVTTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_l47UVzTSEe2g6rtd7Hf7cA" name="PhysicalFunction 4" incomingEdges="_l48idTTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#4d89ed09-6e83-4542-95a4-d32ec4d20c5b"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_l477YDTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_l477YjTSEe2g6rtd7Hf7cA" name="PhysicalFunction 5" incomingEdges="_l48icDTSEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#47447e6b-896e-4e08-af71-8087110dda1f"/>
+          <ownedStyle xmi:type="diagram:Square" uid="_l477YzTSEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+            <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l477ZTTSEe2g6rtd7Hf7cA" name="FunctionalExchange 1" sourceNode="_l46tRTTSEe2g6rtd7Hf7cA" targetNode="_l47UUTTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#6fd8df09-4eec-4b53-a6cd-38e5522c453a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l477ZjTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l477ZzTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l48icDTSEe2g6rtd7Hf7cA" name="FunctionalExchange 5" sourceNode="_l47UVDTSEe2g6rtd7Hf7cA" targetNode="_l477YjTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#80c31274-9a29-45a8-80bf-d520bc55d72d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l48icTTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l48icjTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l48idTTSEe2g6rtd7Hf7cA" name="FunctionalExchange 3" sourceNode="_l47UVDTSEe2g6rtd7Hf7cA" targetNode="_l47UVzTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#738c9f6f-dff9-44e6-8be0-c6686885b7f6"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l48idjTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l48idzTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_l48iejTSEe2g6rtd7Hf7cA" name="FunctionalExchange 2" sourceNode="_l47UUTTSEe2g6rtd7Hf7cA" targetNode="_l47UVDTSEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#568784e4-2e0c-45f2-8b70-adef2e94dab3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_l48iezTSEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_l48ifDTSEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_k9BFsTTSEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_DeKT0DTTEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_DeLh8DTTEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_DeLh8TTTEe2g6rtd7Hf7cA" type="Sirius" element="_DeKT0DTTEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_7guGsDTTEe2g6rtd7Hf7cA" type="2002" element="_7f_t8DTTEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_7gutwDTTEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_7gutwTTTEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_7gutxDTTEe2g6rtd7Hf7cA" type="3008" element="_7gVsMTTTEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_7gutxzTTEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_7gvU0DTTEe2g6rtd7Hf7cA" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_7gvU1DTTEe2g6rtd7Hf7cA" type="3008" element="_7gVsNDTTEe2g6rtd7Hf7cA">
+                  <children xmi:type="notation:Node" xmi:id="_7gvU1zTTEe2g6rtd7Hf7cA" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_7gvU2DTTEe2g6rtd7Hf7cA" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_7gvU2zTTEe2g6rtd7Hf7cA" type="3008" element="_7gVsNzTTEe2g6rtd7Hf7cA">
+                      <children xmi:type="notation:Node" xmi:id="_7gvU3jTTEe2g6rtd7Hf7cA" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_7gvU3zTTEe2g6rtd7Hf7cA" type="7002">
+                        <children xmi:type="notation:Node" xmi:id="_7gvU4zTTEe2g6rtd7Hf7cA" type="3008" element="_7gWTQTTTEe2g6rtd7Hf7cA">
+                          <children xmi:type="notation:Node" xmi:id="_7gvU5jTTEe2g6rtd7Hf7cA" type="5005"/>
+                          <children xmi:type="notation:Node" xmi:id="_7gvU5zTTEe2g6rtd7Hf7cA" type="7002">
+                            <children xmi:type="notation:Node" xmi:id="_7gv74DTTEe2g6rtd7Hf7cA" type="3008" element="_7gWTRDTTEe2g6rtd7Hf7cA">
+                              <children xmi:type="notation:Node" xmi:id="_7gv74zTTEe2g6rtd7Hf7cA" type="5005"/>
+                              <children xmi:type="notation:Node" xmi:id="_7gv75DTTEe2g6rtd7Hf7cA" type="7002">
+                                <children xmi:type="notation:Node" xmi:id="_7gv76DTTEe2g6rtd7Hf7cA" type="3007" element="_7gWTRzTTEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_7gv76zTTEe2g6rtd7Hf7cA" type="5003">
+                                    <layoutConstraint xmi:type="notation:Location" xmi:id="_7gv77DTTEe2g6rtd7Hf7cA" y="5"/>
+                                  </children>
+                                  <children xmi:type="notation:Node" xmi:id="_7gwi_DTTEe2g6rtd7Hf7cA" type="3003" element="_7gWTSDTTEe2g6rtd7Hf7cA">
+                                    <styles xmi:type="notation:ShapeStyle" xmi:id="_7gwi_TTTEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gwi_jTTEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gv76TTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gv76jTTEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                </children>
+                                <children xmi:type="notation:Node" xmi:id="_7gv77TTTEe2g6rtd7Hf7cA" type="3007" element="_7gW6UTTTEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_7gv78DTTEe2g6rtd7Hf7cA" type="5003">
+                                    <layoutConstraint xmi:type="notation:Location" xmi:id="_7gv78TTTEe2g6rtd7Hf7cA" y="5"/>
+                                  </children>
+                                  <children xmi:type="notation:Node" xmi:id="_7gxKADTTEe2g6rtd7Hf7cA" type="3003" element="_7gW6UjTTEe2g6rtd7Hf7cA">
+                                    <styles xmi:type="notation:ShapeStyle" xmi:id="_7gxKATTTEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxKAjTTEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gv77jTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gv77zTTEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                </children>
+                                <children xmi:type="notation:Node" xmi:id="_7gv78jTTEe2g6rtd7Hf7cA" type="3007" element="_7gW6VDTTEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_7gwi8DTTEe2g6rtd7Hf7cA" type="5003">
+                                    <layoutConstraint xmi:type="notation:Location" xmi:id="_7gwi8TTTEe2g6rtd7Hf7cA" y="5"/>
+                                  </children>
+                                  <children xmi:type="notation:Node" xmi:id="_7gxKAzTTEe2g6rtd7Hf7cA" type="3003" element="_7gW6VTTTEe2g6rtd7Hf7cA">
+                                    <styles xmi:type="notation:ShapeStyle" xmi:id="_7gxKBDTTEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxKBTTTEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gv78zTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gv79DTTEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                </children>
+                                <children xmi:type="notation:Node" xmi:id="_7gwi8jTTEe2g6rtd7Hf7cA" type="3007" element="_7gXhYTTTEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_7gwi9TTTEe2g6rtd7Hf7cA" type="5003">
+                                    <layoutConstraint xmi:type="notation:Location" xmi:id="_7gwi9jTTEe2g6rtd7Hf7cA" y="5"/>
+                                  </children>
+                                  <children xmi:type="notation:Node" xmi:id="_7gxKBjTTEe2g6rtd7Hf7cA" type="3003" element="_7gXhYjTTEe2g6rtd7Hf7cA">
+                                    <styles xmi:type="notation:ShapeStyle" xmi:id="_7gxKBzTTEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxKCDTTEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gwi8zTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gwi9DTTEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                </children>
+                                <children xmi:type="notation:Node" xmi:id="_7gwi9zTTEe2g6rtd7Hf7cA" type="3007" element="_7gXhZDTTEe2g6rtd7Hf7cA">
+                                  <children xmi:type="notation:Node" xmi:id="_7gwi-jTTEe2g6rtd7Hf7cA" type="5003">
+                                    <layoutConstraint xmi:type="notation:Location" xmi:id="_7gwi-zTTEe2g6rtd7Hf7cA" y="5"/>
+                                  </children>
+                                  <children xmi:type="notation:Node" xmi:id="_7gxKCTTTEe2g6rtd7Hf7cA" type="3003" element="_7gXhZTTTEe2g6rtd7Hf7cA">
+                                    <styles xmi:type="notation:ShapeStyle" xmi:id="_7gxKCjTTEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxKCzTTEe2g6rtd7Hf7cA"/>
+                                  </children>
+                                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gwi-DTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gwi-TTTEe2g6rtd7Hf7cA" width="100" height="50"/>
+                                </children>
+                                <styles xmi:type="notation:SortingStyle" xmi:id="_7gv75TTTEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:FilteringStyle" xmi:id="_7gv75jTTEe2g6rtd7Hf7cA"/>
+                                <styles xmi:type="notation:DrawerStyle" xmi:id="_7gv75zTTEe2g6rtd7Hf7cA"/>
+                              </children>
+                              <styles xmi:type="notation:ShapeStyle" xmi:id="_7gv74TTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gv74jTTEe2g6rtd7Hf7cA"/>
+                            </children>
+                            <styles xmi:type="notation:SortingStyle" xmi:id="_7gvU6DTTEe2g6rtd7Hf7cA"/>
+                            <styles xmi:type="notation:FilteringStyle" xmi:id="_7gvU6TTTEe2g6rtd7Hf7cA"/>
+                          </children>
+                          <styles xmi:type="notation:ShapeStyle" xmi:id="_7gvU5DTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gvU5TTTEe2g6rtd7Hf7cA"/>
+                        </children>
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_7gvU4DTTEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_7gvU4TTTEe2g6rtd7Hf7cA"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_7gvU4jTTEe2g6rtd7Hf7cA"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_7gvU3DTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gvU3TTTEe2g6rtd7Hf7cA"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_7gvU2TTTEe2g6rtd7Hf7cA"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_7gvU2jTTEe2g6rtd7Hf7cA"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_7gvU1TTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gvU1jTTEe2g6rtd7Hf7cA" x="160" y="70"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_7gvU0TTTEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_7gvU0jTTEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_7gvU0zTTEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_7gutxTTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gutxjTTEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_7gutwjTTEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_7gutwzTTEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_7guGsTTTEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7guGsjTTEe2g6rtd7Hf7cA" x="800" y="420"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_DeLh8jTTEe2g6rtd7Hf7cA"/>
+        <edges xmi:type="notation:Edge" xmi:id="_7gxxEDTTEe2g6rtd7Hf7cA" type="4001" element="_7gYIcDTTEe2g6rtd7Hf7cA" source="_7gv76DTTEe2g6rtd7Hf7cA" target="_7gv77TTTEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_7gxxFDTTEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxxFTTTEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gxxFjTTEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxxFzTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gxxGDTTEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gxxGTTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7gxxETTTEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7gxxEjTTEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7gxxEzTTEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gyYIDTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gyYITTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_7gyYIjTTEe2g6rtd7Hf7cA" type="4001" element="_7gZWkjTTEe2g6rtd7Hf7cA" source="_7gv78jTTEe2g6rtd7Hf7cA" target="_7gwi9zTTEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_7gyYJjTTEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gyYJzTTEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gyYKDTTEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gyYKTTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gyYKjTTEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gyYKzTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7gyYIzTTEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7gyYJDTTEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7gyYJTTTEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gyYLDTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gyYLTTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_7gyYLjTTEe2g6rtd7Hf7cA" type="4001" element="_7gZWlzTTEe2g6rtd7Hf7cA" source="_7gv78jTTEe2g6rtd7Hf7cA" target="_7gwi8jTTEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_7gy_MDTTEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_MTTTEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gy_MjTTEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_MzTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gy_NDTTEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_NTTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7gyYLzTTEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7gyYMDTTEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7gyYMTTTEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gy_NjTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gy_NzTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_7gy_ODTTEe2g6rtd7Hf7cA" type="4001" element="_7gZ9oDTTEe2g6rtd7Hf7cA" source="_7gv77TTTEe2g6rtd7Hf7cA" target="_7gv78jTTEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_7gy_PDTTEe2g6rtd7Hf7cA" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_PTTTEe2g6rtd7Hf7cA" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gy_PjTTEe2g6rtd7Hf7cA" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_PzTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7gy_QDTTEe2g6rtd7Hf7cA" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7gy_QTTTEe2g6rtd7Hf7cA" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7gy_OTTTEe2g6rtd7Hf7cA" routing="Rectilinear" jumpLinkStatus="Above" jumpLinkType="Tunnel"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7gy_OjTTEe2g6rtd7Hf7cA" fontColor="3038217" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7gy_OzTTEe2g6rtd7Hf7cA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gzmQDTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7gzmQTTTEe2g6rtd7Hf7cA" id="(0.5,0.5)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_DeMwEDTTEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_DeMwETTTEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7f_t8DTTEe2g6rtd7Hf7cA" name="FunctionalChain PF2" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#a8c392f0-06c6-4b71-b840-d53f22998171"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#a8c392f0-06c6-4b71-b840-d53f22998171"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gCKMDTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7gVsMTTTEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gVsMjTTEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7gVsNDTTEe2g6rtd7Hf7cA" name="FunctionalChain PF1" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#99518288-f8ae-4115-8241-5c8e0306ce5a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#99518288-f8ae-4115-8241-5c8e0306ce5a"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gVsNTTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7gVsNzTTEe2g6rtd7Hf7cA">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gVsODTTEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+            <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7gWTQTTTEe2g6rtd7Hf7cA" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+              <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#58bd1c51-909e-4b35-a723-b41d74815fa6"/>
+              <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+              <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gWTQjTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+                <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+              <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_7gWTRDTTEe2g6rtd7Hf7cA">
+                <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+                <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+                <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7gWTRTTTEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+                  <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+                </ownedStyle>
+                <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+                <ownedDiagramElements xmi:type="diagram:DNode" uid="_7gWTRzTTEe2g6rtd7Hf7cA" name="PhysicalFunction 1" outgoingEdges="_7gYIcDTTEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#f6e6de5c-d9a2-4bee-9fd6-33f6f30bbb2c"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#ad5e608f-dc22-40d2-b1e6-c22e0758daf4"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_7gWTSDTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                    <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                </ownedDiagramElements>
+                <ownedDiagramElements xmi:type="diagram:DNode" uid="_7gW6UTTTEe2g6rtd7Hf7cA" name="PhysicalFunction 2" outgoingEdges="_7gZ9oDTTEe2g6rtd7Hf7cA" incomingEdges="_7gYIcDTTEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#3c2b4d67-dbf3-4441-a374-bb4a41122270"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#3cccea9a-ddb0-48e3-84ec-8a3f0c593803"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_7gW6UjTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                    <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                </ownedDiagramElements>
+                <ownedDiagramElements xmi:type="diagram:DNode" uid="_7gW6VDTTEe2g6rtd7Hf7cA" name="PhysicalFunction 3" outgoingEdges="_7gZWkjTTEe2g6rtd7Hf7cA _7gZWlzTTEe2g6rtd7Hf7cA" incomingEdges="_7gZ9oDTTEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#08299572-6488-41b2-99e8-ae389ae3f5a5"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#37e1cc57-29bc-4c64-8864-6a52e357e18f"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_7gW6VTTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                    <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                </ownedDiagramElements>
+                <ownedDiagramElements xmi:type="diagram:DNode" uid="_7gXhYTTTEe2g6rtd7Hf7cA" name="PhysicalFunction 4" incomingEdges="_7gZWlzTTEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#b61d3e35-ccce-4532-baaa-a2b8d019cbde"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#4d89ed09-6e83-4542-95a4-d32ec4d20c5b"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_7gXhYjTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                    <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                </ownedDiagramElements>
+                <ownedDiagramElements xmi:type="diagram:DNode" uid="_7gXhZDTTEe2g6rtd7Hf7cA" name="PhysicalFunction 5" incomingEdges="_7gZWkjTTEe2g6rtd7Hf7cA" width="10" height="5" resizeKind="NSEW">
+                  <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction" href="SemanticQueries.capella#20c79960-1642-4eda-9236-c6e2c71b4b2a"/>
+                  <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalFunction" href="SemanticQueries.capella#47447e6b-896e-4e08-af71-8087110dda1f"/>
+                  <ownedStyle xmi:type="diagram:Square" uid="_7gXhZTTTEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="9,92,46" labelPosition="node" width="10" height="5" color="197,255,166">
+                    <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']/@style"/>
+                  </ownedStyle>
+                  <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@nodeMappings[name='FC_AbstractFunction']"/>
+                </ownedDiagramElements>
+              </ownedDiagramElements>
+            </ownedDiagramElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7gYIcDTTEe2g6rtd7Hf7cA" name="FunctionalExchange 1" sourceNode="_7gWTRzTTEe2g6rtd7Hf7cA" targetNode="_7gW6UTTTEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3365244d-5601-4dc5-a119-ead619ef30d7"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#6fd8df09-4eec-4b53-a6cd-38e5522c453a"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_7gYvgDTTEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_7gYvgTTTEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7gZWkjTTEe2g6rtd7Hf7cA" name="FunctionalExchange 5" sourceNode="_7gW6VDTTEe2g6rtd7Hf7cA" targetNode="_7gXhZDTTEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#3261eb64-4e47-4f7d-954d-2e9a5d90b600"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#80c31274-9a29-45a8-80bf-d520bc55d72d"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_7gZWkzTTEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_7gZWlDTTEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7gZWlzTTEe2g6rtd7Hf7cA" name="FunctionalExchange 3" sourceNode="_7gW6VDTTEe2g6rtd7Hf7cA" targetNode="_7gXhYTTTEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#ee529313-72a7-4690-9454-70df6259d71b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#738c9f6f-dff9-44e6-8be0-c6686885b7f6"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_7gZWmDTTEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_7gZWmTTTEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7gZ9oDTTEe2g6rtd7Hf7cA" name="FunctionalExchange 2" sourceNode="_7gW6UTTTEe2g6rtd7Hf7cA" targetNode="_7gW6VDTTEe2g6rtd7Hf7cA">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementLink" href="SemanticQueries.capella#26180a63-8562-4ab9-8218-260a7e4e3f8b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalExchange" href="SemanticQueries.capella#568784e4-2e0c-45f2-8b70-adef2e94dab3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_7gZ9oTTTEe2g6rtd7Hf7cA" routingStyle="manhattan" strokeColor="9,92,46">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_7gZ9ojTTEe2g6rtd7Hf7cA" labelColor="9,92,46"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@edgeMappings[name='FC_Exchange']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_DeKT0TTTEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#3c9bb195-0cf8-4c6c-a815-53fabe987c38"/>
+  </diagram:DSemanticDiagram>
+  <diagram:DSemanticDiagram uid="_Rgf5QDTrEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_RghucDTrEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_RghucTTrEe2g6rtd7Hf7cA" type="Sirius" element="_Rgf5QDTrEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_SIzPYDTrEe2g6rtd7Hf7cA" type="2002" element="_SIIhADTrEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_SIz2cDTrEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_SIz2cTTrEe2g6rtd7Hf7cA" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_SIz2dDTrEe2g6rtd7Hf7cA" type="3008" element="_SIYYojTrEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_SIz2dzTrEe2g6rtd7Hf7cA" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_SI0dgDTrEe2g6rtd7Hf7cA" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_SI0dgTTrEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_SI0dgjTrEe2g6rtd7Hf7cA"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_SI0dgzTrEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_SIz2dTTrEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SIz2djTrEe2g6rtd7Hf7cA"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_SIz2cjTrEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_SIz2czTrEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_SIzPYTTrEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SIzPYjTrEe2g6rtd7Hf7cA" x="770" y="500"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_RghucjTrEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Rgi8kDTrEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Rgi8kTTrEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_SIIhADTrEe2g6rtd7Hf7cA" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#894ffa4e-0137-49b7-bf1c-4e5831e0cb54"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#894ffa4e-0137-49b7-bf1c-4e5831e0cb54"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_SIK9QDTrEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_SIYYojTrEe2g6rtd7Hf7cA">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_SIYYozTrEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_Rgf5QTTrEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#b6239773-1e55-4328-b538-21701efb4ab2"/>
+  </diagram:DSemanticDiagram>
+  <sequence:SequenceDDiagram uid="_XlzjQDTuEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Xl0xZTTuEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_Xl0xZjTuEe2g6rtd7Hf7cA" type="Sirius" element="_XlzjQDTuEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_Zgu-4DTuEe2g6rtd7Hf7cA" type="2001" element="_ZfwugjTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Zgu-4zTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zgu-5DTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZgxbJzTuEe2g6rtd7Hf7cA" type="3001" element="_ZfxVkjTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZgxbKjTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgxbKzTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZgypQDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfxVkzTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgypQTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgypQjTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZgypQzTuEe2g6rtd7Hf7cA" type="3001" element="_ZfxVlDTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZgypRjTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgypRzTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_Zg4I0DTuEe2g6rtd7Hf7cA" type="3005" element="_ZfxVlTTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_Zg4I0TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg4I0jTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgypRDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgypRTTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgxbKDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgxbKTTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZgyCMDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfxVkDTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgyCMTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgyCMjTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgu-4TTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgu-4jTuEe2g6rtd7Hf7cA" x="1634" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Zgvl8DTuEe2g6rtd7Hf7cA" type="2001" element="_ZfvgYDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Zgvl8zTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zgvl9DTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Zg4I0zTuEe2g6rtd7Hf7cA" type="3001" element="_ZfwHcTTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_Zg4I1jTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_Zg4I1zTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Zg4v4zTuEe2g6rtd7Hf7cA" type="3003" element="_ZfwHcjTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Zg4v5DTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg4v5TTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_Zg4v5jTuEe2g6rtd7Hf7cA" type="3001" element="_ZfwugDTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_Zg4v6TTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Zg4v6jTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhCg4DTuEe2g6rtd7Hf7cA" type="3005" element="_ZfwugTTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhCg4TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhCg4jTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_Zg4v5zTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg4v6DTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Zg4I1DTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg4I1TTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_Zg4v4DTuEe2g6rtd7Hf7cA" type="3003" element="_ZfvgYTTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_Zg4v4TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg4v4jTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgvl8TTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgvl8jTuEe2g6rtd7Hf7cA" x="1794" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Zgvl9TTuEe2g6rtd7Hf7cA" type="2001" element="_ZfuSRjTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Zgvl-DTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zgvl-TTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhCg4zTuEe2g6rtd7Hf7cA" type="3001" element="_Zfu5UTTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhCg5jTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhCg5zTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhDH8zTuEe2g6rtd7Hf7cA" type="3003" element="_Zfu5UjTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhDH9DTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhDH9TTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhDH9jTuEe2g6rtd7Hf7cA" type="3001" element="_Zfu5UzTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhDH-TTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhDH-jTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhIAcDTuEe2g6rtd7Hf7cA" type="3005" element="_Zfu5VDTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhIAcTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhIAcjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhDH9zTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhDH-DTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhCg5DTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhCg5TTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhDH8DTuEe2g6rtd7Hf7cA" type="3003" element="_ZfuSRzTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhDH8TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhDH8jTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgvl9jTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgvl9zTuEe2g6rtd7Hf7cA" x="1954" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Zgvl-jTuEe2g6rtd7Hf7cA" type="2001" element="_ZftrNzTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ZgwNADTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgwNATTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhIAczTuEe2g6rtd7Hf7cA" type="3001" element="_ZfuSQjTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhIAdjTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhIAdzTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhIngDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfuSQzTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhIngTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhIngjTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhIngzTuEe2g6rtd7Hf7cA" type="3001" element="_ZfuSRDTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhInhjTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhInhzTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhMR4DTuEe2g6rtd7Hf7cA" type="3005" element="_ZfuSRTTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhMR4TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhMR4jTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhInhDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhInhTTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhIAdDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhIAdTTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhIAeDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfuSQDTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhIAeTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhIAejTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgvl-zTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgvl_DTuEe2g6rtd7Hf7cA" x="2114" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ZgwNAjTuEe2g6rtd7Hf7cA" type="2001" element="_ZftEIDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ZgwNBTTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgwNBjTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhM48DTuEe2g6rtd7Hf7cA" type="3001" element="_ZftEIzTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhM48zTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhM49DTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhM4-DTuEe2g6rtd7Hf7cA" type="3003" element="_ZftEJDTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhM4-TTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhM4-jTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhM4-zTuEe2g6rtd7Hf7cA" type="3001" element="_ZftEJTTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhM4_jTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhM4_zTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhQjUDTuEe2g6rtd7Hf7cA" type="3005" element="_ZftEJjTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhQjUTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhQjUjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhM4_DTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhM4_TTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhM48TTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhM48jTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhM49TTuEe2g6rtd7Hf7cA" type="3003" element="_ZftEITTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhM49jTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhM49zTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgwNAzTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgwNBDTuEe2g6rtd7Hf7cA" x="2434" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ZgwNBzTuEe2g6rtd7Hf7cA" type="2001" element="_ZfsdEDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Zgw0EDTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zgw0ETTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhRKYDTuEe2g6rtd7Hf7cA" type="3001" element="_ZfsdEzTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhRKYzTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhRKZDTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhRKaDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfsdFDTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhRKaTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhRKajTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhRKazTuEe2g6rtd7Hf7cA" type="3001" element="_ZfsdFTTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhRKbjTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhRKbzTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhUNsDTuEe2g6rtd7Hf7cA" type="3005" element="_ZfsdFjTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhUNsTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhUNsjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhRKbDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhRKbTTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhRKYTTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhRKYjTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhRKZTTuEe2g6rtd7Hf7cA" type="3003" element="_ZfsdETTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhRKZjTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhRKZzTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgwNCDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgwNCTTuEe2g6rtd7Hf7cA" x="2594" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Zgw0EjTuEe2g6rtd7Hf7cA" type="2001" element="_ZfrO8DTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_Zgw0FTTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_Zgw0FjTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhUNszTuEe2g6rtd7Hf7cA" type="3001" element="_Zfr2AjTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhUNtjTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhUNtzTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhUNuzTuEe2g6rtd7Hf7cA" type="3003" element="_Zfr2AzTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhUNvDTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhUNvTTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhU0wDTuEe2g6rtd7Hf7cA" type="3001" element="_Zfr2BDTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhU0wzTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhU0xDTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhYfIDTuEe2g6rtd7Hf7cA" type="3005" element="_Zfr2BTTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhYfITTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhYfIjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhU0wTTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhU0wjTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhUNtDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhUNtTTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhUNuDTuEe2g6rtd7Hf7cA" type="3003" element="_Zfr2ADTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhUNuTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhUNujTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgw0EzTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgw0FDTuEe2g6rtd7Hf7cA" x="2754" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_Zgw0FzTuEe2g6rtd7Hf7cA" type="2001" element="_ZftrMDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ZgxbIDTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgxbITTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhYfIzTuEe2g6rtd7Hf7cA" type="3001" element="_ZftrMzTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhYfJjTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhYfJzTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhYfKzTuEe2g6rtd7Hf7cA" type="3003" element="_ZftrNDTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhYfLDTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhYfLTTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhZGMDTuEe2g6rtd7Hf7cA" type="3001" element="_ZftrNTTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhZGMzTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhZGNDTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhcwkDTuEe2g6rtd7Hf7cA" type="3005" element="_ZftrNjTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhcwkTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhcwkjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhZGMTTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhZGMjTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhYfJDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhYfJTTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhYfKDTuEe2g6rtd7Hf7cA" type="3003" element="_ZftrMTTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhYfKTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhYfKjTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_Zgw0GDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zgw0GTTuEe2g6rtd7Hf7cA" x="2274" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_ZgxbIjTuEe2g6rtd7Hf7cA" type="2001" element="_Zfm9gDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_ZgxbJTTuEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgxbJjTuEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhdXoDTuEe2g6rtd7Hf7cA" type="3001" element="_ZfqA0DTuEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_ZhdXozTuEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhdXpDTuEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhdXqDTuEe2g6rtd7Hf7cA" type="3003" element="_ZfqA0TTuEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhdXqTTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhdXqjTuEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZhdXqzTuEe2g6rtd7Hf7cA" type="3001" element="_ZfqA0jTuEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_ZhdXrjTuEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZhdXrzTuEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZhhCADTuEe2g6rtd7Hf7cA" type="3005" element="_ZfqA0zTuEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhhCATTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhhCAjTuEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhdXrDTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhdXrTTuEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhdXoTTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhdXojTuEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ZhdXpTTuEe2g6rtd7Hf7cA" type="3003" element="_ZfpZwDTuEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ZhdXpjTuEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZhdXpzTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_ZgxbIzTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgxbJDTuEe2g6rtd7Hf7cA" x="2914" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_a22dQDTuEe2g6rtd7Hf7cA" type="2002" element="_a11woDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_a23rYDTuEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_a23rYTTuEe2g6rtd7Hf7cA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_a24ScDTuEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_a24ScTTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_a22dQTTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_a22dQjTuEe2g6rtd7Hf7cA" x="1634" y="225" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_bgfQIDTuEe2g6rtd7Hf7cA" type="2002" element="_bfo7kDTuEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_bgfQIzTuEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_bgfQJDTuEe2g6rtd7Hf7cA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_bgfQJTTuEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_bgfQJjTuEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_bgfQITTuEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bgfQIjTuEe2g6rtd7Hf7cA" x="1634" y="320" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_Xl0xZzTuEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_Xl3NoDTuEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_Xl3NoTTuEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZfwugjTuEe2g6rtd7Hf7cA" name="PC 8" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1fa15c33-8d42-4520-942d-0b089dec3717"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#30ecad95-922c-4010-bbc8-8d0533dd54d3"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8qDTuEe2g6rtd7Hf7cA" x="1634" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfxVkjTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1fa15c33-8d42-4520-942d-0b089dec3717"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#30ecad95-922c-4010-bbc8-8d0533dd54d3"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfxVlDTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1fa15c33-8d42-4520-942d-0b089dec3717"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#30ecad95-922c-4010-bbc8-8d0533dd54d3"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZfxVlTTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZfxVkzTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfxVkDTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZfvgYDTuEe2g6rtd7Hf7cA" name="PC 7" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#13e3be35-3237-45f6-a6f6-e0b06a39df8c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#11baccf1-04e6-464a-97f0-7656deb231d8"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8pzTuEe2g6rtd7Hf7cA" x="1794" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfwHcTTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#13e3be35-3237-45f6-a6f6-e0b06a39df8c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#11baccf1-04e6-464a-97f0-7656deb231d8"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfwugDTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#e2080f3e-10cd-4596-86e0-bc5d535b7a62"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#13e3be35-3237-45f6-a6f6-e0b06a39df8c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#11baccf1-04e6-464a-97f0-7656deb231d8"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZfwugTTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZfwHcjTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfvgYTTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZfuSRjTuEe2g6rtd7Hf7cA" name="PC 6" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7e2d8bf4-955c-4a39-ac9f-f69dc5999bd0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#079312e2-5a31-422a-a1dc-bffec29272af"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8pjTuEe2g6rtd7Hf7cA" x="1954" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Zfu5UTTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7e2d8bf4-955c-4a39-ac9f-f69dc5999bd0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#079312e2-5a31-422a-a1dc-bffec29272af"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Zfu5UzTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7e2d8bf4-955c-4a39-ac9f-f69dc5999bd0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#079312e2-5a31-422a-a1dc-bffec29272af"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_Zfu5VDTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Zfu5UjTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfuSRzTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZftrNzTuEe2g6rtd7Hf7cA" name="PC 5" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#405d6489-f89d-4805-9a5d-480b8b504dd6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#4a86e83d-e6a6-4c11-bd5f-af56c50ee473"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8pTTuEe2g6rtd7Hf7cA" x="2114" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfuSQjTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#405d6489-f89d-4805-9a5d-480b8b504dd6"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#4a86e83d-e6a6-4c11-bd5f-af56c50ee473"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfuSRDTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1d701eb1-10af-4255-984c-ab9a60196747"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#405d6489-f89d-4805-9a5d-480b8b504dd6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#4a86e83d-e6a6-4c11-bd5f-af56c50ee473"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZfuSRTTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZfuSQzTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfuSQDTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZftrMDTuEe2g6rtd7Hf7cA" name="PC 4" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7a2be8cb-50df-4a69-8e66-341ec4af49f2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#bb8255ea-fa5d-4b4f-a00e-91ae2a1c3e9b"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8pDTuEe2g6rtd7Hf7cA" x="2274" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZftrMzTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7a2be8cb-50df-4a69-8e66-341ec4af49f2"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#bb8255ea-fa5d-4b4f-a00e-91ae2a1c3e9b"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZftrNTTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#45d814e6-8285-49cb-986a-fb627831d5ba"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#7a2be8cb-50df-4a69-8e66-341ec4af49f2"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#bb8255ea-fa5d-4b4f-a00e-91ae2a1c3e9b"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZftrNjTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZftrNDTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZftrMTTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZftEIDTuEe2g6rtd7Hf7cA" name="PC 3" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#98c43024-ab50-4f5c-8370-bee95c8d2dd0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#ab720153-5d1c-4e28-a370-0e813162e606"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8ozTuEe2g6rtd7Hf7cA" x="2434" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZftEIzTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#98c43024-ab50-4f5c-8370-bee95c8d2dd0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#ab720153-5d1c-4e28-a370-0e813162e606"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZftEJTTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#d4d0f23c-d233-4f9b-92fc-20b73972dc21"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#98c43024-ab50-4f5c-8370-bee95c8d2dd0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#ab720153-5d1c-4e28-a370-0e813162e606"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZftEJjTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZftEJDTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZftEITTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZfsdEDTuEe2g6rtd7Hf7cA" name="PC 2" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1a6df9a0-a2a1-4b72-a8c6-2f193ba177c0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#f0c6b3f1-e04d-4a92-95a4-5385f51375c8"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8ojTuEe2g6rtd7Hf7cA" x="2594" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfsdEzTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1a6df9a0-a2a1-4b72-a8c6-2f193ba177c0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#f0c6b3f1-e04d-4a92-95a4-5385f51375c8"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfsdFTTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#1569f44a-c309-4b42-a7e6-13a4e8898ebe"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1a6df9a0-a2a1-4b72-a8c6-2f193ba177c0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#f0c6b3f1-e04d-4a92-95a4-5385f51375c8"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZfsdFjTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZfsdFDTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfsdETTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ZfrO8DTuEe2g6rtd7Hf7cA" name="PC 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#93116056-6175-47aa-9c8e-85c2b3037333"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#dc6a9822-ef9f-46e5-a608-582c6993c767"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8oTTuEe2g6rtd7Hf7cA" x="2754" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Zfr2AjTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#93116056-6175-47aa-9c8e-85c2b3037333"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#dc6a9822-ef9f-46e5-a608-582c6993c767"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Zfr2BDTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#c16430c6-dae4-4972-8735-0a89be0c42d5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#93116056-6175-47aa-9c8e-85c2b3037333"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#dc6a9822-ef9f-46e5-a608-582c6993c767"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_Zfr2BTTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_Zfr2AzTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_Zfr2ADTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" labelPosition="node" width="15" height="5" color="255,252,183">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.2/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_Zfm9gDTuEe2g6rtd7Hf7cA" name="Physical System" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#095b689f-42ae-4ac0-8757-a965fed981e0"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#9960e91c-faa7-4a99-8734-bd53ec6253da"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_Zfx8oDTuEe2g6rtd7Hf7cA" x="2914" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfqA0DTuEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#095b689f-42ae-4ac0-8757-a965fed981e0"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#9960e91c-faa7-4a99-8734-bd53ec6253da"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_ZfqA0jTuEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9a8ea205-e924-404d-9206-f7c2f73c00f9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#095b689f-42ae-4ac0-8757-a965fed981e0"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponent" href="SemanticQueries.capella#9960e91c-faa7-4a99-8734-bd53ec6253da"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ZfqA0zTuEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@borderedNodeMappings[name='endOfLifeDF']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_ZfqA0TTuEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@borderedNodeMappings[name='default%20execution%20DF']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_ZfpZwDTuEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="15" height="5" color="205,205,205">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']/@conditionnalStyles.3/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping%20DF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_a11woDTuEe2g6rtd7Hf7cA" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#e4e0a4c8-d722-481a-9993-d5dd0b7f8d34"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#e4e0a4c8-d722-481a-9993-d5dd0b7f8d34"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#c8da3939-669c-4812-b425-4fece2136f49"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:CapabilityRealization" href="SemanticQueries.capella#a51c707d-0591-43e7-8d87-3b49882745d9"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_a12XsTTuEe2g6rtd7Hf7cA" x="1634" y="225" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_a11woTTuEe2g6rtd7Hf7cA" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_bfo7kDTuEe2g6rtd7Hf7cA" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#bcad171e-e0a6-4a51-a33d-5bc9fd9fc807"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#bcad171e-e0a6-4a51-a33d-5bc9fd9fc807"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#2a0f6fef-c411-480c-be22-8f0231ece3f4"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:CapabilityRealization" href="SemanticQueries.capella#a51c707d-0591-43e7-8d87-3b49882745d9"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_bfpiojTuEe2g6rtd7Hf7cA" x="1634" y="320" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_bfpioDTuEe2g6rtd7Hf7cA" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUseDF']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_XlzjQTTuEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Exchanges%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#3cdd1abf-7b78-4f5e-af72-54c4bf6c9a93"/>
+  </sequence:SequenceDDiagram>
+  <sequence:SequenceDDiagram uid="_2mYC4DTvEe2g6rtd7Hf7cA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_2mZ4EDTvEe2g6rtd7Hf7cA" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_2mZ4ETTvEe2g6rtd7Hf7cA" type="Sirius" element="_2mYC4DTvEe2g6rtd7Hf7cA" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_3YqbcDTvEe2g6rtd7Hf7cA" type="2001" element="_3Xgk4DTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3YrCgDTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3YrCgTTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3YtexTTvEe2g6rtd7Hf7cA" type="3001" element="_3Xgk4zTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3YteyDTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3YteyTTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3YtezTTvEe2g6rtd7Hf7cA" type="3003" element="_3Xgk5DTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3YtezjTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YtezzTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Yte0DTvEe2g6rtd7Hf7cA" type="3001" element="_3Xgk5TTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3YuF0DTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3YuF0TTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3YyXQDTvEe2g6rtd7Hf7cA" type="3005" element="_3Xgk5jTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3YyXQTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YyXQjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Yte0TTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Yte0jTvEe2g6rtd7Hf7cA" x="2" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3YtexjTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YtexzTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3YteyjTvEe2g6rtd7Hf7cA" type="3003" element="_3Xgk4TTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3YteyzTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YtezDTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3YqbcTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YqbcjTvEe2g6rtd7Hf7cA" x="1025" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3YsQoDTvEe2g6rtd7Hf7cA" type="2001" element="_3Xf90DTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3YsQozTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3YsQpDTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3YyXQzTvEe2g6rtd7Hf7cA" type="3001" element="_3Xf90zTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3YyXRjTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3YyXRzTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Yy-UzTvEe2g6rtd7Hf7cA" type="3003" element="_3Xf91DTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Yy-VDTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Yy-VTTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Yy-VjTvEe2g6rtd7Hf7cA" type="3001" element="_3Xf91TTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3Yy-WTTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3Yy-WjTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3Y320DTvEe2g6rtd7Hf7cA" type="3005" element="_3Xf91jTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y320TTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y320jTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Yy-VzTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Yy-WDTvEe2g6rtd7Hf7cA" x="2" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3YyXRDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YyXRTTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3Yy-UDTvEe2g6rtd7Hf7cA" type="3003" element="_3Xf90TTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3Yy-UTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Yy-UjTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3YsQoTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YsQojTvEe2g6rtd7Hf7cA" x="1185" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3YsQpTTvEe2g6rtd7Hf7cA" type="2001" element="_3XfWwDTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3YsQqDTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3YsQqTTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3Y4d4DTvEe2g6rtd7Hf7cA" type="3001" element="_3XfWwzTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3Y4d4zTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3Y4d5DTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Y4d6DTvEe2g6rtd7Hf7cA" type="3003" element="_3XfWxDTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y4d6TTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y4d6jTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Y4d6zTvEe2g6rtd7Hf7cA" type="3001" element="_3XfWxTTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3Y4d7jTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3Y4d7zTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3Y7hMDTvEe2g6rtd7Hf7cA" type="3005" element="_3XfWxjTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y7hMTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y7hMjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y4d7DTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y4d7TTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y4d4TTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y4d4jTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3Y4d5TTvEe2g6rtd7Hf7cA" type="3003" element="_3XfWwTTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y4d5jTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y4d5zTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3YsQpjTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YsQpzTvEe2g6rtd7Hf7cA" x="1345" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3Ys3sDTvEe2g6rtd7Hf7cA" type="2001" element="_3XeIpjTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3Ys3szTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ys3tDTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3Y7hMzTvEe2g6rtd7Hf7cA" type="3001" element="_3XevsjTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3Y8IQDTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3Y8IQTTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Y8IRTTvEe2g6rtd7Hf7cA" type="3003" element="_3XevszTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y8IRjTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y8IRzTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3Y8ISDTvEe2g6rtd7Hf7cA" type="3001" element="_3XevtDTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3Y8ISzTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3Y8ITDTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZBAwDTvEe2g6rtd7Hf7cA" type="3005" element="_3XevtTTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZBAwTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZBAwjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y8ISTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y8ISjTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y7hNDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y7hNTTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3Y8IQjTvEe2g6rtd7Hf7cA" type="3003" element="_3XevsDTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3Y8IQzTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Y8IRDTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3Ys3sTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Ys3sjTvEe2g6rtd7Hf7cA" x="1505" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3Ys3tTTvEe2g6rtd7Hf7cA" type="2001" element="_3Xc6gDTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3Ys3uDTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ys3uTTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZBn0DTvEe2g6rtd7Hf7cA" type="3001" element="_3Xc6gzTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3ZBn0zTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZBn1DTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZBn2DTvEe2g6rtd7Hf7cA" type="3003" element="_3XdhkDTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZBn2TTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZBn2jTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZBn2zTvEe2g6rtd7Hf7cA" type="3001" element="_3XdhkTTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3ZCO4DTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZCO4TTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZF5QDTvEe2g6rtd7Hf7cA" type="3005" element="_3XdhkjTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZF5QTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZF5QjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZBn3DTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZBn3TTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZBn0TTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZBn0jTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZBn1TTvEe2g6rtd7Hf7cA" type="3003" element="_3Xc6gTTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZBn1jTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZBn1zTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3Ys3tjTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Ys3tzTvEe2g6rtd7Hf7cA" x="1825" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3Ys3ujTvEe2g6rtd7Hf7cA" type="2001" element="_3XcTcDTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3Ys3vTTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ys3vjTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZF5QzTvEe2g6rtd7Hf7cA" type="3001" element="_3XcTczTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3ZF5RjTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZF5RzTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZGgUDTvEe2g6rtd7Hf7cA" type="3003" element="_3XcTdDTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZGgUTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZGgUjTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZGgUzTvEe2g6rtd7Hf7cA" type="3001" element="_3XcTdTTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3ZGgVjTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZGgVzTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZKxwDTvEe2g6rtd7Hf7cA" type="3005" element="_3XcTdjTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZKxwTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZKxwjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZGgVDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZGgVTTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZF5RDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZF5RTTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZF5SDTvEe2g6rtd7Hf7cA" type="3003" element="_3XcTcTTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZF5STTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZF5SjTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3Ys3uzTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Ys3vDTvEe2g6rtd7Hf7cA" x="1985" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3Ys3vzTvEe2g6rtd7Hf7cA" type="2001" element="_3XbFUDTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3Ys3wjTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ys3wzTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZKxwzTvEe2g6rtd7Hf7cA" type="3001" element="_3XbFUzTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3ZLY0DTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZLY0TTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZLY1TTvEe2g6rtd7Hf7cA" type="3003" element="_3XbFVDTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZLY1jTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZLY1zTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZLY2DTvEe2g6rtd7Hf7cA" type="3001" element="_3XbFVTTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3ZLY2zTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZLY3DTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZPDMDTvEe2g6rtd7Hf7cA" type="3005" element="_3XbsYDTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZPDMTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZPDMjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZLY2TTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZLY2jTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZKxxDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZKxxTTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZLY0jTvEe2g6rtd7Hf7cA" type="3003" element="_3XbFUTTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZLY0zTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZLY1DTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3Ys3wDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Ys3wTTvEe2g6rtd7Hf7cA" x="2145" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3Ys3xDTvEe2g6rtd7Hf7cA" type="2001" element="_3XdhkzTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3Ys3xzTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3Ys3yDTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZPDMzTvEe2g6rtd7Hf7cA" type="3001" element="_3XeIojTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3ZPDNjTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZPDNzTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZPqQDTvEe2g6rtd7Hf7cA" type="3003" element="_3XeIozTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZPqQTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZPqQjTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZPqQzTvEe2g6rtd7Hf7cA" type="3001" element="_3XeIpDTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3ZPqRjTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZPqRzTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZStkDTvEe2g6rtd7Hf7cA" type="3005" element="_3XeIpTTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZTUoDTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZTUoTTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZPqRDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZPqRTTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZPDNDTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZPDNTTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZPDODTvEe2g6rtd7Hf7cA" type="3003" element="_3XeIoDTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZPDOTTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZPDOjTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3Ys3xTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3Ys3xjTvEe2g6rtd7Hf7cA" x="1665" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_3YtewDTvEe2g6rtd7Hf7cA" type="2001" element="_3XWM0DTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_3YtewzTvEe2g6rtd7Hf7cA" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_3YtexDTvEe2g6rtd7Hf7cA" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZTUojTvEe2g6rtd7Hf7cA" type="3001" element="_3XaeQDTvEe2g6rtd7Hf7cA">
+            <children xmi:type="notation:Node" xmi:id="_3ZTUpTTvEe2g6rtd7Hf7cA" type="5001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZTUpjTvEe2g6rtd7Hf7cA" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZTUqjTvEe2g6rtd7Hf7cA" type="3003" element="_3XaeQTTvEe2g6rtd7Hf7cA">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZTUqzTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZTUrDTvEe2g6rtd7Hf7cA"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_3ZTUrTTvEe2g6rtd7Hf7cA" type="3001" element="_3XaeQjTvEe2g6rtd7Hf7cA">
+              <children xmi:type="notation:Node" xmi:id="_3ZT7sDTvEe2g6rtd7Hf7cA" type="5001">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_3ZT7sTTvEe2g6rtd7Hf7cA" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_3ZW_ADTvEe2g6rtd7Hf7cA" type="3005" element="_3XaeQzTvEe2g6rtd7Hf7cA">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZW_ATTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZW_AjTvEe2g6rtd7Hf7cA"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZTUrjTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZTUrzTvEe2g6rtd7Hf7cA" x="-68" y="395" width="10" height="10"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZTUozTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZTUpDTvEe2g6rtd7Hf7cA" y="42" width="10" height="395"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_3ZTUpzTvEe2g6rtd7Hf7cA" type="3003" element="_3XWz4DTvEe2g6rtd7Hf7cA">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_3ZTUqDTvEe2g6rtd7Hf7cA" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3ZTUqTTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_3YtewTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3YtewjTvEe2g6rtd7Hf7cA" x="2305" y="50" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4O78IDTvEe2g6rtd7Hf7cA" type="2002" element="_4N-54DTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_4O78IzTvEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4O78JDTvEe2g6rtd7Hf7cA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4O78JTTvEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4O78JjTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4O78ITTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4O78IjTvEe2g6rtd7Hf7cA" x="1025" y="240" width="150" height="50"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_4xeogDTvEe2g6rtd7Hf7cA" type="2002" element="_4wqJIDTvEe2g6rtd7Hf7cA">
+          <children xmi:type="notation:Node" xmi:id="_4xeogzTvEe2g6rtd7Hf7cA" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_4xeohDTvEe2g6rtd7Hf7cA" type="7001">
+            <styles xmi:type="notation:SortingStyle" xmi:id="_4xeohTTvEe2g6rtd7Hf7cA"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_4xeohjTvEe2g6rtd7Hf7cA"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_4xeogTTvEe2g6rtd7Hf7cA" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4xeogjTvEe2g6rtd7Hf7cA" x="1025" y="360" width="150" height="50"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_2mZ4EjTvEe2g6rtd7Hf7cA"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_2mbtQDTvEe2g6rtd7Hf7cA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_2mbtQTTvEe2g6rtd7Hf7cA"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3Xgk4DTvEe2g6rtd7Hf7cA" name="[InterfaceCI] InterfaceCI 6" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bf40fdc-3d11-4b7d-8f7a-85158f10317c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL-DTvEe2g6rtd7Hf7cA" x="1025" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3Xgk4zTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bf40fdc-3d11-4b7d-8f7a-85158f10317c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3Xgk5TTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bf40fdc-3d11-4b7d-8f7a-85158f10317c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3Xgk5jTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3Xgk5DTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3Xgk4TTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3Xf90DTvEe2g6rtd7Hf7cA" name="[InterfaceCI] InterfaceCI 6" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#99f82ea1-a790-4ef1-acac-69df2b128cab"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL9zTvEe2g6rtd7Hf7cA" x="1185" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3Xf90zTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#99f82ea1-a790-4ef1-acac-69df2b128cab"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3Xf91TTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#b06d300e-e719-4e08-b571-b9d296839baf"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#99f82ea1-a790-4ef1-acac-69df2b128cab"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#bc453745-cca1-4d70-8916-8979176655cc"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3Xf91jTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3Xf91DTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3Xf90TTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XfWwDTvEe2g6rtd7Hf7cA" name="[COTSCI] PC 4" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#9edcdf18-7768-42fd-ae23-ee9e8a3d38ba"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#2afd30c7-9093-465a-b54f-8200d34341d8"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL9jTvEe2g6rtd7Hf7cA" x="1345" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XfWwzTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#9edcdf18-7768-42fd-ae23-ee9e8a3d38ba"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#2afd30c7-9093-465a-b54f-8200d34341d8"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XfWxTTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#78749e15-1beb-4e61-b267-8ec03bdd6da9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#9edcdf18-7768-42fd-ae23-ee9e8a3d38ba"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#2afd30c7-9093-465a-b54f-8200d34341d8"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XfWxjTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XfWxDTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XfWwTTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XeIpjTvEe2g6rtd7Hf7cA" name="[COTSCI] PC 3" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#cba2e6b1-85f9-48ff-8a13-c38f0eb6ed16"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c5876a6-a2dc-4274-bddd-f257ba93ad75"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL9TTvEe2g6rtd7Hf7cA" x="1505" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XevsjTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#cba2e6b1-85f9-48ff-8a13-c38f0eb6ed16"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c5876a6-a2dc-4274-bddd-f257ba93ad75"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XevtDTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#ae85bfdd-244c-44f3-8711-0e925b009f5c"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#cba2e6b1-85f9-48ff-8a13-c38f0eb6ed16"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c5876a6-a2dc-4274-bddd-f257ba93ad75"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XevtTTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XevszTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XevsDTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XdhkzTvEe2g6rtd7Hf7cA" name="[COTSCI] PC 2" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#27b18f65-1055-436c-b503-29a2dc1acbb6"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c32a6fa-b2a7-4eb2-af4a-8bef6d53ebc2"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL9DTvEe2g6rtd7Hf7cA" x="1665" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XeIojTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#27b18f65-1055-436c-b503-29a2dc1acbb6"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c32a6fa-b2a7-4eb2-af4a-8bef6d53ebc2"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XeIpDTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#27b18f65-1055-436c-b503-29a2dc1acbb6"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#1c32a6fa-b2a7-4eb2-af4a-8bef6d53ebc2"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XeIpTTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XeIozTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XeIoDTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3Xc6gDTvEe2g6rtd7Hf7cA" name="[InterfaceCI] PC 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#8c5e17da-3eeb-4bb1-84f0-3514a3e20047"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#d10b06aa-74c4-4e47-9b5f-30672dfffcac"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL8zTvEe2g6rtd7Hf7cA" x="1825" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3Xc6gzTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#8c5e17da-3eeb-4bb1-84f0-3514a3e20047"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#d10b06aa-74c4-4e47-9b5f-30672dfffcac"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XdhkTTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#8c5e17da-3eeb-4bb1-84f0-3514a3e20047"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#d10b06aa-74c4-4e47-9b5f-30672dfffcac"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XdhkjTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XdhkDTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3Xc6gTTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XcTcDTvEe2g6rtd7Hf7cA" name="[COTSCI] COTSCI 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#a5498d70-4e20-43d1-a3ad-0e02a4f609d9"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL8jTvEe2g6rtd7Hf7cA" x="1985" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XcTczTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#a5498d70-4e20-43d1-a3ad-0e02a4f609d9"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XcTdTTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#0d84005b-28ff-46d9-aabb-b57ca7714107"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#a5498d70-4e20-43d1-a3ad-0e02a4f609d9"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XcTdjTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XcTdDTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XcTcTTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XbFUDTvEe2g6rtd7Hf7cA" name="[COTSCI] COTSCI 1" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bc45d72-2d97-4c8c-8b4a-4f03b4c5416b"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL8TTvEe2g6rtd7Hf7cA" x="2145" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XbFUzTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bc45d72-2d97-4c8c-8b4a-4f03b4c5416b"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XbFVTTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#2462b1c5-0fc9-4cd8-8659-b4c445226a97"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#1bc45d72-2d97-4c8c-8b4a-4f03b4c5416b"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#42b9e152-8844-425a-9f69-8926244142a1"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XbsYDTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XbFVDTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XbFUTTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_3XWM0DTvEe2g6rtd7Hf7cA" name="[SystemCI] System" width="15" height="5" resizeKind="EAST_WEST">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#b3b3f9c2-076f-49d4-88bd-18b45d0e021f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#70388259-e554-4623-b6c9-0c14852f9665"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_3XhL8DTvEe2g6rtd7Hf7cA" x="2305" y="50" height="50" width="150"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XaeQDTvEe2g6rtd7Hf7cA" width="1" height="40" resizeKind="NSEW">
+        <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#b3b3f9c2-076f-49d4-88bd-18b45d0e021f"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#70388259-e554-4623-b6c9-0c14852f9665"/>
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_3XaeQjTvEe2g6rtd7Hf7cA" width="1" height="1">
+          <target xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InstanceRole" href="SemanticQueries.capella#aac30ac0-9818-4f14-bc69-cb7e844de82d"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="SemanticQueries.capella#b3b3f9c2-076f-49d4-88bd-18b45d0e021f"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem" href="SemanticQueries.capella#70388259-e554-4623-b6c9-0c14852f9665"/>
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_3XaeQzTvEe2g6rtd7Hf7cA" showIcon="false" labelPosition="node" workspacePath="/org.polarsys.capella.core.sirius.analysis/description/images/handlelifeline.svg">
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_2:EndOfLifeMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@borderedNodeMappings[name='endOfLife']"/>
+        </ownedBorderedNodes>
+        <ownedStyle xmi:type="diagram:Square" uid="_3XaeQTTvEe2g6rtd7Hf7cA" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="128,128,128" labelPosition="node" width="1" height="40">
+          <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:ExecutionMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@borderedNodeMappings[name='default%20execution']"/>
+      </ownedBorderedNodes>
+      <ownedStyle xmi:type="diagram:Square" uid="_3XWz4DTvEe2g6rtd7Hf7cA" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" labelPosition="node" width="15" height="5" color="150,177,218">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']/@conditionnalStyles.5/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InstanceRoleMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@nodeMappings[name='Instancerole%20Mapping']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_4N-54DTvEe2g6rtd7Hf7cA" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#13bc875b-c1d7-43d8-978b-7418f6075254"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#13bc875b-c1d7-43d8-978b-7418f6075254"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#70eba49a-505f-469b-a830-5075967cbd9f"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:CapabilityRealization" href="SemanticQueries.capella#dd506bb3-7a4b-4c2f-bf50-b94beda5cf5e"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_4N_g8jTvEe2g6rtd7Hf7cA" x="1025" y="240" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_4N_g8DTvEe2g6rtd7Hf7cA" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUse']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUse']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_4wqJIDTvEe2g6rtd7Hf7cA" name=" ref">
+      <target xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#655066be-3be3-4754-b7cc-7c204dbb5fa2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:InteractionUse" href="SemanticQueries.capella#655066be-3be3-4754-b7cc-7c204dbb5fa2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#26667d53-7601-4fed-bfd1-8e15f4b6bad1"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.la:CapabilityRealization" href="SemanticQueries.capella#dd506bb3-7a4b-4c2f-bf50-b94beda5cf5e"/>
+      <graphicalFilters xmi:type="diagram:AbsoluteBoundsFilter" uid="_4wqJIzTvEe2g6rtd7Hf7cA" x="1025" y="360" height="50" width="150"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_4wqJITTvEe2g6rtd7Hf7cA" showIcon="false" labelAlignment="LEFT" borderSize="1" borderSizeComputationExpression="1" foregroundColor="242,242,242">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUse']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:InteractionUseMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer/@containerMappings[name='InteractionUse']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_2:SequenceDiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_2mYp8DTvEe2g6rtd7Hf7cA"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Component%20Interfaces%20Scenario']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.interaction:Scenario" href="SemanticQueries.capella#05c76287-4dde-4a87-a188-239716b96604"/>
+  </sequence:SequenceDDiagram>
+  <diagram:DSemanticDiagram uid="_h6YFMDUAEe2NlKJvtNxasw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_h7I6MDUAEe2NlKJvtNxasw" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_h7I6MTUAEe2NlKJvtNxasw" type="Sirius" element="_h6YFMDUAEe2NlKJvtNxasw" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_i7e84DUAEe2NlKJvtNxasw" type="2002" element="_i7EtMDUAEe2NlKJvtNxasw">
+          <children xmi:type="notation:Node" xmi:id="_i7lDgDUAEe2NlKJvtNxasw" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_i7lqkDUAEe2NlKJvtNxasw" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_i7oG0DUAEe2NlKJvtNxasw" type="3008" element="_i7Vy8DUAEe2NlKJvtNxasw">
+              <children xmi:type="notation:Node" xmi:id="_i7ot4DUAEe2NlKJvtNxasw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_i7p8ADUAEe2NlKJvtNxasw" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_i7rKIDUAEe2NlKJvtNxasw" type="3008" element="_i7WaATUAEe2NlKJvtNxasw">
+                  <children xmi:type="notation:Node" xmi:id="_i7rxMDUAEe2NlKJvtNxasw" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_i7rxMTUAEe2NlKJvtNxasw" type="7002">
+                    <children xmi:type="notation:Node" xmi:id="_i7sYQDUAEe2NlKJvtNxasw" type="3008" element="_i7XBEDUAEe2NlKJvtNxasw">
+                      <children xmi:type="notation:Node" xmi:id="_i7sYQzUAEe2NlKJvtNxasw" type="5005"/>
+                      <children xmi:type="notation:Node" xmi:id="_i7sYRDUAEe2NlKJvtNxasw" type="7002">
+                        <styles xmi:type="notation:SortingStyle" xmi:id="_i7sYRTUAEe2NlKJvtNxasw"/>
+                        <styles xmi:type="notation:FilteringStyle" xmi:id="_i7sYRjUAEe2NlKJvtNxasw"/>
+                        <styles xmi:type="notation:DrawerStyle" xmi:id="_i7sYRzUAEe2NlKJvtNxasw"/>
+                      </children>
+                      <styles xmi:type="notation:ShapeStyle" xmi:id="_i7sYQTUAEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i7sYQjUAEe2NlKJvtNxasw"/>
+                    </children>
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_i7rxMjUAEe2NlKJvtNxasw"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_i7rxMzUAEe2NlKJvtNxasw"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_i7rKITUAEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i7rKIjUAEe2NlKJvtNxasw" x="150" y="40"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_i7p8ATUAEe2NlKJvtNxasw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_i7p8AjUAEe2NlKJvtNxasw"/>
+                <styles xmi:type="notation:DrawerStyle" xmi:id="_i7qjEDUAEe2NlKJvtNxasw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_i7oG0TUAEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i7oG0jUAEe2NlKJvtNxasw"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_i7lqkTUAEe2NlKJvtNxasw"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_i7lqkjUAEe2NlKJvtNxasw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_i7e84TUAEe2NlKJvtNxasw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_i7e84jUAEe2NlKJvtNxasw" x="760" y="430"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_h7I6MjUAEe2NlKJvtNxasw"/>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_h8BrADUAEe2NlKJvtNxasw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_h8BrATUAEe2NlKJvtNxasw"/>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_i7EtMDUAEe2NlKJvtNxasw" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+      <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#dbc44a57-af22-40ae-a53d-8a18910e0af2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#dbc44a57-af22-40ae-a53d-8a18910e0af2"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#b6239773-1e55-4328-b538-21701efb4ab2"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i7JlsDUAEe2NlKJvtNxasw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_i7Vy8DUAEe2NlKJvtNxasw">
+        <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#b6239773-1e55-4328-b538-21701efb4ab2"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#b6239773-1e55-4328-b538-21701efb4ab2"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i7Vy8TUAEe2NlKJvtNxasw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_i7WaATUAEe2NlKJvtNxasw" name="FunctionalChain 1" childrenPresentation="VerticalStack">
+          <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#894ffa4e-0137-49b7-bf1c-4e5831e0cb54"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference" href="SemanticQueries.capella#894ffa4e-0137-49b7-bf1c-4e5831e0cb54"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i7WaAjUAEe2NlKJvtNxasw" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']"/>
+          <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_i7XBEDUAEe2NlKJvtNxasw">
+            <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+            <semanticElements xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+            <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_i7XBETUAEe2NlKJvtNxasw" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="233,243,222" foregroundColor="233,243,222">
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']/@style"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer/@containerMappings[name='FC_FunctionalChainReference']/@subContainerMappings[name='FC_FunctionalChainStacked']"/>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@filters[name='hide.association.links.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_h6h2MDUAEe2NlKJvtNxasw"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']/@ownedRepresentations[name='Functional%20Chain%20Description']/@defaultLayer"/>
+    <target xmi:type="org.polarsys.capella.core.data.fa:FunctionalChain" href="SemanticQueries.capella#ea4a267a-bb4c-442b-a78b-bb0b7d9d6586"/>
+  </diagram:DSemanticDiagram>
 </xmi:XMI>

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.capella
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/model/SemanticQueries/SemanticQueries.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_5.1.0-->
+<!--Capella_Version_6.0.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/6.0.0"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
@@ -47,7 +47,10 @@
         <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
             id="1ae5afea-602e-4197-bf87-29921a3923a6" name="Root Operational Activity">
           <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
-              id="1c6b13bc-0cce-4557-af08-d13040e8f57e" name="OP1" availableInStates="#f6f2e13a-9e27-4d95-82e4-a3f1418c1d2d #e88696b9-a37e-4e2d-a2ae-40640566b82e"/>
+              id="1c6b13bc-0cce-4557-af08-d13040e8f57e" name="OP1" availableInStates="#f6f2e13a-9e27-4d95-82e4-a3f1418c1d2d #e88696b9-a37e-4e2d-a2ae-40640566b82e">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="c1d6f833-702f-4f96-a6fa-9a8c9447ca91" involved="#3477d406-18a6-48a9-8532-bc8279d8b2cd"/>
+          </ownedFunctionalChains>
           <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
               id="3477d406-18a6-48a9-8532-bc8279d8b2cd" name="OperationalProcess 2">
             <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainInvolvementFunction"
@@ -112,9 +115,21 @@
                 id="c1e06b35-5e2b-4be4-9bda-fb33becb7cf0" name="OperationalActivity 8"/>
           </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
-              id="c1feb001-66ae-42d5-a63f-aff0c44b7335" name="OA7" availableInStates="#fb61c33f-cb41-427b-be68-1f40e7af733f #e42efa21-269d-4e02-80e1-c5c831a36364"/>
+              id="c1feb001-66ae-42d5-a63f-aff0c44b7335" name="OA7" availableInStates="#fb61c33f-cb41-427b-be68-1f40e7af733f #e42efa21-269d-4e02-80e1-c5c831a36364">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
+                id="544e0e84-b58c-46c3-85cd-0c02f8f7f26b" name="OperationalProcess OA7">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="7bfc3568-0bbf-4514-92d1-fc7ad02900d2" involved="#1c6b13bc-0cce-4557-af08-d13040e8f57e"/>
+            </ownedFunctionalChains>
+          </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
-              id="8007a12d-96bb-4257-a907-52847af71700" name="OA8" availableInStates="#f6f2e13a-9e27-4d95-82e4-a3f1418c1d2d #e88696b9-a37e-4e2d-a2ae-40640566b82e"/>
+              id="8007a12d-96bb-4257-a907-52847af71700" name="OA8" availableInStates="#f6f2e13a-9e27-4d95-82e4-a3f1418c1d2d #e88696b9-a37e-4e2d-a2ae-40640566b82e">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
+                id="dddac4a7-c2f2-4d3d-ae80-2d2f1681264a" name="OperationalProcess OA8">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="4990d9e6-461d-4b41-98c6-2091c71454de" involved="#544e0e84-b58c-46c3-85cd-0c02f8f7f26b"/>
+            </ownedFunctionalChains>
+          </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
               id="4a202fcf-5872-4d21-ae2f-97ebeae0b4e7" name="OperationalActivity 9"/>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
@@ -148,6 +163,11 @@
           id="eb25fbf6-e305-4e9f-8b84-921a07eb385e" name="Operational Capabilities">
         <ownedOperationalCapabilities xsi:type="org.polarsys.capella.core.data.oa:OperationalCapability"
             id="5e5b5d52-ab7e-41b4-a1da-34c5141efa5b" name="OperationalCapability 1">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.oa:OperationalProcess"
+              id="0268e41f-4013-4bb4-a719-c5a253e6ec04" name="OperationalProcess 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="285d6db3-ab51-4443-8afc-db9804fec6cb" involved="#dddac4a7-c2f2-4d3d-ae80-2d2f1681264a"/>
+          </ownedFunctionalChains>
           <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
               id="24491dc1-b229-4d72-be52-78d2d01390db" name="[OAS] OperationalProcess 2 1"
               kind="INTERACTION">
@@ -692,9 +712,21 @@
                 id="94bbe21b-1fb7-45d1-8d4f-e6a6778da43e" name="FIP 1"/>
           </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
-              id="d7d4e1c4-bf79-42f4-8b9a-51da8c040b9e" name="SF7" availableInStates="#de7c3db9-d166-4445-b80d-a2d6a592b3c0 #8f7ce582-1a8f-499b-a589-066235ca5dfe"/>
+              id="d7d4e1c4-bf79-42f4-8b9a-51da8c040b9e" name="SF7" availableInStates="#de7c3db9-d166-4445-b80d-a2d6a592b3c0 #8f7ce582-1a8f-499b-a589-066235ca5dfe">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="5072b1e7-ff28-4610-9903-4f5234bcff65" name="FunctionalChain SF7">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="e2f313a9-7179-4993-83b3-22209f82e034" involved="#50c02c12-8977-4465-9e73-ae8800ff86cb"/>
+            </ownedFunctionalChains>
+          </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
-              id="35896194-4ee1-46ca-addf-4c26037c4270" name="SF8" availableInStates="#7d1233e9-013f-4ae0-a692-f847f6502390 #3bffa8df-2534-4669-8203-0ddb0f13422c"/>
+              id="35896194-4ee1-46ca-addf-4c26037c4270" name="SF8" availableInStates="#7d1233e9-013f-4ae0-a692-f847f6502390 #3bffa8df-2534-4669-8203-0ddb0f13422c">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="e77c0ab3-01b8-4b09-80d5-a31c06eab9fb" name="FunctionalChain SF8">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="91c7b99b-1477-4804-8eca-7151bdd08b7d" involved="#5072b1e7-ff28-4610-9903-4f5234bcff65"/>
+            </ownedFunctionalChains>
+          </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
               id="5c8c2b7f-b8a2-454a-be57-3668c7c2f04c" name="SA_Function9">
             <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
@@ -792,6 +824,11 @@
           id="055865bd-7993-4d80-adc5-819088a2b53b" name="Capabilities">
         <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
             id="c25c6355-166e-4d53-ba1d-627b047d7f9b" name="Capability 1">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="099fa717-2bb7-458b-a14a-5b692e96da1b" name="FunctionalChain Capability 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="7cdd0d36-5640-41c0-a583-38594cfd53e0" involved="#e77c0ab3-01b8-4b09-80d5-a31c06eab9fb"/>
+          </ownedFunctionalChains>
           <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
               id="82d3430d-a1b3-43b0-86cc-0d3a3baca132" name="[ES] Capability 1" kind="DATA_FLOW">
             <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
@@ -1417,6 +1454,13 @@
                 id="e94cccab-6e99-4d45-a837-4c4796d699c0" name="SA_Function11" representedInstance="#a759d66b-c0e2-4bb9-9bb9-316792afad1f"/>
             <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
                 id="b1fbdf98-ab78-4435-9417-f1cacabe4aac" name="SA_Function12" representedInstance="#2d6aca52-a824-4c38-961e-c92824169092"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="942ed021-360b-4fed-8bd0-f0a7e10cf477" name="start" coveredInstanceRoles="#e94cccab-6e99-4d45-a837-4c4796d699c0"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="04c412bc-0c03-452c-a1c2-a19e3892fc61" name="end" coveredInstanceRoles="#e94cccab-6e99-4d45-a837-4c4796d699c0"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="e1d3ac27-efa6-4e19-9465-f763a6f68b1a" name="interactionUse" start="#942ed021-360b-4fed-8bd0-f0a7e10cf477"
+                finish="#04c412bc-0c03-452c-a1c2-a19e3892fc61" referencedScenario="#c9e7fcef-b20f-4e34-b485-24cbcd82f41a"/>
             <ownedScenarioRealization xsi:type="org.polarsys.capella.core.data.interaction:ScenarioRealization"
                 id="0b84aa57-69da-41a4-9003-225048f35baa" targetElement="#beec133a-e9c0-4200-a71b-6ad1eca7f589"
                 sourceElement="#6fc72d95-1691-4057-a17d-1b6de8499fdb"/>
@@ -1777,11 +1821,21 @@
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
               id="3cb38702-d351-48a7-8e7f-27700bc83ff8" name="LogicalFunction 1" appliedPropertyValues="#40b0f93b-6724-4da2-9bc8-48c4eb680585"
               appliedPropertyValueGroups="#287b862e-cfd3-492c-ad2d-b654d3152ddf">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="1cbe9417-6f6e-4a24-8970-c7d0c4b1a1e3" name="FunctionalChain LF1">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="c2168548-4732-49da-a863-4add12eec6b8" involved="#776631b3-a5f6-4163-af86-4c4a11e2b2c0"/>
+            </ownedFunctionalChains>
             <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
                 id="51c18a66-2480-483b-9bbf-41838248e57d" name="FOP 1"/>
           </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
               id="b87a57f7-c590-4d10-8604-c233669ebcc7" name="LogicalFunction 2">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="30cc8a50-23bd-4183-828e-536e9b4b52cc" name="FunctionalChain LF2">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="0204082c-13bc-4639-9c7a-3be45fa48a9d" involved="#1cbe9417-6f6e-4a24-8970-c7d0c4b1a1e3"/>
+            </ownedFunctionalChains>
             <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
                 id="f3a80161-ae9e-498b-a247-804c2c4b2f89" name="FIP 1"/>
           </ownedFunctions>
@@ -1974,7 +2028,10 @@
         <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
             id="aed377e4-51e3-46ff-9efd-21172936af86" name="Capability 1">
           <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
-              id="437fc9bc-63f7-43fe-99f3-17e82f84b793" name="FunctionalChain 1"/>
+              id="437fc9bc-63f7-43fe-99f3-17e82f84b793" name="FunctionalChain 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="42e9e194-801c-47ba-8077-d37b66b7e4bd" involved="#30cc8a50-23bd-4183-828e-536e9b4b52cc"/>
+          </ownedFunctionalChains>
           <ownedFunctionalChainAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"
               id="c183136a-abec-43b9-95f9-b8e70687dca6" involved="#776631b3-a5f6-4163-af86-4c4a11e2b2c0"/>
           <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
@@ -3225,11 +3282,21 @@
           </ownedFunctionalChains>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
               id="ad5e608f-dc22-40d2-b1e6-c22e0758daf4" name="PhysicalFunction 1">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="4144f3b6-12d8-486b-bc85-6eb9ad0c833f" name="FunctionalChain PF1">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="58bd1c51-909e-4b35-a723-b41d74815fa6" involved="#29dc7bfc-e5c5-4db7-801c-3ccfa47c793e"/>
+            </ownedFunctionalChains>
             <outputs xsi:type="org.polarsys.capella.core.data.fa:FunctionOutputPort"
                 id="fdd9e69e-179c-43f7-a9f8-0e52b74a6fae" name="FOP 1"/>
           </ownedFunctions>
           <ownedFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
               id="3cccea9a-ddb0-48e3-84ec-8a3f0c593803" name="PhysicalFunction 2">
+            <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+                id="17fbf69d-cba3-445f-9ea4-2c294243649e" name="FunctionalChain PF2">
+              <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                  id="99518288-f8ae-4115-8241-5c8e0306ce5a" involved="#4144f3b6-12d8-486b-bc85-6eb9ad0c833f"/>
+            </ownedFunctionalChains>
             <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
                 id="a7f4d482-bb03-4302-aa03-b22c0506fcc8" name="FIP 1"/>
             <inputs xsi:type="org.polarsys.capella.core.data.fa:FunctionInputPort"
@@ -3283,6 +3350,11 @@
           id="8ed4e297-7f45-44fd-a68d-dff446ee79fa" name="Capabilities">
         <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
             id="a51c707d-0591-43e7-8d87-3b49882745d9" name="Capability 1">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="3c9bb195-0cf8-4c6c-a815-53fabe987c38" name="FunctionalChain Capability 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="a8c392f0-06c6-4b71-b840-d53f22998171" involved="#17fbf69d-cba3-445f-9ea4-2c294243649e"/>
+          </ownedFunctionalChains>
           <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
               id="0ca1c88e-6547-4625-a52e-fd69c92dc97d" name="[IS] Capability 1" kind="INTERFACE">
             <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
@@ -3605,6 +3677,74 @@
           <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
               id="1a0add06-3dfe-4069-b337-59700a5355a6" involved="#bb8255ea-fa5d-4b4f-a00e-91ae2a1c3e9b"/>
         </ownedCapabilityRealizations>
+        <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
+            id="829871b9-f5b1-407e-be6f-96944c998855" name="CapabilityRealization 2">
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="3cdd1abf-7b78-4f5e-af72-54c4bf6c9a93" name="[ES] Scenario 1" kind="DATA_FLOW">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="78a0f42f-d420-4b8f-a2c3-382c94809258" name="PC 8" representedInstance="#1fa15c33-8d42-4520-942d-0b089dec3717"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="e2080f3e-10cd-4596-86e0-bc5d535b7a62" name="PC 7" representedInstance="#13e3be35-3237-45f6-a6f6-e0b06a39df8c"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="9d9a58fa-90c1-42df-bda8-ad7fa6bd14bb" name="PC 6" representedInstance="#7e2d8bf4-955c-4a39-ac9f-f69dc5999bd0"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="1d701eb1-10af-4255-984c-ab9a60196747" name="PC 5" representedInstance="#405d6489-f89d-4805-9a5d-480b8b504dd6"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="45d814e6-8285-49cb-986a-fb627831d5ba" name="PC 4" representedInstance="#7a2be8cb-50df-4a69-8e66-341ec4af49f2"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="d4d0f23c-d233-4f9b-92fc-20b73972dc21" name="PC 3" representedInstance="#98c43024-ab50-4f5c-8370-bee95c8d2dd0"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="1569f44a-c309-4b42-a7e6-13a4e8898ebe" name="PC 2" representedInstance="#1a6df9a0-a2a1-4b72-a8c6-2f193ba177c0"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="c16430c6-dae4-4972-8735-0a89be0c42d5" name="PC 1" representedInstance="#93116056-6175-47aa-9c8e-85c2b3037333"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="9a8ea205-e924-404d-9206-f7c2f73c00f9" name="Physical System" representedInstance="#095b689f-42ae-4ac0-8757-a965fed981e0"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="56f9eac4-87d7-49df-b33d-9e2d61bdf5b3" name="start" coveredInstanceRoles="#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="ed1cc8ab-7e06-493c-aa50-c290f90c6126" name="end" coveredInstanceRoles="#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="4ad9adc9-4891-4728-985d-77dbf49b6a13" name="start" coveredInstanceRoles="#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="9f1b47d5-c5f0-42e1-acbe-aa435655b72a" name="end" coveredInstanceRoles="#78a0f42f-d420-4b8f-a2c3-382c94809258"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="e4e0a4c8-d722-481a-9993-d5dd0b7f8d34" name="interactionUse" start="#56f9eac4-87d7-49df-b33d-9e2d61bdf5b3"
+                finish="#ed1cc8ab-7e06-493c-aa50-c290f90c6126" referencedScenario="#c8da3939-669c-4812-b425-4fece2136f49"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="bcad171e-e0a6-4a51-a33d-5bc9fd9fc807" name="interactionUse" start="#4ad9adc9-4891-4728-985d-77dbf49b6a13"
+                finish="#9f1b47d5-c5f0-42e1-acbe-aa435655b72a" referencedScenario="#2a0f6fef-c411-480c-be22-8f0231ece3f4"/>
+          </ownedScenarios>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="12eb3695-a6a5-449f-a252-e54afc6fb4be" involved="#c2f9b98e-b412-48ac-9f85-024d3309db0f"/>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="1071aaf4-1f4a-48bd-92ac-a4445f01a5b0" involved="#ad5e608f-dc22-40d2-b1e6-c22e0758daf4"/>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="14d9d200-da0a-4651-a7ea-581907a6de14" involved="#3cccea9a-ddb0-48e3-84ec-8a3f0c593803"/>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="d45742cc-d256-4bdb-a538-990f5a70898c" involved="#37e1cc57-29bc-4c64-8864-6a52e357e18f"/>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="822ed68b-3926-42e1-b4cc-d372582cd138" involved="#4d89ed09-6e83-4542-95a4-d32ec4d20c5b"/>
+          <ownedAbstractFunctionAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:AbstractFunctionAbstractCapabilityInvolvement"
+              id="51dda95d-e4fa-450d-aa62-c43b1b7f6747" involved="#47447e6b-896e-4e08-af71-8087110dda1f"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="d9219307-adc2-48f9-8d44-a454674bbd86" involved="#9960e91c-faa7-4a99-8734-bd53ec6253da"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="93c195e4-ab7d-4e05-8591-a91f5b23a9b6" involved="#dc6a9822-ef9f-46e5-a608-582c6993c767"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="1c0208c7-9c93-414d-b0d1-395ee5727199" involved="#f0c6b3f1-e04d-4a92-95a4-5385f51375c8"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="4369c325-1c36-4088-bf03-aa836d002c9d" involved="#ab720153-5d1c-4e28-a370-0e813162e606"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="0fd04d81-2fa8-4515-bafd-d7a6ff0f99db" involved="#bb8255ea-fa5d-4b4f-a00e-91ae2a1c3e9b"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="da894ab5-6d2d-40fe-be5a-916d3483574e" involved="#4a86e83d-e6a6-4c11-bd5f-af56c50ee473"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="dafeba67-f25f-414d-a5c3-b92c24ebb50d" involved="#079312e2-5a31-422a-a1dc-bffec29272af"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="e56a93b1-b2a1-419c-946d-f7c0a37f6e7b" involved="#11baccf1-04e6-464a-97f0-7656deb231d8"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="e6617a81-27d0-4130-861d-2c526e3ebd1d" involved="#30ecad95-922c-4010-bbc8-8d0533dd54d3"/>
+        </ownedCapabilityRealizations>
       </ownedAbstractCapabilityPkg>
       <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
           id="ab24555d-7a3d-4a74-a406-048fa525355f" name="Interfaces">
@@ -3839,6 +3979,8 @@
           id="51981734-92ce-4076-8ef2-702a1097fc2b" name="Capabilities">
         <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
             id="dd506bb3-7a4b-4c2f-bf50-b94beda5cf5e" name="Capability 1">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="7d20c893-386f-4122-a365-64bebea6c8d3" name="FunctionalChain 1"/>
           <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
               id="70eba49a-505f-469b-a830-5075967cbd9f" name="[IS] Capability 1" kind="INTERFACE">
             <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
@@ -3916,6 +4058,69 @@
               id="c51542da-4ff4-41dd-8de1-6894dc229603" involved="#1c32a6fa-b2a7-4eb2-af4a-8bef6d53ebc2"/>
           <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
               id="0b9cc7c8-9bd5-4434-bbb6-6af15bc4701e" involved="#bc453745-cca1-4d70-8916-8979176655cc"/>
+        </ownedCapabilityRealizations>
+        <ownedCapabilityRealizations xsi:type="org.polarsys.capella.core.data.la:CapabilityRealization"
+            id="94e2e370-1828-4bf8-ad0b-80d8e6e22898" name="CapabilityRealization 2">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="b6239773-1e55-4328-b538-21701efb4ab2" name="FunctionalChain 1">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="894ffa4e-0137-49b7-bf1c-4e5831e0cb54" involved="#7d20c893-386f-4122-a365-64bebea6c8d3"/>
+          </ownedFunctionalChains>
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="ea4a267a-bb4c-442b-a78b-bb0b7d9d6586" name="FunctionalChain 2">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="dbc44a57-af22-40ae-a53d-8a18910e0af2" involved="#b6239773-1e55-4328-b538-21701efb4ab2"/>
+          </ownedFunctionalChains>
+          <ownedScenarios xsi:type="org.polarsys.capella.core.data.interaction:Scenario"
+              id="05c76287-4dde-4a87-a188-239716b96604" name="[IS] CapabilityRealization 2"
+              kind="INTERFACE">
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="f807907a-f2ce-4bc0-9fce-2a3266f069e5" name="InterfaceCI 6" representedInstance="#1bf40fdc-3d11-4b7d-8f7a-85158f10317c"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="b06d300e-e719-4e08-b571-b9d296839baf" name="InterfaceCI 6" representedInstance="#99f82ea1-a790-4ef1-acac-69df2b128cab"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="78749e15-1beb-4e61-b267-8ec03bdd6da9" name="PC 4" representedInstance="#9edcdf18-7768-42fd-ae23-ee9e8a3d38ba"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="ae85bfdd-244c-44f3-8711-0e925b009f5c" name="PC 3" representedInstance="#cba2e6b1-85f9-48ff-8a13-c38f0eb6ed16"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="9db48dd4-91c1-41bf-8a2e-3ef1509f6d0b" name="PC 2" representedInstance="#27b18f65-1055-436c-b503-29a2dc1acbb6"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="5c7c95e2-893c-48e2-a0d3-2b7ad33a8b17" name="PC 1" representedInstance="#8c5e17da-3eeb-4bb1-84f0-3514a3e20047"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="0d84005b-28ff-46d9-aabb-b57ca7714107" name="COTSCI 1" representedInstance="#a5498d70-4e20-43d1-a3ad-0e02a4f609d9"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="2462b1c5-0fc9-4cd8-8659-b4c445226a97" name="COTSCI 1" representedInstance="#1bc45d72-2d97-4c8c-8b4a-4f03b4c5416b"/>
+            <ownedInstanceRoles xsi:type="org.polarsys.capella.core.data.interaction:InstanceRole"
+                id="aac30ac0-9818-4f14-bc69-cb7e844de82d" name="System" representedInstance="#b3b3f9c2-076f-49d4-88bd-18b45d0e021f"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="93d48755-dfad-4aef-893f-a42ced61823b" name="start" coveredInstanceRoles="#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="185081a3-34dc-4608-8e62-68df303ec6a6" name="end" coveredInstanceRoles="#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="54723205-12a4-4a7e-8dfc-ee35a6c346b0" name="start" coveredInstanceRoles="#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+            <ownedInteractionFragments xsi:type="org.polarsys.capella.core.data.interaction:FragmentEnd"
+                id="6c04523d-0ca8-4bb0-bfbb-c189219a3b62" name="end" coveredInstanceRoles="#f807907a-f2ce-4bc0-9fce-2a3266f069e5"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="13bc875b-c1d7-43d8-978b-7418f6075254" name="interactionUse" start="#93d48755-dfad-4aef-893f-a42ced61823b"
+                finish="#185081a3-34dc-4608-8e62-68df303ec6a6" referencedScenario="#70eba49a-505f-469b-a830-5075967cbd9f"/>
+            <ownedTimeLapses xsi:type="org.polarsys.capella.core.data.interaction:InteractionUse"
+                id="655066be-3be3-4754-b7cc-7c204dbb5fa2" name="interactionUse" start="#54723205-12a4-4a7e-8dfc-ee35a6c346b0"
+                finish="#6c04523d-0ca8-4bb0-bfbb-c189219a3b62" referencedScenario="#26667d53-7601-4fed-bfd1-8e15f4b6bad1"/>
+          </ownedScenarios>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="b1429e53-cd3e-4816-82a9-acecb3455bfa" involved="#70388259-e554-4623-b6c9-0c14852f9665"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="63aa306c-0440-4586-90bf-279c5de85581" involved="#42b9e152-8844-425a-9f69-8926244142a1"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="3372b07e-baa3-436a-9607-eddc9ffb56ee" involved="#d10b06aa-74c4-4e47-9b5f-30672dfffcac"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="136cec90-3b77-4be9-b8c4-d859b665673c" involved="#1c32a6fa-b2a7-4eb2-af4a-8bef6d53ebc2"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="0714bed1-b246-4b1e-a22d-61ca3f3424d2" involved="#1c5876a6-a2dc-4274-bddd-f257ba93ad75"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="942ca8f5-c3cb-4f43-a457-9c298fc31a3a" involved="#2afd30c7-9093-465a-b54f-8200d34341d8"/>
+          <ownedCapabilityRealizationInvolvements xsi:type="org.polarsys.capella.core.data.capellacommon:CapabilityRealizationInvolvement"
+              id="c2d86b12-f857-459e-8820-433b68cfabc6" involved="#bc453745-cca1-4d70-8916-8979176655cc"/>
         </ownedCapabilityRealizations>
       </ownedAbstractCapabilityPkg>
       <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,7 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String LAB_LOGICAL_SYSTEM__LOGICAL_ARCHITECTURE_BLANK = "_1sUD4FjLEea_Bs2eLgK85w"; //$NON-NLS-1$
   public static final String LAB_LOGICAL_ARCHITECTURE_DIAGRAM = "_RDtOwN6dEem-ItbQX6Y5xA"; //$NON-NLS-1$
   public static final String TABLE_LOGICAL_FUNCTIONS__SYSTEM_FUNCTIONS = "_D4esADYIEeuB6_JYQc-3oQ"; //$NON-NLS-1$
-  
+
   public static final String PROJECT_SEMANTICQUERIES = "2cd4b848-b363-455f-a7c8-c5eb4079e32b";
   public static final String PROJECT_SEMANTICQUERIES__LIBRARY_DEPENDENCIES = "786f4d49-5c42-4da5-8658-e506a110adf7";
   public static final String PROJECT_SEMANTICQUERIES__PROGRESSSTATUS = "affce18f-848a-4676-9dd8-2fce1229f298";
@@ -110,6 +110,8 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String OA__OPERATIONAL_ACTIVITY_OA8 = "8007a12d-96bb-4257-a907-52847af71700";
   public static final String OA__OPERATIONAL_CAPABILITY_OC5 = "02e5ae3f-4df2-4ab2-a7b6-c8922bca3819";
   public static final String OA__OPERATIONAL_PROCESS_OP1 = "1c6b13bc-0cce-4557-af08-d13040e8f57e";
+  public static final String OA__OPERATIONAL_PROCESS_OA7 = "544e0e84-b58c-46c3-85cd-0c02f8f7f26b";
+  public static final String OA__OPERATIONAL_PROCESS_OA8 = "dddac4a7-c2f2-4d3d-ae80-2d2f1681264a";
   public static final String OA__OPERATIONAL_PROCESS_2 = "3477d406-18a6-48a9-8532-bc8279d8b2cd";
   public static final String OA__OPERATIONAL_ACTIVITY_9 = "4a202fcf-5872-4d21-ae2f-97ebeae0b4e7";
   public static final String OA__OPERATIONAL_ACTIVITY_10 = "40483782-12b2-4999-82af-4ecc9822da0f";
@@ -154,6 +156,7 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA__ROOT_SF__FUNCTIONALEXCHANGE_1 = "3d9cd590-fc65-4519-b683-b20b85662218";
   public static final String SA__CAPABILITIES = "055865bd-7993-4d80-adc5-819088a2b53b";
   public static final String SA__CAPABILITIES_CAPABILITY_1 = "c25c6355-166e-4d53-ba1d-627b047d7f9b";
+  public static final String SA__CAPABILITIES_OPERATIONAL_CAPABILITY_1 = "b3738b66-1889-4479-9b4d-5bbb7ab13f52";
   public static final String SA__SCENARIO_OC1_FS = "745f3b2b-95b5-47a9-885d-407c852e6eae";
   public static final String SA__SCENARIO_FS_INTERACTION_1 = "0d6d67d2-94c1-4224-bbf6-c6dacb12cfd0";
   public static final String SA__SCENARIO_FS_INTERACTION_2 = "7d1715eb-49e1-43d8-9ad2-e7d34e5858a2";
@@ -167,6 +170,7 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA__SCENARIO_IS_MESSAGE_RECEIVE = "8c2a604f-4ec9-4169-9d92-113b40a9e2a1";
   public static final String SA__SCENARIO_IS_MESSAGE_EI1 = "5faed343-183c-4b8f-9e2a-3d3fd2c93664";
   public static final String SA__SCENARIO_FS_OCAPA2 = "6fc72d95-1691-4057-a17d-1b6de8499fdb";
+  public static final String SA__SCENARIO_FS_OCAPA1 = "c9e7fcef-b20f-4e34-b485-24cbcd82f41a";
   public static final String SA__INTERFACES = "fff68970-e2db-43e0-8e6f-ac7893f2fc05";
   public static final String SA__INTERFACES_INTERFACE1 = "4339637b-1dca-4053-a47e-db36a2ea3ec8";
   public static final String SA__INTERFACES_INTERFACE2 = "64143bbe-01f5-42d5-8264-e489bc85d4f5";
@@ -239,6 +243,8 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA__SYSTEM_FUNCTION_SF8 = "35896194-4ee1-46ca-addf-4c26037c4270";
   public static final String SA__OPERATIONAL_CAPABILITY_OC2 = "8af618ab-44b8-4b97-9ea8-656f7fd93396";
   public static final String SA__FUNCTIONAL_CHAIN_FC1 = "50c02c12-8977-4465-9e73-ae8800ff86cb";
+  public static final String SA__FUNCTIONAL_CHAIN_SF7 = "5072b1e7-ff28-4610-9903-4f5234bcff65";
+  public static final String SA__FUNCTIONAL_CHAIN_SF8 = "e77c0ab3-01b8-4b09-80d5-a31c06eab9fb";
   public static final String SA__STATE_1 = "384597dd-fdbc-4fc4-acae-68451e8f69e2";
   public static final String SA__STATE_1_1 = "de7c3db9-d166-4445-b80d-a2d6a592b3c0";
   public static final String SA__STATE_1_1_1 = "7d1233e9-013f-4ae0-a692-f847f6502390";
@@ -291,10 +297,13 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String LA__LOGICAL_ACTORS__LA_1 = "56afef9c-56e7-450c-912d-b9811275bf26";
   public static final String LA__LOGICAL_ACTORS__LA_3 = "246d5902-8d11-4eac-ab70-909b4575871b";
   public static final String LA__LOGICAL_ACTORS__LA_4 = "d908dd6d-1bcc-4512-87f5-581c3e661af2";
-  public static final String LA__LOGICAL_ACTORS__LA_5 = "bbb1fb19-0836-46e3-bcee-fda7b89b1bda"; 
+  public static final String LA__LOGICAL_ACTORS__LA_5 = "bbb1fb19-0836-46e3-bcee-fda7b89b1bda";
   public static final String LA__LOGICAL_ACTORS__LA_1__COMPONENT_FUNCTIONAL_ALLOCATION_TO_LOGICALFUNCTION_1 = "164051ff-7008-49fc-8ba0-286a23b8dae2";
   public static final String LA__COMPONENT_EXCHANGE_C2 = "fc14617e-243a-4cd3-af57-98f53c6edfd9";
   public static final String LA__FUNCTIONAL_EXCHANGE_1 = "32e7eb00-a4b4-4c59-b8db-f4a956b5dd32";
+  public static final String LA__FUNCTIONAL_CHAIN_LF1 = "1cbe9417-6f6e-4a24-8970-c7d0c4b1a1e3";
+  public static final String LA__FUNCTIONAL_CHAIN_LF2 = "30cc8a50-23bd-4183-828e-536e9b4b52cc";
+  public static final String LA__SCENARIO_OPCAPA_2 = "00b7bb7d-0521-4335-ba52-e3f68b330404";
   public static final String LA__SYSTEM_ANALYSIS_REALIZATION_TO_SYSTEM_ANALYSIS = "198d7956-01f9-4acb-a7af-85be5958c0e3";
   public static final String LA__LOGICAL_INTERFACE_1 = "4b94444c-563b-48aa-8bfb-9e59615e973f";
   public static final String LA__LOGICAL_INTERFACE_2 = "b818ec8e-6cf0-4a5f-aad8-6468ef7653c2";
@@ -308,6 +317,8 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String PA = "8f178984-e6cf-46de-870f-05dcdbaa0025";
   public static final String PA__PHYSICAL_FUNCTIONS = "31d0ecd3-6548-4a0a-b86c-85b43638d4e9";
   public static final String PA__FUNCTIONAL_CHAIN = "29dc7bfc-e5c5-4db7-801c-3ccfa47c793e";
+  public static final String PA__FUNCTIONAL_CHAIN_PF1 = "4144f3b6-12d8-486b-bc85-6eb9ad0c833f";
+  public static final String PA__FUNCTIONAL_CHAIN_PF2 = "17fbf69d-cba3-445f-9ea4-2c294243649e";
   public static final String PA__FUNCTION_1 = "ad5e608f-dc22-40d2-b1e6-c22e0758daf4";
   public static final String PA__FUNCTION_2 = "3cccea9a-ddb0-48e3-84ec-8a3f0c593803";
   public static final String PA__FUNCTION_3 = "37e1cc57-29bc-4c64-8864-6a52e357e18f";
@@ -351,10 +362,14 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String PA__PL4 = "8b0f14b1-9b08-4ee8-9771-eabb9d99aa8b";
   public static final String EPBS = "1729bd4c-a4d2-48c2-ac5e-cf84172ae391";
   public static final String EPBS__CAPABILITIES = "51981734-92ce-4076-8ef2-702a1097fc2b";
+  public static final String EPBS__CAPABILITIES__CAPABILITY_2 = "94e2e370-1828-4bf8-ad0b-80d8e6e22898";
   public static final String EPBS_SCENARIO_CAPA1_IS = "70eba49a-505f-469b-a830-5075967cbd9f";
   public static final String EPBS_SCENARIO_CAPA1_IS_COPY = "26667d53-7601-4fed-bfd1-8e15f4b6bad1";
   public static final String EPBS__EPBS_CONTEXT = "41f9648e-967b-4046-a54e-3fdbd6d7892e";
   public static final String EPBS__EPBS_CONTEXT__PART_SYSTEM__SYSTEM = "b3b3f9c2-076f-49d4-88bd-18b45d0e021f";
+  public static final String EPBS__FUNCTIONAL_CHAIN = "b6239773-1e55-4328-b538-21701efb4ab2";
+  public static final String EPBS__FUNCTIONAL_CHAIN_1 = "7d20c893-386f-4122-a365-64bebea6c8d3";
+  public static final String EPBS__FUNCTIONAL_CHAIN_2 = "ea4a267a-bb4c-442b-a78b-bb0b7d9d6586";
   public static final String EPBS__SYSTEMCI_SYSTEM = "70388259-e554-4623-b6c9-0c14852f9665";
   public static final String EPBS__SYSTEMCI_SYSTEM__PHYSICAL_ARTIFACT_REALIZATION_TO_PHYSICAL_SYSTEM = "6ca9d1b5-e19f-4cc5-b8a2-3db8490aa223";
   public static final String EPBS__PHYSICAL_ARCHITECTURE_REALIZATION_TO_PHYSICAL_ARCHITECTURE = "001e1adc-f9cb-4852-bcde-41a9670a51e0";
@@ -366,8 +381,10 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA__CAPABILITIES__CAPABILITY_1 = "c25c6355-166e-4d53-ba1d-627b047d7f9b"; //$NON-NLS-1$
   public static final String LA__ROOT_LF__FUNCTIONALCHAIN_1 = "776631b3-a5f6-4163-af86-4c4a11e2b2c0"; //$NON-NLS-1$
   public static final String LA__CAPABILITIES__CAPABILITY_1 = "aed377e4-51e3-46ff-9efd-21172936af86"; //$NON-NLS-1$
+  public static final String LA__CAPABILITIES__OPERATIONAL_CAPABILITY_1 = "1ca2a52f-0c18-4983-9d3c-dca2dcfc4897";
   public static final String LA__CAPABILITIES__CAPABILITY_1__FUNCTIONALCHAIN_1 = "437fc9bc-63f7-43fe-99f3-17e82f84b793"; //$NON-NLS-1$
   public static final String PA__CAPABILITIES__CAPABILITY_1 = "a51c707d-0591-43e7-8d87-3b49882745d9"; //$NON-NLS-1$
+  public static final String PA__CAPABILITIES__CAPABILITY_2 = "829871b9-f5b1-407e-be6f-96944c998855";
   public static final String PA__SCENARIO_ES_COPY = "c8da3939-669c-4812-b425-4fece2136f49";
   public static final String PA__SCENARIO_ES_MESSAGE_C1_1 = "40e9aa9d-ab88-45d1-a054-0afde52aee4c";
   public static final String PA__SCENARIO_ES_MESSAGE_C1_2 = "fd3806ce-d990-47ab-8a5c-30d0b3743cee";
@@ -396,7 +413,7 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String ROLE_3 = "Ia32606de-335a-4794-b28f-40bed6da4c26"; //$NON-NLS-1$
   public static final String LA_MODE_1_TO_MODE_2 = "eb7ef4a7-f6ee-42d2-92b0-61150539561f"; //$NON-NLS-1$
   public static final String PA_MODE_1_TO_MODE_2 = "e6aaca4d-5132-4223-9dd8-74499479397b"; //$NON-NLS-1$
-  
+
   public static final String SA_SERVICE_1 = "c5659ad6-4b50-4378-b785-894c4b8b84ef"; //$NON-NLS-1$
   public static final String SA_PARAMETER_1 = "e639de8b-7b2f-428d-a557-54de20a78767"; //$NON-NLS-1$
   public static final String SA_PARAMETER_2 = "77afc633-8445-4371-adcf-fccd7c9751e1"; //$NON-NLS-1$
@@ -441,13 +458,13 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA__COLLECTION_2_COLLECTION_2 = "8fa45549-ab96-4b46-b026-36c4edef1d7e"; //$NON-NLS-1$
   public static final String SA_REALIZATION_TO_BOOLEAN = "96fd2a9f-d61a-4b53-970c-3726b113164b"; //$NON-NLS-1$
   public static final String SA_DEFAULT_BOOLEANREFERENCE_1 = "85d681e8-0b80-43f8-8db0-734c8491017d"; //$NON-NLS-1$
-  
+
   public static final String SA_DEFAULT_UNARYEXPRESSION_2 = "b0abc4c7-de5a-4e06-bc25-7be09b28c4fa"; //$NON-NLS-1$
   public static final String SA_DOMAIN_TYPE_BOOLEANTYPE_1 = "7eadc13e-efe1-4435-bbe2-ab983b2b2ff9"; //$NON-NLS-1$
   public static final String SA_MAX_ENUM_UNARYEXPRESSION_1 = "b845a15a-cba9-4d44-a65d-b9e5d96779a3"; //$NON-NLS-1$
   public static final String SA_MIN_BINARYEXPRESSION_1 = "7455c439-da50-4e89-9996-6e9c71b33caa"; //$NON-NLS-1$
   public static final String SA_NULL_ENUMERATIONLITERAL_1 = "157a516c-b51a-44b9-a6b3-a9138e19cc06"; //$NON-NLS-1$
-  
+
   public static final String SA_NUMERIC_TYPE_DEFAULT_UNARYEXPRESSION_1 = "c58a8f16-c714-4def-8d0d-e7abf59dd7e3"; //$NON-NLS-1$
   public static final String SA_NUMERIC_TYPE_MAX_BINARYEXPRESSION_1 = "52ba1458-42a2-45b9-b5ba-1e134ac2df73"; //$NON-NLS-1$
   public static final String SA_NUMERIC_TYPE_MIN_NUMERICREFERENCE_1 = "31527fde-7663-4626-ae5c-b6c5fd5a33f1"; //$NON-NLS-1$
@@ -458,15 +475,15 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String SA_PHYSICAL_QUANTITY_MIN_BINARYEXPRESSION_1 = "9010ca1b-8e28-44fe-9418-d761a195404d"; //$NON-NLS-1$
   public static final String SA_PHYSICAL_QUANTITY_NULL_NUMERICREFERENCE_1 = "303ccd73-327f-4fd9-a938-0dad772e3fd5"; //$NON-NLS-1$
   public static final String SA_PHYSICALQUANTITY_7 = "6d7122bf-6a5b-4445-a463-f0989eee76b0"; //$NON-NLS-1$
-  
+
   public static final String SA_STRINGTYPE_8 = "cde04e2b-b8a2-49f0-bcee-2c59422aae9a"; //$NON-NLS-1$
   public static final String SA_STRINGTYPE_DEFAULT_LITERALSTRINGVALUE_1 = "72ab5002-0035-48f8-9f82-80b1151d9b44"; //$NON-NLS-1$
   public static final String SA_STRINGTYPE_MAXLENGTH = "bad57192-3cf8-49c8-929c-12de214a7f41"; //$NON-NLS-1$
   public static final String SA_STRINGTYPE_MINLENGTH = "abe89df4-9ff9-40dc-bae0-c4885d30446f"; //$NON-NLS-1$
-  public static final String SA_STRINGTYPE_NULL= "aa9d6709-50a5-49d3-88ca-9a181619ad93"; //$NON-NLS-1$
-  
+  public static final String SA_STRINGTYPE_NULL = "aa9d6709-50a5-49d3-88ca-9a181619ad93"; //$NON-NLS-1$
+
   public static final String SA_ENUMERATION_6 = "171df66d-e689-4aa0-92c9-f0393c469051"; //$NON-NLS-1$
-  
+
   @Override
   public List<String> getRequiredTestModels() {
     return Collections.singletonList("SemanticQueries");

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/Capability_ExternalReferencedFunctionalChains.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/Capability_ExternalReferencedFunctionalChains.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales Global Services - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+import junit.framework.Test;
+
+public class Capability_ExternalReferencedFunctionalChains extends SemanticQueries {
+  String QUERY = "org.polarsys.capella.core.semantic.queries.AbstractCapabilityExternalReferencedFunctionalChains";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQuery(OA__OPERATIONAL_CAPABILITY1);
+    testQuery(SA__CAPABILITIES__CAPABILITY_1, SA__FUNCTIONAL_CHAIN_FC1, SA__FUNCTIONAL_CHAIN_SF7,
+        SA__FUNCTIONAL_CHAIN_SF8);
+    testQuery(LA__CAPABILITIES__CAPABILITY_1, LA__FUNCTIONAL_CHAIN_LF1, LA__FUNCTIONAL_CHAIN_LF2);
+    testQuery(PA__CAPABILITIES__CAPABILITY_1, PA__FUNCTIONAL_CHAIN, PA__FUNCTIONAL_CHAIN_PF1, PA__FUNCTIONAL_CHAIN_PF2);
+    testQuery(EPBS__CAPABILITIES__CAPABILITY_2, EPBS__FUNCTIONAL_CHAIN_1, EPBS__FUNCTIONAL_CHAIN);
+  }
+
+  public static Test suite() {
+    return new Capability_ExternalReferencedFunctionalChains();
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/Capability_ExternalReferencedScenarios.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/Capability_ExternalReferencedScenarios.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales Global Services - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+import junit.framework.Test;
+
+public class Capability_ExternalReferencedScenarios extends SemanticQueries {
+  String QUERY = "org.polarsys.capella.core.semantic.queries.AbstractCapabilityExternalReferencedScenarios";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQuery(OA__OPERATIONAL_CAPABILITY1, OA__SCENARIO_OAS_OC2);
+    testQuery(SA__CAPABILITIES_OPERATIONAL_CAPABILITY_1, SA__SCENARIO_FS_OCAPA2, SA__SCENARIO_FS_OCAPA1);
+    testQuery(LA__CAPABILITIES__OPERATIONAL_CAPABILITY_1, LA__SCENARIO_OPCAPA_2);
+    testQuery(PA__CAPABILITIES__CAPABILITY_2, PA__SCENARIO_ES, PA__SCENARIO_ES_COPY);
+    testQuery(EPBS__CAPABILITIES__CAPABILITY_2, EPBS_SCENARIO_CAPA1_IS, EPBS_SCENARIO_CAPA1_IS_COPY);
+  }
+
+  public static Test suite() {
+    return new Capability_ExternalReferencedScenarios();
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionalChain_ExternalReferencedFunctionalChains.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/FunctionalChain_ExternalReferencedFunctionalChains.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales Global Services - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+import junit.framework.Test;
+
+public class FunctionalChain_ExternalReferencedFunctionalChains extends SemanticQueries {
+  String QUERY = "org.polarsys.capella.core.semantic.queries.basic.queries.FunctionalChainExternalReferencedFunctionalChains";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQueryOnlyItemQueries(OA__OPERATIONAL_PROCESS_OA8);
+    testQueryOnlyItemQueries(SA__FUNCTIONAL_CHAIN_SF8, SA__FUNCTIONAL_CHAIN_FC1);
+    testQueryOnlyItemQueries(LA__CAPABILITIES__CAPABILITY_1__FUNCTIONALCHAIN_1, LA__FUNCTIONAL_CHAIN_LF1,
+        LA__ROOT_LF__FUNCTIONALCHAIN_1);
+    testQueryOnlyItemQueries(PA__FUNCTIONAL_CHAIN_PF2, PA__FUNCTIONAL_CHAIN);
+    testQueryOnlyItemQueries(EPBS__FUNCTIONAL_CHAIN_2, EPBS__FUNCTIONAL_CHAIN_1);
+  }
+
+  public static Test suite() {
+    return new FunctionalChain_ExternalReferencedFunctionalChains();
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/OperationalCapability_ExternalReferencedOperationalProcesses.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/OperationalCapability_ExternalReferencedOperationalProcesses.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales Global Services - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+import junit.framework.Test;
+
+public class OperationalCapability_ExternalReferencedOperationalProcesses extends SemanticQueries {
+	String QUERY = "org.polarsys.capella.core.semantic.queries.OperationalCapabilityExternalReferencedOperationalProcesses";
+
+	@Override
+	protected String getQueryCategoryIdentifier() {
+		return QUERY;
+	}
+
+	@Override
+	public void test() throws Exception {
+		testQuery(OA__OPERATIONAL_CAPABILITY1,OA__OPERATIONAL_PROCESS_OA7, OA__OPERATIONAL_PROCESS_2,OA__OPERATIONAL_PROCESS_OA8, OA__OPERATIONAL_PROCESS_OP1);
+		testQuery(SA__CAPABILITIES__CAPABILITY_1);
+		testQuery(LA__CAPABILITIES__CAPABILITY_1);
+		testQuery(PA__CAPABILITIES__CAPABILITY_1);
+		testQuery(EPBS__CAPABILITIES__CAPABILITY_2);
+	}
+
+  public static Test suite() {
+    return new OperationalCapability_ExternalReferencedOperationalProcesses();
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/OperationalProcess_ExternalReferencedOperationalProcesses.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/OperationalProcess_ExternalReferencedOperationalProcesses.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Thales Global Services - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+import junit.framework.Test;
+
+public class OperationalProcess_ExternalReferencedOperationalProcesses extends SemanticQueries {
+  String QUERY = "org.polarsys.capella.core.semantic.queries.basic.queries.OperationalProcessExternalReferencedOperationalProcesses";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQueryOnlyItemQueries(OA__OPERATIONAL_PROCESS_OA8, OA__OPERATIONAL_PROCESS_OP1, OA__OPERATIONAL_PROCESS_2);
+    testQueryOnlyItemQueries(SA__FUNCTIONAL_CHAIN_SF8);
+    testQueryOnlyItemQueries(LA__FUNCTIONAL_CHAIN_LF2);
+    testQueryOnlyItemQueries(PA__FUNCTIONAL_CHAIN_PF2);
+    testQueryOnlyItemQueries(EPBS__FUNCTIONAL_CHAIN_1);
+  }
+
+  public static Test suite() {
+    return new OperationalProcess_ExternalReferencedOperationalProcesses();
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testsuites/SemanticQueriesTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testsuites/SemanticQueriesTestSuite.java
@@ -34,7 +34,7 @@ public class SemanticQueriesTestSuite extends BasicTestSuite {
     tests.add(new UniqueIDInPluginsTest());
     tests.add(new AvailableForTypeClassExistTest());
     tests.add(new AbstractFunction_mother_activity_allocation());
-    tests.add(new AbstractFunction_mother_function_allocation());
+    tests.add(new AbstractFunction_mother_function_allocation());   
     tests.add(new CapellaElement_applied_property_value_groups());
     tests.add(new CapellaElement_applied_property_values());
     tests.add(new PropertyValue_applying_valued_element());
@@ -42,6 +42,8 @@ public class SemanticQueriesTestSuite extends BasicTestSuite {
     tests.add(new EntryExitPoint_ParentRegionTest());
     tests.add(new State_OwnedEntryExitPointsTest());
     tests.add(new Capability_InvolvedComponents());
+    tests.add(new Capability_ExternalReferencedFunctionalChains());
+    tests.add(new Capability_ExternalReferencedScenarios());
     tests.add(new CapabilityRealization_InvolvedFunctionalChains());
     tests.add(new CapabilityRealization_InvolvedFunctions());
     tests.add(new CapabilityRealization_OwnedFunctionalChains());
@@ -143,15 +145,18 @@ public class SemanticQueriesTestSuite extends BasicTestSuite {
     tests.add(new DataTypeElementsMaxLength());
     tests.add(new OperationalActivity_InvolvingCapabilities());
     tests.add(new OperationalCapability_InvolvedActivities());
+    tests.add(new OperationalCapability_ExternalReferencedOperationalProcesses());
     tests.add(new FunctionalChainInternalLinks());
     tests.add(new FunctionalChainFlatFunctions());
     tests.add(new FunctionalChainFlatExchanges());
     tests.add(new FunctionalChainEndingFunctions());
     tests.add(new FunctionalChainStartingFunctions());
+    tests.add(new FunctionalChain_ExternalReferencedFunctionalChains());
     tests.add(new OperationalProcessFlatOperationalActivities());
     tests.add(new OperationalProcessFlatInteractions());
     tests.add(new OperationalProcessEndingOperationalActivities());
     tests.add(new OperationalProcessStartingOperationalActivities());
+    tests.add(new OperationalProcess_ExternalReferencedOperationalProcesses());
     tests.add(new StateFragment_RelatedFunctions());
     tests.add(new StateFragment_RelatedOperationalActivities());
     tests.add(new Scenario_InvokedMessages());

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.polarsys.capella.core.model.helpers,
  org.polarsys.capella.core.platform.sirius.ui.navigator,
  org.polarsys.capella.core.data.interaction.ui.quickfix,
- org.polarsys.capella.core.transition.system.topdown
+ org.polarsys.capella.core.transition.system.topdown,
+ org.polarsys.capella.core.platform.sirius.ui.perspective
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.polarsys.capella.test.validation.rules.ju,

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
@@ -2,7 +2,7 @@
 
 <!--Capella_Version_6.0.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
     xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/6.0.0"
     xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/6.0.0"
@@ -29492,18 +29492,44 @@
         <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
             id="4c4eb558-8251-44a9-9f06-9bbd20e3317e" name="Capability 1">
           <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
-              id="8087d204-81d8-4e31-bba9-9a570feb29bf" name="FunctionalChain 1"/>
+              id="8087d204-81d8-4e31-bba9-9a570feb29bf" name="FunctionalChain Capa 1"/>
           <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
               id="509f50f6-0921-49b6-82d9-c891971cac89" involved="#65723dc5-53f5-41e1-ae50-bcdcd6480584"/>
         </ownedCapabilities>
         <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
             id="641da578-f417-4dc4-a675-94fb924d2050" name="Capability 2">
           <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
-              id="15b09bce-fb4d-4fe4-b09b-848c76e08a8b" name="FunctionalChain 1"/>
+              id="15b09bce-fb4d-4fe4-b09b-848c76e08a8b" name="FunctionalChain Capa 2"/>
           <ownedFunctionalChainAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"
               id="400554d6-b8ad-4dc0-90cc-ef285bccc11d" involved="#15b09bce-fb4d-4fe4-b09b-848c76e08a8b"/>
           <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
               id="f940ef76-404e-49a4-9a75-8c304d2bc42e" involved="#65723dc5-53f5-41e1-ae50-bcdcd6480584"/>
+        </ownedCapabilities>
+        <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
+            id="5beef70b-8798-46b6-97d4-9217bd29ba62" name="Capability 3">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="16b5cd53-9b60-4843-bb44-e8617f4933d4" name="FunctionalChain Capa 3">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="a8638421-205d-47f6-96c9-de6c1f712497" involved="#15b09bce-fb4d-4fe4-b09b-848c76e08a8b"/>
+          </ownedFunctionalChains>
+          <ownedFunctionalChainAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"
+              id="23c758bb-9c16-4b20-b564-0ed6779eb0dc" involved="#16b5cd53-9b60-4843-bb44-e8617f4933d4"/>
+          <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
+              id="dbf598ce-4689-43c9-86d4-d15329a5e7e6" involved="#65723dc5-53f5-41e1-ae50-bcdcd6480584"/>
+        </ownedCapabilities>
+        <ownedCapabilities xsi:type="org.polarsys.capella.core.data.ctx:Capability"
+            id="86ff71a4-dc57-4584-a2d6-414d1f2a94b9" name="Capability 4">
+          <ownedFunctionalChains xsi:type="org.polarsys.capella.core.data.fa:FunctionalChain"
+              id="5f45d4d2-0ea1-47e5-9a6f-88a9892f2222" name="FunctionalChain Capa 4">
+            <ownedFunctionalChainInvolvements xsi:type="org.polarsys.capella.core.data.fa:FunctionalChainReference"
+                id="67795108-851b-4a5a-b156-e270c0c5e334" involved="#16b5cd53-9b60-4843-bb44-e8617f4933d4"/>
+          </ownedFunctionalChains>
+          <ownedFunctionalChainAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"
+              id="dd514e3d-8ca4-4c72-9314-e933caad198c" involved="#5f45d4d2-0ea1-47e5-9a6f-88a9892f2222"/>
+          <ownedFunctionalChainAbstractCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.interaction:FunctionalChainAbstractCapabilityInvolvement"
+              id="c1170155-eac9-40e9-b7bc-785a3873bc12" involved="#16b5cd53-9b60-4843-bb44-e8617f4933d4"/>
+          <ownedCapabilityInvolvements xsi:type="org.polarsys.capella.core.data.ctx:CapabilityInvolvement"
+              id="394204ba-ba3d-4f8b-a56c-179992dd9f9c" involved="#65723dc5-53f5-41e1-ae50-bcdcd6480584"/>
         </ownedCapabilities>
       </ownedAbstractCapabilityPkg>
       <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dwf_ca/Rule_DWF_CA_09.java
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dwf_ca/Rule_DWF_CA_09.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2019, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,6 +30,8 @@ public class Rule_DWF_CA_09 extends AbstractRulesOnDesignTest {
 
   public static final String SYSTEM_CAPABILITY_1 = "4c4eb558-8251-44a9-9f06-9bbd20e3317e";
   public static final String SYSTEM_CAPABILITY_2 = "641da578-f417-4dc4-a675-94fb924d2050";
+  public static final String SYSTEM_CAPABILITY_3 = "5beef70b-8798-46b6-97d4-9217bd29ba62";
+  public static final String SYSTEM_CAPABILITY_4 = "86ff71a4-dc57-4584-a2d6-414d1f2a94b9";
 
   /**
    * @see org.polarsys.capella.test.validation.rules.ju.testcases.ValidationRuleTestCase#getTargetedEClass()
@@ -53,7 +55,7 @@ public class Rule_DWF_CA_09 extends AbstractRulesOnDesignTest {
    */
   protected List<String> getScopeDefinition() {
     // data to validate
-    return Arrays.asList(new String[] { SYSTEM_CAPABILITY_1, SYSTEM_CAPABILITY_2 });
+    return Arrays.asList(new String[] { SYSTEM_CAPABILITY_1, SYSTEM_CAPABILITY_2, SYSTEM_CAPABILITY_3, SYSTEM_CAPABILITY_4 });
   }
 
   /**
@@ -62,7 +64,9 @@ public class Rule_DWF_CA_09 extends AbstractRulesOnDesignTest {
    */
   protected List<OracleDefinition> getOracleDefinitions() {
     return Arrays.asList(new OracleDefinition[] { new OracleDefinition(SYSTEM_CAPABILITY_1, 1),
-        new OracleDefinition(SYSTEM_CAPABILITY_2, 0), });
+        new OracleDefinition(SYSTEM_CAPABILITY_2, 0),
+        new OracleDefinition(SYSTEM_CAPABILITY_3, 1),
+        new OracleDefinition(SYSTEM_CAPABILITY_4, 1),});
   }
 
 }


### PR DESCRIPTION
Added Semantic queries to display :
-External Referenced Functional Chains on AbstractCapability (except Operational Capability)
-External Referenced Functional Chains on Functional Chains (except Operational Processes)
-External Referenced Scenarios on AbstractCapability
-External Referenced Operational Processes on OperationalCapability
-External Referenced Operational Processes on Operational Process

Updated DWF_CA_09 Rule so that it checks that, for a given Capability , its External Referenced FunctionalChains are properly involved

Change-Id: I7dff5240b6f7668450898fbf31b3bffc15fef568
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>