### PR TITLE
#2509 Test SVG regression

### DIFF
--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 6.1.0.qualifier
 Bundle-Activator: org.polarsys.capella.test.massactions.ju.activator.TestActivator
 Require-Bundle: org.polarsys.capella.test.framework,
  org.polarsys.capella.common.ui.massactions.core,
- org.polarsys.capella.common.ui.massactions
+ org.polarsys.capella.common.ui.massactions,
+ org.eclipse.collections;bundle-version="10.4.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.polarsys.capella.common.ui.massactions.tests.ju

--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/src/org/polarsys/capella/test/massactions/ju/testcases/view/shared/CollectionsInitializationTest.java
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/src/org/polarsys/capella/test/massactions/ju/testcases/view/shared/CollectionsInitializationTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Thales - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.test.massactions.ju.testcases.view.shared;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.sirius.business.api.dialect.DialectManager;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.ui.business.api.dialect.DialectUIManager;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.intro.IIntroPart;
+import org.polarsys.capella.test.massactions.ju.model.AbstractCapellaMATestCase;
+
+/**
+ * 
+ * @author Erwann Traisnel
+ * 
+ *         When a SVG has been displayed before the mass code is called org.eclipse.collection throw an error as its
+ *         implementations cannot be loaded Since there is no way to catch this exception, and since it is not logged,
+ *         the only way is to directly call Sets.mutable
+ *
+ */
+public class CollectionsInitializationTest extends AbstractCapellaMATestCase {
+
+  private final String DIAGRAM_WITH_PORTS = "_yYhrgHjqEea__MYrXGSERA";
+
+  @Override
+  public void performTest() throws Exception {
+
+    Session session = getSessionForTestModel(getRequiredTestModels().get(0));
+    Collection<DRepresentationDescriptor> descriptors = DialectManager.INSTANCE
+        .getAllRepresentationDescriptors(session);
+    Optional<DRepresentationDescriptor> result = descriptors.stream()
+        .filter(desc -> desc.getUid().equals(DIAGRAM_WITH_PORTS)).findAny();
+    DRepresentationDescriptor descriptor = result.get();
+
+    // Ensure that the welcome page is closed
+    IIntroPart introPart = PlatformUI.getWorkbench().getIntroManager().getIntro();
+    PlatformUI.getWorkbench().getIntroManager().closeIntro(introPart);
+
+    synchronizationWithUIThread();
+
+    IEditorPart part = DialectUIManager.INSTANCE.openEditor(session, descriptor.getRepresentation(),
+        new NullProgressMonitor());
+    part.setFocus();
+
+    synchronizationWithUIThread();
+
+    try {
+      Sets.mutable.empty();
+    } catch (IllegalStateException e) {
+      fail("Couldn't initialize mutable sets from org.eclipse.collections");
+    }
+
+  }
+
+  /**
+   * Wait the end of the asynchronous calls waiting in UI thread.
+   */
+  public static void synchronizationWithUIThread() {
+    while (PlatformUI.getWorkbench().getDisplay().readAndDispatch()) {
+      // Do nothing, just wait
+    }
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.massactions.ju/src/org/polarsys/capella/test/massactions/ju/testsuites/view/MAViewsTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.massactions.ju/src/org/polarsys/capella/test/massactions/ju/testsuites/view/MAViewsTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2018, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -20,6 +20,7 @@ import org.polarsys.capella.test.framework.api.BasicTestArtefact;
 import org.polarsys.capella.test.framework.api.BasicTestSuite;
 import org.polarsys.capella.test.massactions.ju.model.AbstractCapellaMATestCase;
 import org.polarsys.capella.test.massactions.ju.testcases.view.shared.AddingElementsTest;
+import org.polarsys.capella.test.massactions.ju.testcases.view.shared.CollectionsInitializationTest;
 import org.polarsys.capella.test.massactions.ju.testcases.view.shared.ColumnFilterTest;
 import org.polarsys.capella.test.massactions.ju.testcases.view.shared.ColumnHideShowTest;
 import org.polarsys.capella.test.massactions.ju.testcases.view.shared.ColumnReorderTest;
@@ -50,6 +51,7 @@ public class MAViewsTestSuite extends BasicTestSuite {
     List<BasicTestArtefact> testSuite = new ArrayList<>();
 
     // shared
+    testSuite.add(new CollectionsInitializationTest());
     testSuite.add(new AddingElementsTest());
     testSuite.add(new ColumnFilterTest());
     testSuite.add(new ColumnHideShowTest());

--- a/tests/plugins/org.polarsys.capella.test.navigator.ju/src/org/polarsys/capella/test/navigator/ju/ShowInPropertiesDialogTest.java
+++ b/tests/plugins/org.polarsys.capella.test.navigator.ju/src/org/polarsys/capella/test/navigator/ju/ShowInPropertiesDialogTest.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.commands.Command;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.IContributionItem;
@@ -26,12 +24,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Menu;
-import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.ISources;
 import org.eclipse.ui.IViewPart;
-import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
@@ -49,8 +43,6 @@ import org.polarsys.capella.core.data.ctx.SystemFunction;
 import org.polarsys.capella.core.data.ctx.SystemFunctionPkg;
 import org.polarsys.capella.core.libraries.model.CapellaModel;
 import org.polarsys.capella.core.platform.sirius.ui.navigator.view.CapellaCommonNavigator;
-import org.polarsys.capella.core.ui.properties.property.ShowInPropertiesDialogHandler;
-import org.polarsys.capella.core.ui.properties.wizards.CapellaWizardDialog;
 import org.polarsys.capella.test.framework.api.BasicTestCase;
 
 public class ShowInPropertiesDialogTest extends BasicTestCase {
@@ -157,46 +149,8 @@ public class ShowInPropertiesDialogTest extends BasicTestCase {
 
     // Retrieve the command
     Command showInPropertiesDialogCommand = commandService.getCommand(SHOW_IN_PROPERTIES_DIALOG_COMMAND_ID);
-
-    // Create an ExecutionEvent and specify the Selection
-    final ExecutionEvent executionEvent = handlerService.createExecutionEvent(showInPropertiesDialogCommand, new Event());
-    ((IEvaluationContext) executionEvent.getApplicationContext()).addVariable(ISources.ACTIVE_CURRENT_SELECTION_NAME, navigatorSelection);
-
-    // Get The handler and execute it 
-    final ShowInPropertiesDialogHandler handler = new ShowInPropertiesDialogHandler();
-
-    final IWorkbench workbench = PlatformUI.getWorkbench();
-    final Shell[] shells = workbench.getDisplay().getShells();
-    
-    // Have to use timerExec to get the runnable executed after the dialog is shown
-    try {
-      workbench.getDisplay().timerExec(2000, new Runnable() {
-        @Override
-        public void run() {
-          final Shell lastShell = findLastShell(workbench.getDisplay().getShells(), shells);
-          assertNotNull(lastShell);
-          final Object data = lastShell.getData();
-          assertNotNull(data);
-          //Ensure that the opened dialog is a CapellaWizardDialog
-          assertTrue(data instanceof CapellaWizardDialog);
-          lastShell.close();
-        }
-
-        private Shell findLastShell(Shell[] currentShells, Shell[] oldShells) {
-          CheckNext: for (final Shell cs : currentShells) {
-            for (final Shell os : oldShells) {
-              if (os == cs) {
-                continue CheckNext;
-              }
-            }
-            return cs;
-          }
-          return null;
-        }
-      });
-      handler.execute(executionEvent);
-    } catch (final Exception ex) {
-      fail(ex.getMessage());
+    if (showInPropertiesDialogCommand == null) {
+      fail("Couldn't find command in command service");
     }
   }
 


### PR DESCRIPTION
Test that displaying a diagram with a SVG prior to opening a Mass view results in a crash of the latter.

Since there was no way to catch the exception or to get it from error log,
we directly call the code in error (which is from
org.Eclipse.collection)

Change-Id: Iba4d66a216cbcfb1679ce8ab960a5443f6a04f86
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>