### PR TITLE
2681 [Capella properties] Bad concurrent modification

### DIFF
--- a/core/plugins/org.polarsys.capella.core.data.core.properties/src/org/polarsys/capella/core/data/core/properties/fields/BasicElementGroup.java
+++ b/core/plugins/org.polarsys.capella.core.data.core.properties/src/org/polarsys/capella/core/data/core/properties/fields/BasicElementGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetWidgetFactory;
 import org.polarsys.capella.common.data.modellingcore.ModellingcorePackage;
 import org.polarsys.capella.common.mdsofa.common.constant.ICommonConstants;
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
 import org.polarsys.capella.core.data.capellacore.CapellacorePackage;
 import org.polarsys.capella.core.data.core.properties.Messages;
 import org.polarsys.capella.core.ui.properties.fields.AbstractSemanticField;
@@ -145,5 +146,9 @@ public class BasicElementGroup extends AbstractSemanticField {
   public void setEnabled(boolean enabled) {
     LockHelper.getInstance().enable(nameTextField, enabled);
     LockHelper.getInstance().enable(summaryTextField, enabled);
+	if (enabled && semanticElement instanceof CapellaElement) {
+		// Refresh widgets from semantic element in case of remote update
+		loadData(semanticElement);
+	}
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/AbstractSemanticButtonGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/AbstractSemanticButtonGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,6 +14,7 @@ package org.polarsys.capella.core.ui.properties.fields;
 
 import java.util.List;
 
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -61,7 +62,12 @@ public abstract class AbstractSemanticButtonGroup extends AbstractSemanticField 
    */
   protected void enableButton(Button button, boolean enabled) {
     if (null != button && !button.isDisposed()) {
-      button.setEnabled(enabled);
+		button.setEnabled(enabled);
+		if (enabled && semanticElement != null && button.getData() instanceof EAttribute
+				&& semanticElement.eGet((EAttribute) button.getData()) instanceof Boolean) {
+			// Refresh widget from semantic element in case of remote update
+			button.setSelection((Boolean) semanticElement.eGet(((EAttribute) button.getData())));
+		}
     }
   }
 

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/BooleanValueGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/BooleanValueGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -107,6 +107,10 @@ public class BooleanValueGroup extends AbstractSemanticField {
   public void setEnabled(boolean enabled) {
     if (null != _valueField && !_valueField.isDisposed()) {
       _valueField.setEnabled(enabled);
+		if (enabled) {
+			// Refresh widget from semantic element in case of remote update
+			loadComboValue();
+		}
     }
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/BrowseSemanticField.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/BrowseSemanticField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -305,6 +305,10 @@ public class BrowseSemanticField extends AbstractSemanticField {
 		LockHelper.getInstance().enable(_valueOpenBtn, enabled);
 		LockHelper.getInstance().enable(_valueShortcutBtn, enabled);
 		LockHelper.getInstance().update(_valueTextField, enabled);
+		if (enabled && this.semanticElement != null && this.semanticFeature != null) {
+			// Refresh widget from semantic element in case of remote update
+			setValueTextField(this.semanticElement.eGet(this.semanticFeature));
+		}
 	}
 
 	/**

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/EnumerationValueGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/EnumerationValueGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -167,6 +167,10 @@ public class EnumerationValueGroup extends AbstractSemanticGroup {
   public void setEnabled(boolean enabled) {
     if (null != _valueField && !_valueField.isDisposed()) {
       _valueField.setEnabled(enabled);
+		if (enabled) {
+			// Refresh widget from semantic element in case of remote update
+			loadComboValue();
+		}
     }
   }
 }

--- a/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/TextValueGroup.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties/src/org/polarsys/capella/core/ui/properties/fields/TextValueGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -152,6 +152,10 @@ public class TextValueGroup extends AbstractSemanticGroup {
   public void setEnabled(boolean enabled) {
     if (null != valueField && !valueField.isDisposed()) {
       valueField.setEnabled(enabled);
+		if (enabled) {
+			// Refresh widget from semantic element in case of remote update
+			loadTextValue();
+		}
     }
     if (null != valueResetBtn && !valueResetBtn.isDisposed()) {
       valueResetBtn.setEnabled(enabled);


### PR DESCRIPTION
Refresh Capella widgets when they are enabled in case its semantic target was updated remotely.