### PR TITLE
#2563 Select REC/RPL elements now works on edges

### DIFF
--- a/common/plugins/org.polarsys.capella.common.re.ui/src/org/polarsys/capella/common/re/ui/menu/RecDynamicMenu.java
+++ b/common/plugins/org.polarsys.capella.common.re.ui/src/org/polarsys/capella/common/re/ui/menu/RecDynamicMenu.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.gmf.runtime.diagram.ui.editparts.GraphicalEditPart;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -85,13 +85,13 @@ public class RecDynamicMenu extends ContributionItem {
   public static Collection<CatalogElement> getCommonRecs(IStructuredSelection selection) {
     LinkedHashSet<EObject> selectedElements = new LinkedHashSet<EObject>();
     for (Object aSelectedElement : selection.toArray()) {
-        if (aSelectedElement instanceof GraphicalEditPart) {
-          EObject semantic = CapellaAdapterHelper.resolveBusinessObject(((GraphicalEditPart) aSelectedElement));
-          selectedElements.add(semantic);
-        } else {
-          return new ArrayList<CatalogElement>();
-        }
+      if (aSelectedElement instanceof AbstractGraphicalEditPart) {
+        EObject semantic = CapellaAdapterHelper.resolveBusinessObject(((AbstractGraphicalEditPart) aSelectedElement));
+        selectedElements.add(semantic);
+      } else {
+        return new ArrayList<CatalogElement>();
       }
+    }
 
     HashMap<EObject, Collection<CatalogElement>> mapOfRecs = new HashMap<EObject, Collection<CatalogElement>>();
     for (EObject anElement : selectedElements) {

--- a/common/plugins/org.polarsys.capella.common.re.ui/src/org/polarsys/capella/common/re/ui/menu/RplDynamicMenu.java
+++ b/common/plugins/org.polarsys.capella.common.re.ui/src/org/polarsys/capella/common/re/ui/menu/RplDynamicMenu.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.gmf.runtime.diagram.ui.editparts.GraphicalEditPart;
+import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -85,8 +85,8 @@ public class RplDynamicMenu extends ContributionItem {
   public static Collection<CatalogElement> getCommonRpls(IStructuredSelection selection) {
     LinkedHashSet<EObject> selectedElements = new LinkedHashSet<EObject>();
     for (Object aSelectedElement : selection.toArray()) {
-      if (aSelectedElement instanceof GraphicalEditPart) {
-        EObject semantic = CapellaAdapterHelper.resolveBusinessObject(((GraphicalEditPart) aSelectedElement));
+      if (aSelectedElement instanceof AbstractGraphicalEditPart) {
+        EObject semantic = CapellaAdapterHelper.resolveBusinessObject(((AbstractGraphicalEditPart) aSelectedElement));
         selectedElements.add(semantic);
       } else {
         return new ArrayList<CatalogElement>();

--- a/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.2. Basic Use Case.html
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.2. Basic Use Case.html
@@ -203,7 +203,7 @@
 		<p>
 			<img height="199" width="627" border="0" src="Images/8.2.%20Basic%20Use%20Case_html_m35487b8e.png"/>
 		</p>
-		<p>This can also be achieved by selecting any source elements of the REC, right click on it "Capella Select &gt; Related Rec Elements &gt; REC"
+		<p>This can also be achieved by selecting any source elements of the REC, right click on it "Capella Select &gt; Related REC Elements &gt; REC"
 
 			<img border="0" src="Images/select_related_rec.png"/>
 		</p>
@@ -211,8 +211,8 @@
 		<p>
 			<img height="211" width="627" border="0" src="Images/8.2.%20Basic%20Use%20Case_html_c008666.png"/>
 		</p>
-		<p>If multiple RPLs of the same REC are displayed, and you want to copy the REC layout to all RPls, this can be achieved by pasting the layout on each RPL, one at a time.
-			To do so, select a RPL element, right click "Capella Select &gt; Related Rpl Elements &gt; RPL X" and paste the layout
+		<p>If multiple RPLs of the same REC are displayed, and you want to copy the REC layout to all RPLs, this can be achieved by pasting the layout on each RPL, one at a time.
+			To do so, select a RPL element, right click "Capella Select &gt; Related RPL Elements &gt; RPL X" and paste the layout
 			Do this for each RPL.</p>
 		<p>
 			<img border="0" src="Images/select_related_rpl.png"/>

--- a/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.2. Basic Use Case.mediawiki
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.2. Basic Use Case.mediawiki
@@ -215,7 +215,7 @@ On a diagram showing the source elements of the REC, select all elements and cop
 
 [[Image:Images/8.2.%20Basic%20Use%20Case_html_m35487b8e.png|627x199px]]
 
-This can also be achieved by selecting any source elements of the REC, right click on it "Capella Select > Related Rec Elements > REC"
+This can also be achieved by selecting any source elements of the REC, right click on it "Capella Select > Related REC Elements > REC"
 [[Image:Images/select_related_rec.png]]
 
 On a diagram where the RPL is displayed, paste the layout:
@@ -223,8 +223,8 @@ On a diagram where the RPL is displayed, paste the layout:
 
 [[Image:Images/8.2.%20Basic%20Use%20Case_html_c008666.png|627x211px]]
 
-If multiple RPLs of the same REC are displayed, and you want to copy the REC layout to all RPls, this can be achieved by pasting the layout on each RPL, one at a time.
-To do so, select a RPL element, right click "Capella Select > Related Rpl Elements > RPL X" and paste the layout
+If multiple RPLs of the same REC are displayed, and you want to copy the REC layout to all RPLs, this can be achieved by pasting the layout on each RPL, one at a time.
+To do so, select a RPL element, right click "Capella Select > Related RPL Elements > RPL X" and paste the layout
 Do this for each RPL.
 
 [[Image:Images/select_related_rpl.png]]

--- a/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.6. Advanced Features.html
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.6. Advanced Features.html
@@ -214,14 +214,14 @@
 		</p>
 		<h2 id="Selecting_all_related_Elements_of_a_given_REC_on_a_diagram">Selecting all related Elements of a given REC on a diagram</h2>
 		<p>It is possible to select all elements of a given REC that are displayed on a diagram.</p>
-		<p>To do so, select a source element from the REC, right click "Capella Select &gt; Related Rec Elements &gt; REC"
+		<p>To do so, select a source element from the REC, right click "Capella Select &gt; Related REC Elements &gt; REC"
 			This will set the current selection to all this REC source elements, that are displayed on the diagram</p>
 		<p>
 			<img border="0" src="Images/select_related_rec.png"/>
 		</p>
 		<h2 id="Selecting_all_related_Elements_of_a_given_RPL_on_a_diagram">Selecting all related Elements of a given RPL on a diagram</h2>
 		<p>It is possible to select all elements of a given RPL that are displayed on a diagram.</p>
-		<p>To do so, select an element from the RPL, right click "Capella Select &gt; Related Rpl Elements &gt; RPL"
+		<p>To do so, select an element from the RPL, right click "Capella Select &gt; Related RPL Elements &gt; RPL"
 			This will set the current selection to all this RPL elements, that are displayed on the diagram</p>
 		<p>This is particularly useful to copy/paste a layout from a REC to its RPLs</p>
 		<p>

--- a/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.6. Advanced Features.mediawiki
+++ b/doc/plugins/org.polarsys.capella.re.doc/html/08. Replicable Element (REC-RPL)/8.6. Advanced Features.mediawiki
@@ -120,7 +120,7 @@ Elements will be copied into the library and become a REC and initial selected e
 
 It is possible to select all elements of a given REC that are displayed on a diagram.
 
-To do so, select a source element from the REC, right click "Capella Select > Related Rec Elements > REC"
+To do so, select a source element from the REC, right click "Capella Select > Related REC Elements > REC"
 This will set the current selection to all this REC source elements, that are displayed on the diagram
 
 [[Image:Images/select_related_rec.png]]
@@ -129,7 +129,7 @@ This will set the current selection to all this REC source elements, that are di
 
 It is possible to select all elements of a given RPL that are displayed on a diagram.
 
-To do so, select an element from the RPL, right click "Capella Select > Related Rpl Elements > RPL"
+To do so, select an element from the RPL, right click "Capella Select > Related RPL Elements > RPL"
 This will set the current selection to all this RPL elements, that are displayed on the diagram
 
 This is particularly useful to copy/paste a layout from a REC to its RPLs

--- a/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/5_Layout management/5_Layout management.html
+++ b/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/5_Layout management/5_Layout management.html
@@ -168,7 +168,7 @@
 		</p>
 		<p>As explained, a copy paste action may not properly work on a selection of elements that contains several times the same element.
 			This may however be achieved by splitting your original copy paste action into multiple ones, so that the format of each occurrence is properly copy-pasted</p>
-		<p>Accelerators exist to ease this process, such as Select &gt; Related RPL elements, or Select &gt; Related REC elements 
+		<p>Accelerators exist to ease this process, such as Capella Select &gt; Related RPL elements, or Capella Select &gt; Related REC elements 
 			They significantly help copy pasting between REC and RPLs, by copying the format of a REC and applying it to each RPL independently.</p>
 		<p>
 			<div class="thumb">

--- a/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/5_Layout management/5_Layout management.mediawiki
+++ b/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/5_Layout management/5_Layout management.mediawiki
@@ -85,7 +85,7 @@ Format can also be pasted on a selection of elements, either right-clicking the 
 As explained, a copy paste action may not properly work on a selection of elements that contains several times the same element.
 This may however be achieved by splitting your original copy paste action into multiple ones, so that the format of each occurrence is properly copy-pasted
 
-Accelerators exist to ease this process, such as Select > Related RPL elements, or Select > Related REC elements 
+Accelerators exist to ease this process, such as Capella Select > Related RPL elements, or Capella Select > Related REC elements 
 They significantly help copy pasting between REC and RPLs, by copying the format of a REC and applying it to each RPL independently.
 
 [[File:../../Images/select_related_rec.png|thumbnail]]

--- a/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/6_Diagram exploration/6_Diagram exploration.html
+++ b/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/6_Diagram exploration/6_Diagram exploration.html
@@ -73,18 +73,18 @@
 		<table class="wikitable">
 			<tr>
 				<td>
-					<b>Related Rec Elements</b>
+					<b>Related REC Elements</b>
 				</td>
 				<td>Select all elements on the active diagram which are related to the 
-					<b>selected Rec</b> as the current selected element(s)
+					<b>selected REC</b> as the current selected element(s)
 				</td>
 			</tr>
 			<tr>
 				<td>
-					<b>Related Rpl Elements</b>
+					<b>Related RPL Elements</b>
 				</td>
 				<td>Select all elements on the active diagram which are related to the 
-					<b>selected Rpl</b> as the current selected element(s)
+					<b>selected RPL</b> as the current selected element(s)
 				</td>
 			</tr>
 			<tr>

--- a/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/6_Diagram exploration/6_Diagram exploration.mediawiki
+++ b/doc/plugins/org.polarsys.capella.tipsandtricks.doc/html/Tips and tricks/6_Diagram exploration/6_Diagram exploration.mediawiki
@@ -32,11 +32,11 @@ The new '''Select''' menu in diagram consists of tools for highlighting related 
 The available tools are:
 
 {| class="wikitable"
-|'''Related Rec Elements'''
-|Select all elements on the active diagram which are related to the '''selected Rec''' as the current selected element(s)
+|'''Related REC Elements'''
+|Select all elements on the active diagram which are related to the '''selected REC''' as the current selected element(s)
 |-
-|'''Related Rpl Elements'''
-|Select all elements on the active diagram which are related to the '''selected Rpl''' as the current selected element(s)
+|'''Related RPL Elements'''
+|Select all elements on the active diagram which are related to the '''selected RPL''' as the current selected element(s)
 |-
 |'''Elements of Same Type'''
 |Select all elements on the active diagram which have the '''same type''' as the current selected element(s)

--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/common/SelectToolsTest.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/common/SelectToolsTest.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.diagram.AbstractDNode;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.DDiagramElement;
+import org.eclipse.sirius.diagram.DEdge;
 import org.eclipse.sirius.diagram.DNodeContainer;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.DiagramElementMapping;
@@ -103,6 +104,10 @@ public class SelectToolsTest extends AbstractDiagramTestCase {
           }
           if (de instanceof AbstractDNode) {
             cd.selectOwnedPorts(de.getUid());
+            cd.selectRelatedRecs(de.getUid());
+            cd.selectRelatedRpls(de.getUid());
+          }
+          if (de instanceof DEdge) {
             cd.selectRelatedRecs(de.getUid());
             cd.selectRelatedRpls(de.getUid());
           }


### PR DESCRIPTION
Fixed issue where select rec/rpl menu and actions wouldn't appear on edges, but would on their edge label

Change-Id: I380f5728040f79e7b65fc37c23ddf196b9373181
Signed-off-by: Erwann Traisnel <erwann.traisnel@obeo.fr>