### PR TITLE
#2691 Fix Usage.log path and name in Linux/macOS

### DIFF
--- a/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage/src/org/polarsys/capella/common/tools/report/appenders/usage/util/UsageAppender.java
+++ b/common/plugins/org.polarsys.capella.common.tools.report.appenders.usage/src/org/polarsys/capella/common/tools/report/appenders/usage/util/UsageAppender.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.polarsys.capella.common.tools.report.appenders.usage.util;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.apache.log4j.RollingFileAppender;
@@ -25,7 +26,7 @@ public class UsageAppender extends RollingFileAppender {
     super(new UsageLayout(), getFileName());
     setMaxFileSize("20MB");
     setMaxBackupIndex(30);
-    
+
     addFilter(new Filter() {
       @Override
       public int decide(LoggingEvent arg0) {
@@ -35,6 +36,6 @@ public class UsageAppender extends RollingFileAppender {
   }
 
   private static String getFileName() {
-    return System.getProperty(UsageMonitoringLogger.USAGE_PATH)+ "\\Usage.log";
+    return System.getProperty(UsageMonitoringLogger.USAGE_PATH) + File.separator + "Usage.log";
   }
 }


### PR DESCRIPTION
Bug: https://github.com/eclipse/capella/issues/2691