### PR TITLE
#2449 Fixed double click on FC/PP/OP References

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/OpenRelatedDiagramAction.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/OpenRelatedDiagramAction.java
@@ -13,6 +13,7 @@
 package org.polarsys.capella.core.platform.sirius.ui.navigator.actions;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.window.Window;
@@ -26,6 +27,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.polarsys.capella.common.ui.toolkit.dialogs.OpenRepresentationDialog;
 import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
+import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
 import org.polarsys.capella.core.sirius.ui.actions.NewRepresentationAction;
 import org.polarsys.capella.core.sirius.ui.actions.OpenRepresentationsAction;
 import org.polarsys.capella.core.sirius.ui.actions.SelectNewRepresentationAction;
@@ -35,13 +37,12 @@ public class OpenRelatedDiagramAction {
   EObject target;
 
   public OpenRelatedDiagramAction(EObject target) {
-    this.target = target;
+    this.target = DoubleClickBehaviourUtil.INSTANCE.getTargetSemanticElement(target);
   }
 
   public void run() {
-
-    Collection<DRepresentationDescriptor> representations = DoubleClickBehaviourUtil.INSTANCE
-        .getRepresentationsDescriptors(target);
+    Collection<DRepresentationDescriptor> representations = RepresentationHelper
+        .getAllRepresentationDescriptorsTargetedBy(Collections.singleton(target));
     if (!representations.isEmpty()) {
       if (representations.size() > 1) {
         Shell activeShell = Display.getDefault().getActiveShell();

--- a/core/plugins/org.polarsys.capella.core.preferences/src/org/polarsys/capella/core/commands/preferences/ui/sirius/DoubleClickBehaviourUtil.java
+++ b/core/plugins/org.polarsys.capella.core.preferences/src/org/polarsys/capella/core/commands/preferences/ui/sirius/DoubleClickBehaviourUtil.java
@@ -12,23 +12,18 @@
  *******************************************************************************/
 package org.polarsys.capella.core.commands.preferences.ui.sirius;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.polarsys.capella.core.data.cs.PhysicalPath;
 import org.polarsys.capella.core.data.cs.PhysicalPathReference;
 import org.polarsys.capella.core.data.fa.FunctionalChain;
 import org.polarsys.capella.core.data.fa.FunctionalChainReference;
 import org.polarsys.capella.core.data.interaction.InteractionUse;
 import org.polarsys.capella.core.data.interaction.Scenario;
-import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
 import org.polarsys.capella.core.preferences.Activator;
 
 /**
  * This util class is used to determine if navigation shall be made on double click, based on the preference
- * from @CapellaDiagramPreferencePage It also provides a method to get RepresentationDescriptors
+ * from @CapellaDiagramPreferencePage It also provides a method to get the target element of a reference
  * 
  * @author etraisnel
  */
@@ -48,7 +43,7 @@ public class DoubleClickBehaviourUtil {
         || source instanceof Scenario);
   }
 
-  public Collection<DRepresentationDescriptor> getRepresentationsDescriptors(EObject target) {
+  public EObject getTargetSemanticElement(EObject target) {
     if (target instanceof FunctionalChainReference) {
       target = ((FunctionalChainReference) target).getReferencedFunctionalChain();
     } else if (target instanceof PhysicalPathReference) {
@@ -56,8 +51,6 @@ public class DoubleClickBehaviourUtil {
     } else if (target instanceof InteractionUse) {
       target = ((InteractionUse) target).getReferencedScenario();
     }
-
-    return RepresentationHelper.getAllRepresentationDescriptorsTargetedBy(Collections.singleton(target));
+    return target;
   }
-
 }

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/policies/OpenRelatedDiagramEditPolicy.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/policies/OpenRelatedDiagramEditPolicy.java
@@ -13,6 +13,7 @@
 package org.polarsys.capella.core.sirius.analysis.policies;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
@@ -50,6 +51,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.polarsys.capella.common.ui.toolkit.dialogs.OpenRepresentationDialog;
 import org.polarsys.capella.common.ui.toolkit.dialogs.SelectNewRepresentationDialog;
 import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
+import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
 import org.polarsys.capella.core.sirius.analysis.Messages;
 
 /**
@@ -79,9 +81,10 @@ public class OpenRelatedDiagramEditPolicy extends OpenDiagramEditPolicy {
           }
           if (!((DDiagramElement) element).getParentDiagram().isIsInShowingMode() && targetSemanticElement != null
               && DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(targetSemanticElement)) {
+            targetSemanticElement = DoubleClickBehaviourUtil.INSTANCE.getTargetSemanticElement(targetSemanticElement);
             Session session = SessionManager.INSTANCE.getSession(element);
-            Collection<DRepresentationDescriptor> representations = DoubleClickBehaviourUtil.INSTANCE
-                .getRepresentationsDescriptors(targetSemanticElement);
+            Collection<DRepresentationDescriptor> representations = RepresentationHelper
+                .getAllRepresentationDescriptorsTargetedBy(Collections.singleton(targetSemanticElement));
             if (!representations.isEmpty()) {
               if (representations.size() > 1) {
                 Shell activeShell = Display.getDefault().getActiveShell();


### PR DESCRIPTION
If the referenced object had existing representations, double click worked
But if it hadn't, nothing would happen
Fixed it

Change-Id: Ibd862c938a2802eef6a4d225ab1fa6fa0fd16b37
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>