### PR TITLE
#2532 Fix CommandLineArgumentHelper Deprecation

### DIFF
--- a/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineArgumentHelper.java
+++ b/core/plugins/org.polarsys.capella.core.commandline.core/src/org/polarsys/capella/core/commandline/core/CommandLineArgumentHelper.java
@@ -97,6 +97,7 @@ public class CommandLineArgumentHelper {
   /**
    * @return the filePath
    */
+  @Deprecated
   public String getFilePath() {
     return filePath;
   }
@@ -146,6 +147,7 @@ public class CommandLineArgumentHelper {
   /**
    * @return the createFolder
    */
+  @Deprecated
   public boolean isCreateFolder() {
     return createFolder;
   }
@@ -167,6 +169,7 @@ public class CommandLineArgumentHelper {
   /**
    * @return the exportProject
    */
+  @Deprecated
   public String getExportProject() {
     return exportProject;
   }
@@ -174,6 +177,7 @@ public class CommandLineArgumentHelper {
   /**
    * @return the zipNameProject
    */
+  @Deprecated
   public String getZipNameProject() {
     return zipNameProject;
   }

--- a/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.html
+++ b/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.html
@@ -232,7 +232,7 @@
 -data &lt;workspacePath&gt;
 -export "EOLE_AF"
 -exportZipName "/EOLE_AF/EOLE_qualifier.zip"
--filepath "/EOLE_AF/EOLE_AF.aird"
+-input "/EOLE_AF/EOLE_AF.aird"
 -outputfolder "/EOLE_AF/output"
 -forceoutputfoldercreation
 -logfile D:/CommandLineLog/log.html

--- a/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.mediawiki
+++ b/doc/plugins/org.polarsys.capella.commandline.doc/html/19. Command Line Support/19.1. Core Mechanism and Applications.mediawiki
@@ -168,7 +168,7 @@ Mandatory parameters:
 -data <workspacePath>
 -export "EOLE_AF"
 -exportZipName "/EOLE_AF/EOLE_qualifier.zip"
--filepath "/EOLE_AF/EOLE_AF.aird"
+-input "/EOLE_AF/EOLE_AF.aird"
 -outputfolder "/EOLE_AF/output"
 -forceoutputfoldercreation
 -logfile D:/CommandLineLog/log.html


### PR DESCRIPTION
Set getters that return deprecated variables to deprecated

Change-Id: Ie2fa344bd66ea7d2a44fa74d4a976d39c152c281
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>