### PR TITLE
#2526 Export Dialog / Export validation preference filename fix

### DIFF
--- a/common/plugins/org.polarsys.capella.common.ui/src/org/polarsys/capella/common/ui/toolkit/dialogs/AbstractExportDialog.java
+++ b/common/plugins/org.polarsys.capella.common.ui/src/org/polarsys/capella/common/ui/toolkit/dialogs/AbstractExportDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -108,6 +108,18 @@ public abstract class AbstractExportDialog extends AbstractViewerDialog {
     //
     String fileName = fd.open();
 
+    
+    int filterIndex = fd.getFilterIndex();
+    if (filterIndex != -1) {
+      // If a filter was selected
+      String selectedFilter = fd.getFilterExtensions()[filterIndex];
+      String fileExtension = selectedFilter.substring(1);
+      if (!fileName.endsWith(fileExtension)) {
+        // If the filename doesn't already have the extension, append it
+        fileName = fileName + fileExtension;
+      }
+    }
+    
     //
     // The export operation itself
     //

--- a/core/plugins/org.polarsys.capella.core.validation.ui/src/org/polarsys/capella/core/validation/ui/export/prefs/ExportValidationPreferencePage.java
+++ b/core/plugins/org.polarsys.capella.core.validation.ui/src/org/polarsys/capella/core/validation/ui/export/prefs/ExportValidationPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
-
 import org.polarsys.capella.common.helpers.export.DataExporter;
 import org.polarsys.capella.common.helpers.export.IExporterProvider;
 import org.polarsys.capella.core.commands.preferences.service.AbstractDefaultPreferencePage;
@@ -125,6 +124,17 @@ public class ExportValidationPreferencePage extends
 		// File Dialog selection
 		//
 		String fileName = fd.open();
+		
+    int filterIndex = fd.getFilterIndex();
+    if (filterIndex != -1) {
+      // If a filter was selected
+      String selectedFilter = fd.getFilterExtensions()[filterIndex];
+      String fileExtension = selectedFilter.substring(1);
+      if (!fileName.endsWith(fileExtension)) {
+        // If the filename doesn't already have the extension, append it
+        fileName = fileName + fileExtension;
+      }
+    }
 
 		//
 		// The export operation itself


### PR DESCRIPTION
If extension was missing from filename, the export would always fail Now ensures that the filename ends with the file extension, or add it if missing

Change-Id: I47197c67a1039b28b6b0fd94e9550eac69320c13
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>