### PR TITLE
 #2498 Migrate DWF_DS_25 to DCOM_24

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.fa.validation/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.data.fa.validation/plugin.xml
@@ -863,7 +863,7 @@ function containing the bound which has been realized.
                   isEnabledByDefault="true"
                   lang="Java"
                   mode="Batch"
-                  name="TC_DF_07 - Functional exchange convoyed exchange items check"
+                  name="TC_DF_07 - Functional exchange conveyed exchange items check"
                   severity="WARNING"
                   statusCode="1">
                <message>

--- a/core/plugins/org.polarsys.capella.core.data.interaction.validation/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.validation/plugin.xml
@@ -278,21 +278,21 @@ Whatever the level, UNSET Scenarios raise an error.
             </constraint>
             <constraint
                   class="org.polarsys.capella.core.data.interaction.validation.sequenceMessage.SequenceMessageInvokedOperationExchangeItems"
-                  id="DWF_DS_25"
+                  id="DCOM_24"
                   isEnabledByDefault="true"
                   lang="Java"
                   mode="Batch"
-                  name="DWF_DS_25 - SequenceMessage has different ExchangeItem Elements as its Invoked Operation"
+                  name="DCOM_24 - Sequence Message conveys no Exchange Item compared to its Invoked Operation"
                   severity="WARNING"
                   statusCode="1">
                <message>
-                  {0} (SequenceMessage) should have the same ExchangeItem Elements as its Invoked {1} ({2})
+                  {0} (SequenceMessage) conveys no Exchange Item compared to its Invoked {1} ({2})
                </message>
                <target
                      class="SequenceMessage">
                </target>
                <description>
-                  This rule checks that the SequenceMessage has the same ExchangeItem Elements as its Invoked Operation.
+                  This rule generates a warning if a Sequence Message has no Exchange Item while its Invoked Operation has some.
                </description>
             </constraint>
          </constraints>

--- a/core/plugins/org.polarsys.capella.core.data.interaction.validation/src/org/polarsys/capella/core/data/interaction/validation/sequenceMessage/SequenceMessageInvokedOperationExchangeItems.java
+++ b/core/plugins/org.polarsys.capella.core.data.interaction.validation/src/org/polarsys/capella/core/data/interaction/validation/sequenceMessage/SequenceMessageInvokedOperationExchangeItems.java
@@ -21,17 +21,11 @@ import org.eclipse.emf.validation.EMFEventType;
 import org.eclipse.emf.validation.IValidationContext;
 import org.polarsys.capella.common.data.modellingcore.AbstractExchangeItem;
 import org.polarsys.capella.common.helpers.EObjectLabelProviderHelper;
-import org.polarsys.capella.core.data.cs.ExchangeItemAllocation;
 import org.polarsys.capella.core.data.fa.AbstractFunction;
-import org.polarsys.capella.core.data.fa.ComponentExchange;
 import org.polarsys.capella.core.data.fa.FunctionalExchange;
 import org.polarsys.capella.core.data.information.AbstractEventOperation;
-import org.polarsys.capella.core.data.information.Operation;
-import org.polarsys.capella.core.data.information.Service;
 import org.polarsys.capella.core.data.interaction.MessageKind;
 import org.polarsys.capella.core.data.interaction.SequenceMessage;
-import org.polarsys.capella.core.data.interaction.properties.dialogs.sequenceMessage.model.communications.InterfaceCommunication;
-import org.polarsys.capella.core.data.oa.CommunicationMean;
 import org.polarsys.capella.core.data.oa.OperationalActivity;
 import org.polarsys.capella.core.model.helpers.FunctionalExchangeExt;
 import org.polarsys.capella.core.model.helpers.SequenceMessageExt;
