### PR TITLE
#2527 Add default filename for metrics & progressmonitor export

### DIFF
--- a/common/plugins/org.polarsys.capella.common.ui/src/org/polarsys/capella/common/ui/toolkit/dialogs/AbstractExportDialog.java
+++ b/common/plugins/org.polarsys.capella.common.ui/src/org/polarsys/capella/common/ui/toolkit/dialogs/AbstractExportDialog.java
@@ -100,6 +100,7 @@ public abstract class AbstractExportDialog extends AbstractViewerDialog {
     //
     FileDialog fd = new FileDialog(getParentShell(), SWT.SAVE);
     fd.setText(Messages.fileBrowserDialogTitle);
+    fd.setFileName(getDefaultFileName());
     fd.setFilterExtensions(dataExporter.getSupportedExtension());
     fd.setFilterNames(dataExporter.getSupportedDescription());
 
@@ -198,5 +199,9 @@ public abstract class AbstractExportDialog extends AbstractViewerDialog {
    */
   protected Viewer getViewer() {
     return _viewer;
+  }
+  
+  protected String getDefaultFileName() {
+    return "";//$NON-NLS-1$
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/MetricMessages.java
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/MetricMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -29,6 +29,8 @@ public class MetricMessages extends NLS {
   public static String metricDialogDefaultTitle;
   public static String metricDialogTitleFromEObj;
   public static String metricDialogTitleFromFile;
+  
+  public static String metricDialog_default_filename;
 
   public static String treeObjectColumnLabel;
   public static String treeResultColumnLabel;
@@ -56,6 +58,8 @@ public class MetricMessages extends NLS {
   public static String progressMonitoring_setAction_nochanges_info;
   public static String progressMonitoring_setAction_changes_info;
 
+  public static String progressMonitoring_dialog_default_filename;
+  
   public static String progressMonitoring_dialog_title;
   public static String progressMonitoring_dialog_msg;
 

--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/dialog/MetricDialog.java
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/dialog/MetricDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -170,5 +170,10 @@ public class MetricDialog extends AbstractExportDialog {
 
   public void setResourceName(String name) {
     resourceName = name;
+  }
+  
+  @Override
+  protected String getDefaultFileName() {
+    return MetricMessages.metricDialog_default_filename;
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/dialog/ProgressMonitoringOverviewDialog.java
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/dialog/ProgressMonitoringOverviewDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
+import org.eclipse.sirius.common.tools.Messages;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
@@ -227,5 +228,10 @@ public class ProgressMonitoringOverviewDialog extends AbstractExportDialog {
       }
     }
     return result;
+  }
+  
+  @Override
+  protected String getDefaultFileName() {
+    return MetricMessages.progressMonitoring_dialog_default_filename;
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/messages.properties
+++ b/core/plugins/org.polarsys.capella.core.ui.metric/src/org/polarsys/capella/core/ui/metric/messages.properties
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+# Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -23,6 +23,8 @@ metricDialogShellTitle = Metrics
 metricDialogDefaultTitle = Metrics
 metricDialogTitleFromEObj = Metrics from {0} (resource {1}).
 metricDialogTitleFromFile = Metrics on File {0}.
+
+metricDialog_default_filename=metrics
 
 treeObjectColumnLabel = Elements
 treeResultColumnLabel = Quantity
@@ -71,6 +73,7 @@ progressMonitoring_dialog_propagate_technical_button_tooltip=Enable setting Stat
 progressMonitoring_dialog_propagate_to_representation_button_lbl=Propagate to all Sub Representations
 progressMonitoring_dialog_propagate_to_representation_button_tooltip=Enable setting Status to all Diagrams and Tables in the scope of the selection
 
+progressMonitoring_dialog_default_filename=progress_monitoring
 
 progressMonitoring_clearReview_button_lbl=Clear Review field
 progressMonitoring_clearReview_button_tooltip=Clear all review fields


### PR DESCRIPTION
Default name are respectively set to "metrics" (default to metrics.csv) and "progress_monitoring" (default as progress_monitoring.csv)

Change-Id: Ia8ee207957db28de73ba352d22de43227270fffc
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>