### PR TITLE
#2596 Properties wizard can now be opened on double click in semantic

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/plugin.xml
@@ -480,9 +480,18 @@
                class="org.polarsys.capella.core.platform.sirius.ui.navigator.actions.providers.ModelElementActionProvider"
                id="capella.project.explorer.modelElementActionProvider">
             <enablement>
-               <instanceof
-                     value="org.polarsys.kitalpha.emde.model.Element">
-               </instanceof>
+               <or>
+                  <instanceof
+                        value="org.polarsys.kitalpha.emde.model.Element">
+                  </instanceof>
+                  <instanceof
+                        value="org.eclipse.sirius.viewpoint.DRepresentationDescriptor">
+                  </instanceof>
+                   <test
+                        forcePluginActivation="false"
+                        property="org.polarsys.capella.core.platform.sirius.ui.navigator.itemWrapperPropertyTester">
+                  </test>
+              </or>
             </enablement>
          </actionProvider>
           <dropAssistant

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/OpenAction.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/actions/OpenAction.java
@@ -12,16 +12,19 @@
  *******************************************************************************/
 package org.polarsys.capella.core.platform.sirius.ui.navigator.actions;
 
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.actions.BaseSelectionListenerAction;
+import org.eclipse.sirius.ui.tools.api.views.common.item.ItemWrapper;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
 import org.polarsys.capella.core.model.handler.command.CapellaResourceHelper;
+import org.polarsys.capella.core.sirius.ui.actions.OpenRepresentationsAction;
 import org.polarsys.capella.core.ui.properties.CapellaUIPropertiesPlugin;
 
-public class OpenAction extends BaseSelectionListenerAction {
+public class OpenAction extends OpenRepresentationsAction {
 
   public OpenAction() {
     super(Messages.OpenActionLabel);
@@ -42,20 +45,40 @@ public class OpenAction extends BaseSelectionListenerAction {
             OpenRelatedDiagramAction action = new OpenRelatedDiagramAction(elementAsEObject);
             action.run();
           }
+        }else {
+          if(isRepresentationDescriptor(element)) {
+            openRepresentations(Collections.singletonList((DRepresentationDescriptor)element));
+          }
         }
       }
     }
   }
 
+  /**
+   * returns true if action should be enabled
+   * Selection is valid if it contains SemanticElements and RepresentationDescriptors(can be wrapped) only
+   */
   @Override
   protected boolean updateSelection(IStructuredSelection selection) {
-    boolean result = false;
-
+    boolean result = true;
     if (!selection.isEmpty()) {
-      result = (CapellaResourceHelper.isSemanticElements(selection.toList())) ? true : false;
+      for(Object selectedElement : selection.toList()) {
+        if( !CapellaResourceHelper.isSemanticElement(selectedElement) || !isRepresentationDescriptor(selectedElement)) {
+          return false;
+        }
+      }
     }
-
     return result;
   }
 
+
+  private boolean isRepresentationDescriptor(Object element) {
+    if (element instanceof ItemWrapper) {
+      element = ((ItemWrapper) element).getWrappedObject();
+    }
+    if (element instanceof DRepresentationDescriptor) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/actions/OpenRepresentationsAction.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/actions/OpenRepresentationsAction.java
@@ -55,6 +55,10 @@ public class OpenRepresentationsAction extends BaseSelectionListenerAction {
     super("Open"); //$NON-NLS-1$
   }
 
+  protected OpenRepresentationsAction(String name) {
+    super(name); 
+  }
+
   /**
    * @param drep
    */
@@ -75,17 +79,24 @@ public class OpenRepresentationsAction extends BaseSelectionListenerAction {
     } catch (IllegalStateException e) {
       if (new IllegalStateExceptionQuery(e).isAConnectionLostException()) {
         return false;
-      } else {
-        throw e;
       }
+      throw e;
     }
   }
 
   /**
    * The action is enabled if at least one valid representation
    */