@@ -63,7 +57,7 @@ public class SequenceMessageInvokedOperationExchangeItems extends AbstractModelC
         AbstractEventOperation invokedOperation = sequenceMessage.getInvokedOperation();
         if (null != invokedOperation) {
             Collection<AbstractExchangeItem> lstInvokedEI = SequenceMessageExt.getExchangeItemsFromOperation(sequenceMessage);
-            if (!sequenceMessage.getExchangedItems().containsAll(lstInvokedEI)) {
+            if (!lstInvokedEI.isEmpty() && sequenceMessage.getExchangedItems().isEmpty()) {
                 String invokedOperationDisplayName = computeDisplayNameForOperation(invokedOperation);
                 return ctx.createFailureStatus(sequenceMessage.getName(), invokedOperation.getName(), invokedOperationDisplayName);
             }

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/completeness/ValidationRules.html
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/completeness/ValidationRules.html
@@ -325,12 +325,26 @@
 		<table class="VALIDATION-RULE">
 			<tr>
 				<th>
+					<img title="WARNING" alt="WARNING" border="0" src="../../../Images/error.gif"/>
+				</th>
+				<td>DCOM_24 - Sequence Message conveys no Exchange Item compared to its Invoked Operation</td>
+			</tr>
+			<tr>
+				<td colspan="2">This rule generates a warning if a Sequence Message has no Exchange Item while its Invoked Operation has some.</td>
+			</tr>
+		</table>
+		<p>
+			<br/>
+		</p>
+		<table class="VALIDATION-RULE">
+			<tr>
+				<th>
 					<img title="WARNING" alt="WARNING" border="0" src="../../../Images/warning.gif"/>
 				</th>
 				<td>DC_CL_01  Communication Link is delegated by one subcomponent at least </td>
 			</tr>
 			<tr>
-				<td colspan="2">Model Validation shall check that Exchange Items referenced by a Communication Link is delegated to one or many subcomponents of the source Component.</td>
+				<td colspan="2">Model Validation shall check that Exchange Items referenced by a Communication Link is delegated to one or many subcomponents of the source Component.</td>
 			</tr>
 		</table>
 		<p>
@@ -344,7 +358,7 @@
 				<td>DC_CL_02 Communication Link for a component is defined in its parent </td>
 			</tr>
 			<tr>
-				<td colspan="2">Model Validation shall check that an Exchange Item referenced by a Communication Link from a SubComponent is also referenced by a Communication Link from owning Components.</td>
+				<td colspan="2">Model Validation shall check that an Exchange Item referenced by a Communication Link from a SubComponent is also referenced by a Communication Link from owning Components.</td>
 			</tr>
 		</table>
 	</body>

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/completeness/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/completeness/ValidationRules.mediawiki
@@ -158,15 +158,22 @@
 |}
 <br>
 {| class="VALIDATION-RULE"
+!|[[Image:../../../Images/error.gif|WARNING]]
+|DCOM_24 - Sequence Message conveys no Exchange Item compared to its Invoked Operation
+|-
+| colspan="2"|This rule generates a warning if a Sequence Message has no Exchange Item while its Invoked Operation has some.
+|}
+<br>
+{| class="VALIDATION-RULE"
 !|[[Image:../../../Images/warning.gif|WARNING]]
 |DC_CL_01  Communication Link is delegated by one subcomponent at least 
 |-
-| colspan="2"|Model Validation�shall check that Exchange Items referenced by a Communication Link is delegated to one or many subcomponents of the source Component.
+| colspan="2"|Model Validation shall check that Exchange Items referenced by a Communication Link is delegated to one or many subcomponents of the source Component.
 |}
 <br>
 {| class="VALIDATION-RULE"
 !|[[Image:../../../Images/warning.gif|WARNING]]
 |DC_CL_02 Communication Link for a component is defined in its parent 
 |-
-| colspan="2"|Model Validation�shall check that an Exchange Item referenced by a Communication Link from a SubComponent is also referenced by a Communication Link from owning Components.
+| colspan="2"|Model Validation shall check that an Exchange Item referenced by a Communication Link from a SubComponent is also referenced by a Communication Link from owning Components.
 |}

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/well-formedness/scenarios/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/design/well-formedness/scenarios/ValidationRules.mediawiki
@@ -172,9 +172,3 @@ Whatever the level, UNSET Scenarios raise an error.
 |-
 | colspan="2"|Check that the Instance Role has the same name as its Represented Instance.
 |}
-{| class="VALIDATION-RULE"
-!|[[Image:../../../../Images/warning.gif|WARNING]]
-|DWF_DS_25 - SequenceMessage has different ExchangeItem Elements as its Invoked Operation
-|-
-| colspan="2"|Checks that the SequenceMessage has the same ExchangeItem Elements as its Invoked Operation.
-|}

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/transition/consistency/dataflows/ValidationRules.html
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/transition/consistency/dataflows/ValidationRules.html
@@ -117,7 +117,7 @@
 				<th>
 					<img title="WARNING" alt="WARNING" border="0" src="../../../../Images/warning.gif"/>
 				</th>
-				<td>TC_DF_07 - Functional exchange convoyed exchange items check </td>
+				<td>TC_DF_07 - Functional exchange conveyed exchange items check </td>
 			</tr>
 			<tr>
 				<td colspan="2">This rule checks that a FunctionalExchange isn't linked to an ExchangeItem from a previous level whereas it is realized in the same level than the FunctionalExchange. FunctionalExchange should be linked to the realized ExchangeItem.

