### PR TITLE
#2656: Fix NPE on Linux with the CapellaAnalysisSelector

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/danalysis/CapellaAnalysisSelector.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.ui/src/org/polarsys/capella/core/sirius/ui/danalysis/CapellaAnalysisSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,7 +21,6 @@ import org.eclipse.sirius.ui.business.api.session.analysis.SmartDialogAnalysisSe
 import org.eclipse.sirius.ui.tools.api.dialogs.AnalysisSelectorFilteredItemsSelectionDialog;
 import org.eclipse.sirius.viewpoint.DAnalysis;
 import org.eclipse.sirius.viewpoint.DRepresentation;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -43,7 +42,7 @@ public class CapellaAnalysisSelector extends SmartDialogAnalysisSelector {
   protected AnalysisSelectorFilteredItemsSelectionDialog createAnalysisSelectorDialog(Shell shell,
       DAnalysis bestCandidate, Collection<DAnalysis> allAnalysis, List<DAnalysis> bestCandidates,
       DRepresentation representation) {
-    return new AnalysisSelectorFilteredItemsSelectionDialog(Display.getDefault().getActiveShell(),
+    return new AnalysisSelectorFilteredItemsSelectionDialog(shell,
         allAnalysis.iterator().next(), allAnalysis, new ArrayList<>(allAnalysis), true);
   }
 }


### PR DESCRIPTION
We use the shell provided in parameter instead of retrieving the shell from the getActiveShell() method.

A similar issue has been fix in Sirius in
SmartDialogAnalysisSelector#selectSmartlyAnalysis. On Linux, Display#getActiveShell might return null.

Bug: https://github.com/eclipse/capella/issues/2656