### PR TITLE
[Semantic Browser] physical links the corresponding connected ports are not displayed within the semantic browser

### DIFF
--- a/core/plugins/org.polarsys.capella.core.semantic.queries/plugin.xml
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/plugin.xml
@@ -3040,6 +3040,48 @@
                </categoryQuery>
             </category>
             <category
+                  id="org.polarsys.capella.core.semantic.queries.PhysicalLinkSource"
+                  isTopLevel="true"
+                  name="Source">
+               <availableForType
+                     class="org.polarsys.capella.core.data.cs.PhysicalLink">
+               </availableForType>
+               <targetBrowserId
+                     id="ReferencingElementBrowser">
+               </targetBrowserId>
+               <categoryQuery>
+                  <basicQuery
+                        class="org.polarsys.capella.core.semantic.queries.basic.queries.PhysicalLinkSource">
+                  </basicQuery>
+               </categoryQuery>
+               <itemQueries>
+            		<basicQuery
+                 	 	class="org.polarsys.capella.core.semantic.queries.basic.queries.PhysicalPortOwner">
+            		</basicQuery>
+         		</itemQueries>
+            </category>
+            <category
+                  id="org.polarsys.capella.core.semantic.queries.PhysicalLinkTarget"
+                  isTopLevel="true"
+                  name="Target">
+               <availableForType
+                     class="org.polarsys.capella.core.data.cs.PhysicalLink">
+               </availableForType>
+               <targetBrowserId
+                     id="ReferencedElementBrowser">
+               </targetBrowserId>
+               <categoryQuery>
+                  <basicQuery
+                        class="org.polarsys.capella.core.semantic.queries.basic.queries.PhysicalLinkTarget">
+                  </basicQuery>
+               </categoryQuery>
+               <itemQueries>
+            		<basicQuery
+                 	 	class="org.polarsys.capella.core.semantic.queries.basic.queries.PhysicalPortOwner">
+            		</basicQuery>
+         		</itemQueries>
+            </category>
+            <category
                   id="org.polarsys.capella.core.semantic.queries.basic.queries.RequirementTracedElements"
                   isTopLevel="true"
                   name="Traced Elements">

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalLinkSource.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalLinkSource.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2023 THALES GLOBAL SERVICES.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+* 
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*    Thales - initial API and implementation
+*******************************************************************************/
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.cs.PhysicalLink;
+import org.polarsys.capella.core.data.helpers.cs.services.PhysicalLinkExt;
+import org.polarsys.capella.core.data.information.Port;
+
+/**
+ * return source @Port of a given @PhysicalLink
+ */
+public class PhysicalLinkSource implements IQuery {
+
+  @Override
+  public List<Object> compute(Object object) {
+    if (object instanceof PhysicalLink) {
+      PhysicalLink link = (PhysicalLink) object;
+      Port port = PhysicalLinkExt.getSourcePort(link);
+      if (null != port) {
+        return Collections.singletonList(port);
+      }
+    }
+    return Collections.emptyList();
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalLinkTarget.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalLinkTarget.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2023 THALES GLOBAL SERVICES.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+* 
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*    Thales - initial API and implementation
+*******************************************************************************/
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.cs.PhysicalLink;
+import org.polarsys.capella.core.data.helpers.cs.services.PhysicalLinkExt;
+import org.polarsys.capella.core.data.information.Port;
+
+/**
+ * return target @Port of a given @PhysicalLink
+ */
+public class PhysicalLinkTarget implements IQuery {
+
+  @Override
+  public List<Object> compute(Object object) {
+    if (object instanceof PhysicalLink) {
+      PhysicalLink link = (PhysicalLink) object;
+      Port port = PhysicalLinkExt.getTargetPort(link);
+      if (null != port) {
+        return Collections.singletonList(port);
+      }
+    }
+    return Collections.emptyList();
+  }
+
+}

--- a/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalPortOwner.java
+++ b/core/plugins/org.polarsys.capella.core.semantic.queries/src/org/polarsys/capella/core/semantic/queries/basic/queries/PhysicalPortOwner.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2023 THALES GLOBAL SERVICES.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+* 
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*    Thales - initial API and implementation
+*******************************************************************************/
+package org.polarsys.capella.core.semantic.queries.basic.queries;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.polarsys.capella.common.helpers.query.IQuery;
+import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.cs.PhysicalPort;
+
+/**
+ * return container of a @PhysicalPort
+ */
+public class PhysicalPortOwner implements IQuery {
+
+  @Override
+  public List<Object> compute(Object object) {
+    if (object instanceof PhysicalPort) {
+      PhysicalPort pp = (PhysicalPort) object;
+      EObject eContainer = pp.eContainer();
+      if (eContainer instanceof Component) {
+        return Collections.singletonList(eContainer);
+      }
+    }
+    return Collections.emptyList();
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/model/SemanticQueries.java
@@ -314,6 +314,7 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String LA__LOGICAL_CAPABILITY_TRACE = "2922b720-9b9c-4103-b404-43308630e9e3";
   public static final String LA__LOGICAL_CAPABILITY_TRACE_SOURCE = "7f696210-08b4-492f-b9f4-26912aa5b5fd";
   public static final String LA__LOGICAL_CAPABILITY_TRACE_TARGET = "055865bd-7993-4d80-adc5-819088a2b53b";
+
   public static final String PA = "8f178984-e6cf-46de-870f-05dcdbaa0025";
   public static final String PA__PHYSICAL_FUNCTIONS = "31d0ecd3-6548-4a0a-b86c-85b43638d4e9";
   public static final String PA__FUNCTIONAL_CHAIN = "29dc7bfc-e5c5-4db7-801c-3ccfa47c793e";
@@ -363,10 +364,11 @@ public abstract class SemanticQueries extends AbstractSemanticQueryTestCase {
   public static final String PA__PF1_FOP1 = "fdd9e69e-179c-43f7-a9f8-0e52b74a6fae";
   public static final String PA__PF2_FIP1 = "a7f4d482-bb03-4302-aa03-b22c0506fcc8";
   public static final String PA__FE1 = "6fd8df09-4eec-4b53-a6cd-38e5522c453a";
-  public static final String PA__FS_CAPABILITY1 ="a76a6e35-c557-4e4c-b848-62a72b71f5ca";
+  public static final String PA__FS_CAPABILITY1 = "a76a6e35-c557-4e4c-b848-62a72b71f5ca";
   public static final String PA__ES_CAPABILITY1 = "2a0f6fef-c411-480c-be22-8f0231ece3f4";
   public static final String PA__ES_CAPABILITY1_COPY = "c8da3939-669c-4812-b425-4fece2136f49";
-  public static final String PA__ES_SCENARIO_INVOKING_FUNCTIONS= "ebeabdd3-7411-4420-b739-0f5fda85d79f";
+  public static final String PA__ES_SCENARIO_INVOKING_FUNCTIONS = "ebeabdd3-7411-4420-b739-0f5fda85d79f";
+
   public static final String EPBS = "1729bd4c-a4d2-48c2-ac5e-cf84172ae391";
   public static final String EPBS__CAPABILITIES = "51981734-92ce-4076-8ef2-702a1097fc2b";
   public static final String EPBS__CAPABILITIES__CAPABILITY_2 = "94e2e370-1828-4bf8-ad0b-80d8e6e22898";

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/PhysicalLinkSourceTest.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/PhysicalLinkSourceTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+* Copyright (c) 2023 THALES GLOBAL SERVICES.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+* 
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*    Thales - initial API and implementation
+*******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+public class PhysicalLinkSourceTest extends SemanticQueries {
+  private final String QUERY = "org.polarsys.capella.core.semantic.queries.PhysicalLinkSource";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQueryIncludingItemQueries(PA__PHYSICAL_LINK_1, PA__PHYSICAL_PORT_1, PA__PC1);
+  }
+
+}

--- a/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/PhysicalLinkTargetTest.java
+++ b/tests/plugins/org.polarsys.capella.test.semantic.queries.ju/src/org/polarsys/capella/test/semantic/queries/ju/testcases/PhysicalLinkTargetTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+* Copyright (c) 2023 THALES GLOBAL SERVICES.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+* 
+* SPDX-License-Identifier: EPL-2.0
+* 
+* Contributors:
+*    Thales - initial API and implementation
+*******************************************************************************/
+package org.polarsys.capella.test.semantic.queries.ju.testcases;
+
+import org.polarsys.capella.test.semantic.queries.ju.model.SemanticQueries;
+
+public class PhysicalLinkTargetTest extends SemanticQueries {
+  private final String QUERY = "org.polarsys.capella.core.semantic.queries.PhysicalLinkTarget";
+
+  @Override
+  protected String getQueryCategoryIdentifier() {
+    return QUERY;
+  }
+
+  @Override
+  public void test() throws Exception {
+    testQueryIncludingItemQueries(PA__PHYSICAL_LINK_1, PA__PHYSICAL_PORT_2, PA__PC2);
+  }
+}


### PR DESCRIPTION
add port and owner of the port of a physical link in referenced and referencing elements within semantic browser.
add junit