-  private List<DRepresentationDescriptor> getOpenableRepresentationDescriptors(IStructuredSelection selection) {
-    return RepresentationHelper.getSelectedDescriptors(selection.toList()).stream()
+  protected List<DRepresentationDescriptor> getOpenableRepresentationDescriptors(IStructuredSelection selection) {
+    return getOpenableRepresentationDescriptors(RepresentationHelper.getSelectedDescriptors(selection.toList()));
+  }
+  /**
+   * Returns all valid descriptors from given descriptors
+   * @param elements
+   * @return
+   */
+  protected List<DRepresentationDescriptor> getOpenableRepresentationDescriptors(Collection<DRepresentationDescriptor> elements) {
+    return elements.stream()
         .filter(RepresentationHelper::isValid).collect(Collectors.toList());
   }
 
@@ -107,12 +118,20 @@ public class OpenRepresentationsAction extends BaseSelectionListenerAction {
       return;
     }
 
+    openRepresentations(reps);
+  }
+
+  /**
+   * Runs a OpenRepresentationsRunnable on given descriptors
+   * @param descriptors
+   */
+  protected void openRepresentations(Collection<DRepresentationDescriptor> descriptors) {
     String eventName = "Open Representation";
     String eventContext = ICommonConstants.EMPTY_STRING;
     String addendum = ICommonConstants.EMPTY_STRING;
     UsageMonitoringLogger.getInstance().log(eventName, eventContext, EventStatus.NONE, addendum);
 
-    IRunnableWithProgress runnable = new OpenRepresentationsRunnable(reps, false);
+    IRunnableWithProgress runnable = new OpenRepresentationsRunnable(descriptors, false);
     ProgressMonitorDialog progressDialog = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
 
     try {

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/handlers/NavigationSemanticBrowserDoubleClickHandler.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/handlers/NavigationSemanticBrowserDoubleClickHandler.java
@@ -1,0 +1,115 @@
+package org.polarsys.capella.core.ui.semantic.browser.sirius.handlers;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
+import org.polarsys.capella.common.ui.toolkit.browser.content.provider.wrapper.EObjectWrapper;
+import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
+import org.polarsys.capella.core.platform.sirius.ui.navigator.actions.OpenRelatedDiagramAction;
+import org.polarsys.capella.core.ui.semantic.browser.handler.DefaultSemanticBrowserDoubleClickHandler;
+import org.polarsys.capella.core.ui.semantic.browser.sirius.actions.DiagramOpenAction;
+import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
+
+public class NavigationSemanticBrowserDoubleClickHandler extends DefaultSemanticBrowserDoubleClickHandler{
+  
+  @Override
+  public void handle(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
+    //Get selection of currently selected viewer
+    //Right now this is the only way to get the selection from Referenced or Referencing viewer
+    IStructuredSelection selection = (IStructuredSelection) view.getSite().getSelectionProvider().getSelection();
+
+    if (!selection.isEmpty()) {      
+      if(selection.size() == 1 ){
+        if(isCtrlKeyPressed()) { 
+          //If CTRL is pressed on double-click on a single element, it shall be put as the current element
+          super.handle(view, event, selectedElement);
+        } else {
+          //If it wasn't pressed, run navigation action
+          runAction(view, event, selectedElement);
+        }       
+      }else{
+        //If multiple elements in the selection, run action on each of them
+        for(Object element : selection.toList()) {
+          runAction(view, event, element);          
+        }
+      }
+    }
+  }
+  
+  protected void runAction(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
+    if (selectedElement instanceof EObjectWrapper) {
+      selectedElement = ((EObjectWrapper) selectedElement).getElement();
+    }   
+    if(! (selectedElement instanceof EObject)) {
+      //Not handled
+      return; 
+    }
+    
+    EObject elementAsEObject = (EObject) selectedElement;
+    if(shouldOpenDiagram(elementAsEObject)) {
+      openDiagram(view, (DRepresentationDescriptor)elementAsEObject);
+    }else {
+      if(shouldNavigate(elementAsEObject)) {
+        openRelatedDiagrams(elementAsEObject);
+      }else{ 
+        // Should open wizard
+        super.runAction(view, event, elementAsEObject);
+      }      
+    }
+                 
+    
+  }
+  
+  /**
+   * Returns true if double-click on selectedElement should execute the navigation action
+   * @param selectedElement
+   * @return
+   */
+  public boolean shouldNavigate(EObject selectedElement) {      
+    return DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(selectedElement);
+  }
+  
+  /**
+   * Returns true if double-click on selectedElement should open the properties wizard
+   * @param selectedElement
+   * @return
+   */
+  public boolean shouldOpenPropertyWizard(EObject selectedElement) {
+    if(shouldOpenDiagram(selectedElement))
+      return false;
+   return !shouldNavigate(selectedElement);  
+  }
+  
+  /**
+   * Returns true if double-click on selectedElement should open the diagram
+   * @param selectedElement
+   * @return
+   */
+  public boolean shouldOpenDiagram(EObject selectedElement) {
+    return selectedElement instanceof DRepresentationDescriptor;
+  }
+  
+  /**
+   * Open diagram of given diagram descriptor
+   * @param diagramToOpen
+   */
+  protected void openDiagram(SemanticBrowserView view, DRepresentationDescriptor diagramToOpen) {
+    DiagramOpenAction action = new DiagramOpenAction();
+    // Open related diagram editor.
+    action.init(view);
+    action.selectionChanged(null, new StructuredSelection(diagramToOpen));
+    action.run(null);
+  }
+
+  /**
+   * Run the OpenRelatedDiagramAction on selected element 
+   * @param selectedElement
+   */
+  protected void openRelatedDiagrams(EObject selectedElement) {   
+    OpenRelatedDiagramAction action = new OpenRelatedDiagramAction(selectedElement);
+    action.run();       
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/view/SiriusSemanticBrowserView.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser.sirius/src/org/polarsys/capella/core/ui/semantic/browser/sirius/view/SiriusSemanticBrowserView.java
@@ -12,17 +12,11 @@
  *******************************************************************************/
 package org.polarsys.capella.core.ui.semantic.browser.sirius.view;
 
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.ui.IWorkbenchPart;
-import org.polarsys.capella.common.ui.toolkit.browser.content.provider.wrapper.EObjectWrapper;
-import org.polarsys.capella.core.commands.preferences.ui.sirius.DoubleClickBehaviourUtil;
-import org.polarsys.capella.core.platform.sirius.ui.navigator.actions.OpenRelatedDiagramAction;
-import org.polarsys.capella.core.ui.semantic.browser.sirius.actions.DiagramOpenAction;
+import org.polarsys.capella.core.ui.semantic.browser.handler.AbstractSemanticBrowserDoubleClickHandler;
+import org.polarsys.capella.core.ui.semantic.browser.sirius.handlers.NavigationSemanticBrowserDoubleClickHandler;
 import org.polarsys.capella.core.ui.semantic.browser.sirius.helpers.SiriusSelectionHelper;
 import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
 
@@ -30,6 +24,9 @@ import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
  * Browser Semantic View. Load by extension point.
  */
 public class SiriusSemanticBrowserView extends SemanticBrowserView {
+  
+  NavigationSemanticBrowserDoubleClickHandler navigationDoubleClickHandler ;
+  
   /**
    * {@inheritDoc}
    */
@@ -37,47 +34,10 @@ public class SiriusSemanticBrowserView extends SemanticBrowserView {
   protected Object handleWorkbenchPageSelectionEvent(IWorkbenchPart part, ISelection selection) {
     return SiriusSelectionHelper.handleSelection(part, selection);
   }
-
-  /**
-   * @see org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView#handleDoubleClick(org.eclipse.jface.viewers.DoubleClickEvent)
-   */
+  
   @Override
-  protected void handleDoubleClick(DoubleClickEvent event) {
-    boolean callSuper = true;
-    //Get selection of currently selected viewer
-    //Right now this is the only way to get the selection from Referenced or Referencing viewer
-    IStructuredSelection selection = (IStructuredSelection) getSite().getSelectionProvider().getSelection();
-
-    if (!selection.isEmpty()) {
-      //If CTRL is pressed on double-click on a single element, it shall be put as the current element
-      if( (selection.size() == 1 && !isCtrlKeyPressed()) || (selection.size() > 1)) {
-        for(Object selectedElement : selection.toList()) {
-          if (selectedElement instanceof EObjectWrapper) {
-            selectedElement = ((EObjectWrapper) selectedElement).getElement();
-          }
-          if (selectedElement instanceof DRepresentationDescriptor) {
-            DiagramOpenAction action = new DiagramOpenAction();
-            // Open related diagram editor.
-            action.init(this);
-            action.selectionChanged(null, new StructuredSelection(selectedElement));
-            action.run(null);
-            // if it is DRepresentation; then open the representation and return immediately.
-            // Do not run into super.handleDoubleClick in order to avoid opening the wizard properties
-          } else {	
-            if (selectedElement instanceof EObject) {						
-              EObject selectedElementAsEObject = (EObject) selectedElement;
-              if( DoubleClickBehaviourUtil.INSTANCE.shouldOpenRelatedDiagramsOnDoubleClick(selectedElementAsEObject)) {
-                OpenRelatedDiagramAction action = new OpenRelatedDiagramAction(selectedElementAsEObject);
-                action.run();
-              }
-            }            
-          }
-          callSuper = false;
-        }
-      }
-    }
-    if(callSuper) {
-      super.handleDoubleClick(event);      
-    }
-  }   
+  public AbstractSemanticBrowserDoubleClickHandler getSemanticBrowserDoubleClickHandlerFor(DoubleClickEvent event) {
+    if(navigationDoubleClickHandler == null) navigationDoubleClickHandler = new NavigationSemanticBrowserDoubleClickHandler();
+    return navigationDoubleClickHandler;
+  }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser/META-INF/MANIFEST.MF
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.polarsys.capella.common.ui.toolkit.browser;visibility:=reexp
 Export-Package: org.polarsys.capella.core.ui.semantic.browser,
  org.polarsys.capella.core.ui.semantic.browser.actions,
  org.polarsys.capella.core.ui.semantic.browser.content.provider,
+ org.polarsys.capella.core.ui.semantic.browser.handler,
  org.polarsys.capella.core.ui.semantic.browser.internal,
  org.polarsys.capella.core.ui.semantic.browser.label.provider,
  org.polarsys.capella.core.ui.semantic.browser.model,

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/handler/AbstractSemanticBrowserDoubleClickHandler.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/handler/AbstractSemanticBrowserDoubleClickHandler.java
@@ -1,0 +1,32 @@
+package org.polarsys.capella.core.ui.semantic.browser.handler;
+
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
+
+public abstract class AbstractSemanticBrowserDoubleClickHandler {
+
+  /**
+   * Indicates whether ctrl key is pressed or not
+   * this value is updated when double click occurs in the view
+   */
+  protected boolean isCtrlKeyPressed = false;
+  
+  public void setControlKeyPressed(boolean value) {
+    isCtrlKeyPressed = value;
+  }
+  
+  /**
+   * Handle double-click event, on the selectedElement on the given view
+   * @param view
+   * @param event
+   * @param selectedElement
+   */
+  public void handle(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
+    
+  }
+  
+  public boolean isCtrlKeyPressed() {
+    return isCtrlKeyPressed;
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/handler/DefaultSemanticBrowserDoubleClickHandler.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/handler/DefaultSemanticBrowserDoubleClickHandler.java
@@ -1,0 +1,31 @@
+package org.polarsys.capella.core.ui.semantic.browser.handler;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.polarsys.capella.core.ui.properties.CapellaUIPropertiesPlugin;
+import org.polarsys.capella.core.ui.semantic.browser.view.SemanticBrowserView;
+
+public class DefaultSemanticBrowserDoubleClickHandler extends AbstractSemanticBrowserDoubleClickHandler{
+
+  @Override
+  public void handle(SemanticBrowserView view,DoubleClickEvent event, Object selectedElement) {    
+    if (selectedElement instanceof EObject) {
+      if (isCtrlKeyPressed()) {
+        if (view.getRootElement() != selectedElement) {
+          // CTRL is pressed, let's navigate...
+          view.setInput(selectedElement);
+          // Set and reveal the focused element.
+          view.getCurrentViewer().setSelection(new StructuredSelection(selectedElement), true);
+        }
+      } else {
+        runAction(view, event, selectedElement);
+      }
+    }
+  }
+  
+  protected void runAction(SemanticBrowserView view, DoubleClickEvent event, Object selectedElement) {
+    //Open properties wizard on selected element
+    CapellaUIPropertiesPlugin.getDefault().openWizard(event, (EObject) selectedElement);
+  }
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/META-INF/MANIFEST.MF
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/META-INF/MANIFEST.MF
@@ -21,7 +21,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.polarsys.capella.core.platform.sirius.ui.navigator,
  org.polarsys.capella.core.data.gen,
- org.polarsys.capella.core.ui.semantic.browser.sirius
+ org.polarsys.capella.core.ui.semantic.browser.sirius,
+ org.polarsys.capella.core.ui.toolkit,
+ org.polarsys.capella.core.ui.properties;bundle-version="6.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.polarsys.capella.test.semantic.ui.ju,
  org.polarsys.capella.test.semantic.ui.ju.testsuites

--- a/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/src/org/polarsys/capella/test/semantic/ui/ju/testsuites/SemanticUITestSuite.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.ui.ju/src/org/polarsys/capella/test/semantic/ui/ju/testsuites/SemanticUITestSuite.java
@@ -20,6 +20,7 @@ import org.polarsys.capella.test.framework.api.BasicTestArtefact;
 import org.polarsys.capella.test.framework.api.BasicTestSuite;
 import org.polarsys.capella.test.semantic.ui.ju.testcases.SBNavigationMenuInteractionUseTest;
 import org.polarsys.capella.test.semantic.ui.ju.testcases.SBNavigationMenuPPTest;
+import org.polarsys.capella.test.semantic.ui.ju.testcases.SemanticBrowserCurrentElementNavigationTest;
 import org.polarsys.capella.test.semantic.ui.ju.testcases.SemanticBrowserReferencingElementNavigationTest;
 import org.polarsys.capella.test.semantic.ui.ju.testcases.SemanticBrowserRepresentationHasSemanticQueriesTest;
 
@@ -30,7 +31,7 @@ public class SemanticUITestSuite extends BasicTestSuite {
   @Override
   protected List<BasicTestArtefact> getTests() {
     List<BasicTestArtefact> tests = new ArrayList<BasicTestArtefact>();
-
+    tests.add(new SemanticBrowserCurrentElementNavigationTest());
     tests.add(new SemanticBrowserReferencingElementNavigationTest());
     tests.add(new SemanticBrowserRepresentationHasSemanticQueriesTest());
     tests.add(new SBNavigationMenuPPTest());


### PR DESCRIPTION
browser

Fixed issue where double-clicking wouldn't open properties wizard anymore

Fixed multi-selection in both project explorer and SB When pressing enter, the corresponding action is ran for each selected elements
actions being :
open diagram on representation descriptor
navigate on chain (FC/PP/OP) (create if 0, open if 1, ask if more than 1 diagram)

Updated condtions of ModelElementActionProvider so that it can also take representations descriptors

Change-Id: I4a2052c23ac73d218aa911a78842de99826e6d2f