### PR TITLE
#2605 Fixed test that does not work in Team context

### DIFF
--- a/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/xab/PhysicalLinkIconAndLabel.java
+++ b/tests/plugins/org.polarsys.capella.test.diagram.tools.ju/src/org/polarsys/capella/test/diagram/tools/ju/xab/PhysicalLinkIconAndLabel.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import org.eclipse.gef.EditPart;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.diagram.DDiagramElement;
-import org.eclipse.sirius.diagram.model.business.internal.spec.DEdgeSpec;
+import org.eclipse.sirius.diagram.DEdge;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeBeginNameEditPart;
 import org.eclipse.sirius.diagram.ui.internal.edit.parts.DEdgeEndNameEditPart;
 import org.eclipse.sirius.viewpoint.RGBValues;
@@ -46,13 +46,13 @@ public class PhysicalLinkIconAndLabel extends XABDiagramsProject {
     PhysicalPath path1 = pab.createPhysicalPath("Path 1", "Physical Link 1");
     PhysicalPath path2 = pab.createPhysicalPath("Path 2", "Physical Link 1");
     DDiagramElement plView = (DDiagramElement) pab.getView("Physical Link 1");
-    assertTrue(plView instanceof DEdgeSpec);
+    assertTrue(plView instanceof DEdge);
     
     checkIcons(pab, plView);
     
-    assertTrue("Wrong label for overlapped Physical Link", ((DEdgeSpec) plView).getBeginLabel().equals(
+    assertTrue("Wrong label for overlapped Physical Link", ((DEdge) plView).getBeginLabel().equals(
         DiagramServices.getDiagramServices().getOverlappedLabels(Arrays.asList(path1.getName(), path2.getName())))
-        && ((DEdgeSpec) plView).getEndLabel().equals(
+        && ((DEdge) plView).getEndLabel().equals(
             DiagramServices.getDiagramServices().getOverlappedLabels(Arrays.asList(path1.getName(), path2.getName()))));
   }
 


### PR DESCRIPTION
Fixed issue with PhysicalLinkIconAndLabel unit test that used DNodeSpec instead of DNode

Change-Id: I817301f804212614f0ae4ecdb5f66aa23b7389af