### PR TITLE
eclipse#2598 Fix resource display in model tree

### DIFF
--- a/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/viewer/CapellaNavigatorContentProvider.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.ui.navigator/src/org/polarsys/capella/core/platform/sirius/ui/navigator/viewer/CapellaNavigatorContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -397,7 +397,8 @@ public class CapellaNavigatorContentProvider extends GroupedAdapterFactoryConten
                   || CapellaResourceHelper.isAirdResource(childResource.getURI())) {
                 // We don't want to display metadata node or aird node.
               } else {
-                others.addFirst(childResource.getContents());
+                // Add the root elements of the child resource at the beginning
+                others.addAll(0, childResource.getContents());
               }
 
             } else {


### PR DESCRIPTION
Whenever an additional resource is added to a Capella session (e.g. additional resources added by a Capella add-on), The Capella model explorer wants to add this resource's contents in the model tree.

The previous implementation unintentionally added the ContentsEList of the resource as a child, instead of the elements of this ContentsEList.
That caused the Capella model explorer to display a Node with a default image and a poor label obtained from ContentsEList.toString().