--- a/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/transition/consistency/dataflows/ValidationRules.mediawiki
+++ b/doc/plugins/org.polarsys.capella.validation.doc/html/Validation Rules/transition/consistency/dataflows/ValidationRules.mediawiki
@@ -60,7 +60,7 @@ function containing the bound which has been realized.
 <br>
 {| class="VALIDATION-RULE"
 !|[[Image:../../../../Images/warning.gif|WARNING]]
-|TC_DF_07 - Functional exchange convoyed exchange items check 
+|TC_DF_07 - Functional exchange conveyed exchange items check 
 |-
 | colspan="2"|This rule checks that a FunctionalExchange isn't linked to an ExchangeItem from a previous level whereas it is realized in the same level than the FunctionalExchange. FunctionalExchange should be linked to the realized ExchangeItem.
 A warning can be raised if you have performed a transition of the FunctionalExchange before performing a transition of the linked ExchangeItem.

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/model/RulesOnDesignTest/RulesOnDesignTest.capella
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--Capella_Version_5.1.0-->
+<!--Capella_Version_6.1.0-->
 <org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation"
     xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/6.0.0"
@@ -33188,7 +33188,7 @@
     </ownedArchitectures>
   </ownedModelRoots>
   <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
-      id="c72bf948-9bc0-4a2c-a94e-90eb02adafe9" name="DWF_DS_25" summary="A state machine must have only one initial state">
+      id="c72bf948-9bc0-4a2c-a94e-90eb02adafe9" name="DCOM_24" summary="A state machine must have only one initial state">
     <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
         id="0d047236-2d9b-48d6-8113-bf41ff3560e3" name="Operational Analysis">
       <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
@@ -33727,7 +33727,7 @@
             <ownedMessages xsi:type="org.polarsys.capella.core.data.interaction:SequenceMessage"
                 id="85aea90c-32a7-40e8-aed1-29e560a1d29d" name="FunctionalExchange 1"
                 kind="ASYNCHRONOUS_CALL" sendingEnd="#1b6381de-b04e-4fcb-bd25-a28e429abdcf"
-                receivingEnd="#8aa56df4-2de3-434d-a0a3-871bd83cc2bb" exchangedItems="#7052dda1-fc2a-4a19-b44a-0f72302b53f8 #38c6a2e9-6f49-4be3-8307-3dc0fbddeed6"/>
+                receivingEnd="#8aa56df4-2de3-434d-a0a3-871bd83cc2bb" exchangedItems="#38c6a2e9-6f49-4be3-8307-3dc0fbddeed6"/>
             <ownedMessages xsi:type="org.polarsys.capella.core.data.interaction:SequenceMessage"
                 id="0821d8e4-d299-4a03-b734-03d8a851e5bc" name="FunctionalExchange 2"
                 kind="ASYNCHRONOUS_CALL" sendingEnd="#8eb418a4-b259-4831-98c6-34a7f5c9126a"
@@ -33879,7 +33879,7 @@
             <ownedMessages xsi:type="org.polarsys.capella.core.data.interaction:SequenceMessage"
                 id="affe6248-ea74-4e21-9dcc-b8695139b031" name="C 1" kind="ASYNCHRONOUS_CALL"
                 sendingEnd="#3419cfc9-d628-407a-89d0-0c14ce885db9" receivingEnd="#7cfdb0e7-36b9-4ae0-a167-e9d31357d42c"
-                exchangedItems="#7052dda1-fc2a-4a19-b44a-0f72302b53f8 #38c6a2e9-6f49-4be3-8307-3dc0fbddeed6 #4b97348a-ec69-435c-9948-0d1a923b28a4"/>
+                exchangedItems="#7052dda1-fc2a-4a19-b44a-0f72302b53f8 #4b97348a-ec69-435c-9948-0d1a923b28a4"/>
             <ownedMessages xsi:type="org.polarsys.capella.core.data.interaction:SequenceMessage"
                 id="350def69-40f1-4912-a90c-0c3094a38d92" name="C 3" kind="ASYNCHRONOUS_CALL"
                 sendingEnd="#a37d78f8-52cc-4f7e-a2ca-44affcbcd9af" receivingEnd="#7ad6dd2d-f048-45d4-b9aa-c238a4d925a2"/>

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dcom/DCOMRulesTestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dcom/DCOMRulesTestSuite.java
@@ -57,6 +57,8 @@ public class DCOMRulesTestSuite extends BasicTestSuite {
     tests.add(new Rule_DCOM_20());
     tests.add(new Rule_DCOM_21());
     tests.add(new Rule_DCOM_22());
+    tests.add(new Rule_DCOM_23());
+    tests.add(new Rule_DCOM_24());
 		return tests;
 	}
 

--- a/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dcom/Rule_DCOM_24.java
+++ b/tests/plugins/org.polarsys.capella.test.validation.rules.ju/src/org/polarsys/capella/test/validation/rules/ju/testcases/dcom/Rule_DCOM_24.java
@@ -10,7 +10,7 @@
  * Contributors:
  *    Thales - initial API and implementation
  *******************************************************************************/
-package org.polarsys.capella.test.validation.rules.ju.testcases.dwf_ds;
+package org.polarsys.capella.test.validation.rules.ju.testcases.dcom;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,10 +35,11 @@ import org.polarsys.capella.test.framework.helpers.log.FormatedSysoutLogger;
 import org.polarsys.capella.test.validation.rules.ju.testcases.AbstractRulesOnDesignTest;
 
 /**
- * test on DWF_DS_25: This rule checks that Sequence Messages allocated ExchangeItems are consistent with their invoked
- * operation ExchangeItems.
+ * test on DCOM_24: This rule checks that Sequence Messages allocated ExchangeItems are consistent with their invoked
+ * operation ExchangeItems. Only raises a warning if none of the invoked operation ExchangeItems are allocated to the
+ * Sequence Message.
  */
-public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
+public class Rule_DCOM_24 extends AbstractRulesOnDesignTest {
 
     protected FormatedLogger logger = new FormatedSysoutLogger();
 
@@ -55,7 +56,7 @@ public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
      * @generated
      */
     protected String getRuleID() {
-        return "org.polarsys.capella.core.data.interaction.validation.DWF_DS_25";
+        return "org.polarsys.capella.core.data.interaction.validation.DCOM_24";
     }
     
     @Override
@@ -78,7 +79,11 @@ public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
                 // SequenceMessages invoking Interactions with correctly allocated EI
                 "c17be500-c92f-461c-a9d4-e679a3f5f7ea", 
                 // SequenceMessages invoking ComponentExchanges with correctly allocated EI
-                "affe6248-ea74-4e21-9dcc-b8695139b031");
+                "affe6248-ea74-4e21-9dcc-b8695139b031",
+                // SequenceMessages invoking Interactions with subset of allocated EI
+                "85aea90c-32a7-40e8-aed1-29e560a1d29d",
+                // SequenceMessages invoking ComponentExchanges with subset of allocated EI
+                "ff7785c8-6927-41e6-aab7-ecb7835827b2");
     }
 
     /**
@@ -90,6 +95,8 @@ public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
                 // SequenceMessages invoking FunctionalExchanges (1 = missing EI , 0 = no EI and non expected)
                 new OracleDefinition("c10f833f-84e7-4dbc-ade9-271b2cc3ff55", 1), new OracleDefinition("fa1de654-4a15-4bfb-8894-6463cf853843", 1),
                 new OracleDefinition("fabc8ba8-d847-446f-acf1-b5058b4f98a1", 0),
+                // SequenceMessages invoking Interactions and correctly allocated subset of EI (so expected 0)
+                new OracleDefinition("85aea90c-32a7-40e8-aed1-29e560a1d29d", 0),
                 // SequenceMessages invoking ComponentExchanges (1 = missing EI , 0 = no EI and non expected)
                 new OracleDefinition("c16b6582-fda0-444e-9f80-c53f5bcdcfa0", 1), new OracleDefinition("f3f9d688-35c9-41c1-a781-1d3cd1f48dac", 0),
                 new OracleDefinition("c0a51532-c307-4e97-b263-a0ec5f6bf159", 1),
@@ -99,7 +106,9 @@ public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
                 // SequenceMessages invoking Interactions and correctly allocated EI (so expected 0)
                 new OracleDefinition("c17be500-c92f-461c-a9d4-e679a3f5f7ea", 0),
                 // SequenceMessages invoking ComponentExchanges with correctly allocated EI (so expected 0)
-                new OracleDefinition("affe6248-ea74-4e21-9dcc-b8695139b031", 0));
+                new OracleDefinition("affe6248-ea74-4e21-9dcc-b8695139b031", 0),
+                // SequenceMessages invoking ComponentExchanges with correctly allocated subset of EI (so expected 0)
+                new OracleDefinition("ff7785c8-6927-41e6-aab7-ecb7835827b2", 0));
     }
     
     @Override
@@ -107,7 +116,7 @@ public class Rule_DWF_DS_25 extends AbstractRulesOnDesignTest {
         IStatus result = Status.OK_STATUS;
         for(IMarker marker: markers) {
             List<EObject> modelElements = MarkerViewHelper.getModelElementsFromMarker(marker);
-            if (!((modelElements.size() < 1) || !(modelElements.get(0) instanceof SequenceMessage))) {
+            if (!((modelElements.isEmpty()) || !(modelElements.get(0) instanceof SequenceMessage))) {
                 final SequenceMessage sequenceMessage = (SequenceMessage) modelElements.get(0);
                 AddAllExchangeItemsToSequenceMessageResolver resolver = new AddAllExchangeItemsToSequenceMessageResolver();
                 


### PR DESCRIPTION
Fix checking rule to only raise an error if the SequenceMessage allocated exchange items are empty while the invoked Exchange has ExchangeItems.

Move rule from DWF_DS_25 to DCOM_24

Adapt warning message
Update documentation
Update tests