### PR TITLE
#2514 Update library property tester and provider/manager APis

### DIFF
--- a/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/ILibraryManager.java
+++ b/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/ILibraryManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -31,7 +31,13 @@ public abstract class ILibraryManager {
   /**
    * Returns all available models
    */
+  @Deprecated
   public abstract Collection<IModelIdentifier> getAvailableModels();
+
+  /**
+   * Returns all available models for the given {@link TransactionalEditingDomain}
+   */
+  public abstract Collection<IModelIdentifier> getAvailableModels(TransactionalEditingDomain domain);
 
   /** 
    * Returns all models related to the given editing domain.

--- a/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/manager/LibraryManager.java
+++ b/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/manager/LibraryManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -42,11 +42,6 @@ public class LibraryManager extends ILibraryManager implements ILibraryProviderL
   Collection<ILibraryProvider> providers = null;
 
   /**
-   * A stored version of all model identifiers. it is cleared each time a provider notifies us.
-   */
-  Collection<IModelIdentifier> models = null;
-
-  /**
    * A stored version of model per editing domain.
    */
   HashMap<TransactionalEditingDomain, IModel> modelsPerDomain = null;
@@ -77,23 +72,25 @@ public class LibraryManager extends ILibraryManager implements ILibraryProviderL
 
   @Override
   public Collection<IModelIdentifier> getAvailableModels() {
-    if (models == null) {
-      models = new ArrayList<IModelIdentifier>();
-      for (ILibraryProvider provider : getProviders()) {
-        for (IModelIdentifier model : provider.getAvailableModels()) {
-          if (!models.contains(model)) {
-            models.add(model);
-          }
-        }
-      }
-    }
-    return models;
+      return getAvailableModels(null);
   }
+
+  @Override
+  public Collection<IModelIdentifier> getAvailableModels(TransactionalEditingDomain domain) {
+      Collection<IModelIdentifier> models = new ArrayList<IModelIdentifier>();
+      for (ILibraryProvider provider : getProviders()) {
+          for (IModelIdentifier model : provider.getAvailableModels(domain)) {
+              if (!models.contains(model)) {
+                  models.add(model);
+              }
+          }
+      }
+      return models;
+    }
 
   @Override
   public void onLibraryProviderChanged(LibraryProviderEvent event) {
     // We should clear cache (maybe we could do less)
-    models = null;
     modelsPerDomain = null;
   }
 
@@ -101,7 +98,7 @@ public class LibraryManager extends ILibraryManager implements ILibraryProviderL
   public Collection<IModel> getAllModels(TransactionalEditingDomain domain) {
     HashMap<IModelIdentifier, IModel> models = new HashMap<IModelIdentifier, IModel>();
 
-    for (IModelIdentifier identifier : getAvailableModels()) {
+    for (IModelIdentifier identifier : getAvailableModels(domain)) {
       IModel model = getModel(domain, identifier);
       if (model != null) {
         models.put(identifier, model);

--- a/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/provider/ILibraryProvider.java
+++ b/common/plugins/org.polarsys.capella.common.libraries/src/org/polarsys/capella/common/libraries/provider/ILibraryProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import java.util.Collection;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.sirius.business.api.session.Session;
 import org.polarsys.capella.common.libraries.IModel;
 import org.polarsys.capella.common.libraries.IModelIdentifier;
 
@@ -30,7 +31,13 @@ public interface ILibraryProvider {
   /**
    * Returns all models available through the provider
    */
+  @Deprecated
   public Collection<IModelIdentifier> getAvailableModels();
+
+  /**
+   * Returns all models available for the given {@link Session} through the provider
+   */
+  public Collection<IModelIdentifier> getAvailableModels(TransactionalEditingDomain domain);
 
   /**
    * Returns the related model if the object is linked to a model provided by this provider or null otherwise

--- a/core/plugins/org.polarsys.capella.core.libraries.ui/src/org/polarsys/capella/core/libraries/ui/propertyTester/CapellaModelIsLocalPropertyTester.java
+++ b/core/plugins/org.polarsys.capella.core.libraries.ui/src/org/polarsys/capella/core/libraries/ui/propertyTester/CapellaModelIsLocalPropertyTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,9 +14,10 @@ package org.polarsys.capella.core.libraries.ui.propertyTester;
 
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.jface.viewers.StructuredSelection;
-
-import org.polarsys.capella.core.libraries.utils.IFileRequestor;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.business.api.session.SessionManager;
 import org.polarsys.capella.core.model.handler.command.CapellaResourceHelper;
 
 /**
@@ -33,7 +34,12 @@ public class CapellaModelIsLocalPropertyTester extends PropertyTester {
       // the project is exported if there is no semantic model file at the same level of the aird file
       if ((selection != null) && (selection instanceof IFile)) {
         IFile airdFile = (IFile) selection;
-        return new IFileRequestor().search(airdFile.getParent(), CapellaResourceHelper.CAPELLA_MODEL_FILE_EXTENSION, false).size() > 0;
+        Session session = SessionManager.INSTANCE.getExistingSession(URI.createPlatformResourceURI(airdFile.getFullPath().toString(), true));
+        // Session is not null if it is opened
+        if (session != null) {
+            // Use the session to check that at least one semantic resource is a Capella model
+            return session.getSemanticResources().stream().anyMatch(res -> CapellaResourceHelper.CAPELLA_MODEL_FILE_EXTENSION.equals(res.getURI().fileExtension()));
+        }
       }
     }
     return false;

--- a/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/AbstractCapellaProvider.java
+++ b/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/AbstractCapellaProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.sirius.business.api.query.URIQuery;
 import org.polarsys.capella.common.helpers.TransactionHelper;
 import org.polarsys.capella.common.libraries.ILibraryManager;
 import org.polarsys.capella.common.libraries.IModel;
@@ -51,6 +52,15 @@ public abstract class AbstractCapellaProvider extends AbstractLibraryProvider {
 
   protected boolean isHandled(URI uri) {
     return false;
+  }
+
+  protected boolean isLocalProject(TransactionalEditingDomain domain) {
+      for (Resource resource : domain.getResourceSet().getResources()) {
+          if (resource.getURI().scheme().equals(URIQuery.CDO_URI_SCHEME)) {
+              return false;
+          }
+      }
+      return true;
   }
 
   @Override

--- a/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/CapellaWorkspaceProvider.java
+++ b/core/plugins/org.polarsys.capella.core.libraries/src/org/polarsys/capella/core/libraries/provider/CapellaWorkspaceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -146,6 +146,13 @@ public class CapellaWorkspaceProvider extends AbstractCapellaProvider
       }
     }
     return _modelIds;
+  }
+
+  public Collection<IModelIdentifier> getAvailableModels(TransactionalEditingDomain domain) {
+      if (isLocalProject(domain)) {
+          return getAvailableModels();
+      }
+      return Collections.EMPTY_LIST;
   }
 
   @Override

--- a/doc/plugins/org.polarsys.capella.developer.doc/.settings/org.eclipse.core.resources.prefs
+++ b/doc/plugins/org.polarsys.capella.developer.doc/.settings/org.eclipse.core.resources.prefs
@@ -2,4 +2,3 @@ eclipse.preferences.version=1
 encoding//html/Capella\ Studio.html=UTF-8
 encoding//html/Introduction.html=UTF-8
 encoding//html/Tutorials.html=UTF-8
-encoding//html/Viewpoint\ Guidelines.html=UTF-8

--- a/doc/plugins/org.polarsys.capella.re.doc/html/09. Libraries/9.2. Basic Use Case.html
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/09. Libraries/9.2. Basic Use Case.html
@@ -46,10 +46,15 @@
 			<img border="0" src="Images/9.2.%20Basic%20Use%20Case_html_m74ed6e65.png"/>
 		</p>
 		<p>
-			<b> Notice : </b> This wizard seems to provide the functionality to 
-			<i>Unreference a Library from a Project</i>. Unckeck the Library in this wizard is only the first-step to perform while unreferencing a library. This operation has a dedicated How-to procedure in the 
-			<i>Advanced Operations &gt; Unreference a Library</i> section.
+			<b> Notices : </b> 
 		</p>
+		<ol>
+			<li>This wizard seems to provide the functionality to 
+				<i>Unreference a Library from a Project</i>. Unckeck the Library in this wizard is only the first-step to perform while unreferencing a library. This operation has a dedicated How-to procedure in the 
+				<i>Advanced Operations &gt; Unreference a Library</i> section.
+			</li>
+			<li>As libraries may rely on additional viewpoints, adding reference to a library will make the project depend on those viewpoints. Make sure these viewpoints are also available and installed for all users of the current project.</li>
+		</ol>
 		<h2 id="Using_Library_Elements_from_a_Project">Using Library Elements from a Project</h2>
 		<p>Elements from the referenced library are accessible from elements in the Project model.</p>
 		<p><u>

--- a/doc/plugins/org.polarsys.capella.re.doc/html/09. Libraries/9.2. Basic Use Case.mediawiki
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/09. Libraries/9.2. Basic Use Case.mediawiki
@@ -63,7 +63,9 @@ Once the Project Model is opened, the referenced Library can be seen directly fr
 
 [[Image:Images/9.2.%20Basic%20Use%20Case_html_m74ed6e65.png]]
 
-''' Notice : ''' This wizard seems to provide the functionality to ''Unreference a Library from a Project''. Unckeck the Library in this wizard is only the first-step to perform while unreferencing a library. This operation has a dedicated How-to procedure in the ''Advanced Operations > Unreference a Library'' section.
+''' Notices : ''' 
+# This wizard seems to provide the functionality to ''Unreference a Library from a Project''. Unckeck the Library in this wizard is only the first-step to perform while unreferencing a library. This operation has a dedicated How-to procedure in the ''Advanced Operations > Unreference a Library'' section.
+# As libraries may rely on additional viewpoints, adding reference to a library will make the project depend on those viewpoints. Make sure these viewpoints are also available and installed for all users of the current project.
 
 == Using Library Elements from a Project ==
 


### PR DESCRIPTION
To bypass the limitation of library management for shared capella project (add/remove reference to shared library project), a property tester requires to be updated and an API added:
- CapellaModelIsLocalPropertyTester now uses the airdFile to check that the session is opened and contains a Capella model
- ILibraryManager and ILibraryProvider methods getAvailableModels has been doubled to give the session has a parameter. This allows CDOLibraryProvider to use the session to check for other models on the CDO repository it is connected to.

Change-Id: If79cedfe0128cc960f3da679706c5be85557c1e2
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>