### PR TITLE
[#2487] Allocated ExchangeItems properly transitionned

### DIFF
--- a/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/fa/FunctionInputPortRule.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/fa/FunctionInputPortRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 
 package org.polarsys.capella.core.transition.system.rules.fa;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IStatus;
@@ -26,6 +27,7 @@ import org.polarsys.capella.core.transition.common.handlers.contextscope.Context
 import org.polarsys.capella.core.transition.common.handlers.transformation.TransformationHandlerHelper;
 import org.polarsys.capella.core.transition.system.rules.AbstractCapellaElementRule;
 import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IContext;
+import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IPremise;
 
 /**
  */
@@ -52,8 +54,8 @@ public class FunctionInputPortRule extends AbstractCapellaElementRule {
   @Override
   protected void attachRelated(EObject element, EObject result, IContext context) {
     super.attachRelated(element, result, context);
-    AttachmentHelper.getInstance(context).attachTracedElements(element, result, FaPackage.Literals.FUNCTION_INPUT_PORT__INCOMING_EXCHANGE_ITEMS,
-        context);
+    AttachmentHelper.getInstance(context).attachTracedElements(element, result,
+        FaPackage.Literals.FUNCTION_INPUT_PORT__INCOMING_EXCHANGE_ITEMS, context);
   }
 
   @Override
@@ -68,10 +70,22 @@ public class FunctionInputPortRule extends AbstractCapellaElementRule {
       result.addAll(element.getIncoming());
       result.addAll(element.getOutgoing());
       result.addAll(element.getIncomingExchangeItems());
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getIncoming(), context);
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getOutgoing(), context);
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getIncomingExchangeItems(), context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getIncoming(),
+          context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getOutgoing(),
+          context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE,
+          element.getIncomingExchangeItems(), context);
     }
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void premicesRelated(EObject element, ArrayList<IPremise> needed) {
+    super.premicesRelated(element, needed);
+    needed.addAll(
+        createDefaultPrecedencePremices(element, FaPackage.Literals.FUNCTION_INPUT_PORT__INCOMING_EXCHANGE_ITEMS));
+  }
 }

--- a/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/fa/FunctionOutputPortRule.java
+++ b/core/plugins/org.polarsys.capella.core.transition.system/src/org/polarsys/capella/core/transition/system/rules/fa/FunctionOutputPortRule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -13,6 +13,7 @@
 
 package org.polarsys.capella.core.transition.system.rules.fa;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IStatus;
@@ -26,6 +27,7 @@ import org.polarsys.capella.core.transition.common.handlers.contextscope.Context
 import org.polarsys.capella.core.transition.common.handlers.transformation.TransformationHandlerHelper;
 import org.polarsys.capella.core.transition.system.rules.AbstractCapellaElementRule;
 import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IContext;
+import org.polarsys.kitalpha.transposer.rules.handler.rules.api.IPremise;
 
 /**
  */
@@ -52,8 +54,8 @@ public class FunctionOutputPortRule extends AbstractCapellaElementRule {
   @Override
   protected void attachRelated(EObject element, EObject result, IContext context) {
     super.attachRelated(element, result, context);
-    AttachmentHelper.getInstance(context).attachTracedElements(element, result, FaPackage.Literals.FUNCTION_OUTPUT_PORT__OUTGOING_EXCHANGE_ITEMS,
-        context);
+    AttachmentHelper.getInstance(context).attachTracedElements(element, result,
+        FaPackage.Literals.FUNCTION_OUTPUT_PORT__OUTGOING_EXCHANGE_ITEMS, context);
   }
 
   @Override
@@ -68,11 +70,24 @@ public class FunctionOutputPortRule extends AbstractCapellaElementRule {
       result.addAll(element.getIncoming());
       result.addAll(element.getOutgoing());
       result.addAll(element.getOutgoingExchangeItems());
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getIncoming(), context);
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getOutgoing(), context);
-      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getOutgoingExchangeItems(), context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getIncoming(),
+          context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE, element.getOutgoing(),
+          context);
+      ContextScopeHandlerHelper.getInstance(context).addAll(ITransitionConstants.SOURCE_SCOPE,
+          element.getOutgoingExchangeItems(), context);
 
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void premicesRelated(EObject element, ArrayList<IPremise> needed) {
+    super.premicesRelated(element, needed);
+    needed.addAll(
+        createDefaultPrecedencePremices(element, FaPackage.Literals.FUNCTION_OUTPUT_PORT__OUTGOING_EXCHANGE_ITEMS));
   }
 
 }


### PR DESCRIPTION
During S-SS transition, exchange items allocated to functionInputPort were not properly transitionned in horizontal

Fixed it and potential issue on FunctionOutputPort

Change-Id: Ia96881cd0a6b0b601fc3ca87f872ef503d7b6d76
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>