### PR TITLE
#2624 Fixed Invalid hyperlink detection on referenced diagrams

### DIFF
--- a/core/plugins/org.polarsys.capella.core.model.handler/src/org/polarsys/capella/core/model/handler/helpers/RepresentationHelper.java
+++ b/core/plugins/org.polarsys.capella.core.model.handler/src/org/polarsys/capella/core/model/handler/helpers/RepresentationHelper.java
@@ -52,6 +52,7 @@ import org.polarsys.capella.common.utils.RunnableWithBooleanResult;
 import org.polarsys.capella.core.data.cs.Component;
 import org.polarsys.capella.core.model.handler.command.CapellaResourceHelper;
 import org.polarsys.capella.shared.id.handler.IScope;
+import org.polarsys.capella.shared.id.handler.IdManager;
 
 import com.google.common.collect.Iterables;
 
@@ -366,6 +367,19 @@ public class RepresentationHelper {
    */
   public static DRepresentationDescriptor getRepresentationDescriptor(DRepresentation representation) {
     return new DRepresentationQuery(representation).getRepresentationDescriptor();
+  }
+
+  /**
+   * Get the representation descriptor whose UID or repPath equals to the parameter id 
+   * or the semantic object with the given id
+   */
+  public static EObject getRepresentationDescriptorOrSemanticObject(ResourceSet rSet, String id) {
+    IScope scope = new SemanticResourcesScope(rSet);
+    EObject eObject = IdManager.getInstance().getEObject(id, scope);
+    if (eObject == null) {
+      return RepresentationHelper.getRepresentationDescriptor(rSet, id);
+    }
+    return eObject;
   }
 
   /**

--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/utils/saxparser/SaxParserHelper.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/utils/saxparser/SaxParserHelper.java
@@ -13,13 +13,10 @@
 
 package org.polarsys.capella.core.model.utils.saxparser;
 
-import java.util.List;
-
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.polarsys.capella.common.helpers.TransactionHelper;
-import org.polarsys.capella.shared.id.handler.IScope;
-import org.polarsys.capella.shared.id.handler.IdManager;
+import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
 
 /**
  */
@@ -73,12 +70,8 @@ public class SaxParserHelper {
     EObject eObject = null;
     if (split.length == 2) {
       String id = split[1].replace("/", ""); //$NON-NLS-1$ //$NON-NLS-2$
-      eObject = IdManager.getInstance().getEObject(id, new IScope() {
-        @Override
-        public List<Resource> getResources() {
-          return TransactionHelper.getEditingDomain(context).getResourceSet().getResources();
-        }
-      });
+      ResourceSet rSet = TransactionHelper.getEditingDomain(context).getResourceSet();
+      eObject = RepresentationHelper.getRepresentationDescriptorOrSemanticObject(rSet, id);
     }
 
     return eObject;

--- a/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/utils/saxparser/WriteCapellaElementDescriptionSAXParser.java
+++ b/core/plugins/org.polarsys.capella.core.model.helpers/src/org/polarsys/capella/core/model/utils/saxparser/WriteCapellaElementDescriptionSAXParser.java
@@ -23,7 +23,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.viewpoint.DRepresentation;
 import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.polarsys.capella.common.mdsofa.common.constant.ICommonConstants;
 import org.polarsys.capella.common.tools.report.config.registry.ReportManagerRegistry;
@@ -55,7 +55,7 @@ public class WriteCapellaElementDescriptionSAXParser {
   }
 
   protected boolean managedObject(EObject object) {
-    return (object instanceof Element || object instanceof DDiagram) || (object instanceof DRepresentationDescriptor);
+    return (object instanceof Element || object instanceof DRepresentation) || (object instanceof DRepresentationDescriptor);
   }
 
   private String getDescription(EObject object) {

--- a/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/parser/helper/InvalidNameHandler.java
+++ b/core/plugins/org.polarsys.capella.core.platform.sirius.sirius.validation/src/org/polarsys/capella/core/platform/sirius/sirius/validation/parser/helper/InvalidNameHandler.java
@@ -10,7 +10,9 @@ import org.eclipse.emf.validation.IValidationContext;
 import org.eclipse.emf.validation.model.ConstraintStatus;
 import org.eclipse.emf.validation.service.ConstraintRegistry;
 import org.eclipse.emf.validation.service.IConstraintDescriptor;
-import org.eclipse.sirius.diagram.DDiagram;
+import org.eclipse.sirius.viewpoint.DRepresentation;
+import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
+import org.polarsys.capella.core.model.utils.NamingHelper;
 import org.polarsys.capella.core.model.utils.saxparser.SaxParserHelper;
 import org.polarsys.capella.core.platform.sirius.sirius.validation.ddiagram.LinkDescription;
 
@@ -37,7 +39,7 @@ public class InvalidNameHandler implements ILinkParser {
   public void handleParsedLink(LinkDescription parsedLink) {
     if (parsedLink.getTargetElement() != null && parsedLink.getHref().startsWith("hlink://")) {
       EObject elementFound = parsedLink.getTargetElement();
-      boolean isDiagram = elementFound instanceof DDiagram;
+      boolean isDiagram = elementFound instanceof DRepresentationDescriptor || elementFound instanceof DRepresentation;
       String name = DescriptionParserHelper.getElementName(elementFound);
       String value = parsedLink.getName();
       String elementId = parsedLink.getHref().replace("hlink://", "");

--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/navigation/CapellaNavigationModelElement.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/navigation/CapellaNavigationModelElement.java
@@ -14,7 +14,6 @@ package org.polarsys.capella.core.ui.properties.richtext.navigation;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
@@ -28,9 +27,6 @@ import org.polarsys.capella.common.helpers.TransactionHelper;
 import org.polarsys.capella.common.ui.services.UIUtil;
 import org.polarsys.capella.core.model.handler.command.CapellaResourceHelper;
 import org.polarsys.capella.core.model.handler.helpers.RepresentationHelper;
-import org.polarsys.capella.core.model.handler.helpers.SemanticResourcesScope;
-import org.polarsys.capella.shared.id.handler.IScope;
-import org.polarsys.capella.shared.id.handler.IdManager;
 import org.polarsys.kitalpha.richtext.widget.tools.ext.intf.OpenLinkStrategy;
 
 public class CapellaNavigationModelElement implements OpenLinkStrategy {
@@ -59,12 +55,8 @@ public class CapellaNavigationModelElement implements OpenLinkStrategy {
     }
 
     private EObject getElement(final EditingDomain editingDomain, String uriFragment) {
-        ResourceSet resourceSet = editingDomain.getResourceSet();
-        IScope capellaSemanticResourceScope = new SemanticResourcesScope(resourceSet);
-        EObject semanticElement = IdManager.getInstance().getEObject(uriFragment, capellaSemanticResourceScope);
-        if (semanticElement == null) {
-          return RepresentationHelper.getRepresentationDescriptor(resourceSet, uriFragment);
-        }
+        EObject semanticElement = RepresentationHelper
+            .getRepresentationDescriptorOrSemanticObject(editingDomain.getResourceSet(), uriFragment);
         return semanticElement;
     }
 


### PR DESCRIPTION
Fixed issue where, in team, if diagram hadn't been opened, link towards this diagram would be considered invalid

The DRepresentationDescriptor UID is now also used to resolve the diagram link

Change-Id: I05caddc0e0b52aaf05cbf5a2ff445fe2dee30c9d