### PR TITLE
Fix disable.nebula.richtext property.

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/DescriptionPropertySection.java
+++ b/core/plugins/org.polarsys.capella.core.ui.properties.richtext/src/org/polarsys/capella/core/ui/properties/richtext/sections/DescriptionPropertySection.java
@@ -169,6 +169,8 @@ public abstract class DescriptionPropertySection extends AbstractSection {
   @Override
   public void loadData(EObject object) {
     super.loadData(object);
-    descriptionGroup.setBaseHrefPath(MDERichTextHelper.getProjectPath(object));
+    if (RichtextManager.getInstance().isRichTextEnabled()) {
+      descriptionGroup.setBaseHrefPath(MDERichTextHelper.getProjectPath(object));
+    }
   }
 }


### PR DESCRIPTION
In v6.1.0, I am trying to work around #2316 by using the line
```
disable.nebula.richtext=true
```
in my config.ini file. When I do that, I get errors at runtime from this call to setBaseHREF.

I have also found that it is impossible to build v6.1.0 right now, because Sirius 7.1.0 has gone missing from the distribution site. Here is the patch I needed to make to be able to build this at all:

```
diff --git a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
index 56d2674f9b..fedd4e6d0b 100644
--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -64,7 +64,7 @@ location Xerces-2.12.2 "https://download.eclipse.org/modeling/gmp/gmf-runtime/up
        org.apache.xerces
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/7.1.0-S20230302-034329/2021-06" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/7.2.0-S20230616-100446/2023-03" {
        org.eclipse.sirius.doc.feature.feature.group
        org.eclipse.sirius.doc.feature.source.feature.group
        org.eclipse.sirius.runtime.source.feature.group
```

I am hoping that maybe this dependency is cached on the build server, and that this PR will build anyway.