### PR TITLE
#2765 Update the layout port action labels

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/CapellaMessages.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/CapellaMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2016, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,9 +19,14 @@ import org.eclipse.osgi.util.NLS;
  */
 public class CapellaMessages extends NLS {
   private static final String BUNDLE_NAME = "org.polarsys.capella.core.sirius.analysis.activator.messages"; //$NON-NLS-1$
+
+  public static String ArrangeBorderNodesAction_actionDiagramText;
   public static String ArrangeBorderNodesAction_actionText;
   public static String ArrangeBorderNodesAction_commandLabel;
+  public static String ArrangeBorderNodesAction_toolbarActionDiagramText;
   public static String ArrangeBorderNodesAction_toolbarActionText;
+  public static String ArrangeBorderNodesAction_toolTipDiagramText;
+  public static String ArrangeBorderNodesAction_toolTipText;
   
   static {
     // initialize resource bundle

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/SiriusViewActivator.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/SiriusViewActivator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -68,9 +68,13 @@ public class SiriusViewActivator extends AbstractUIPlugin {
     viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin("/" + ID + "/description/EPBS.odesign")); //$NON-NLS-1$ //$NON-NLS-2$
 
     // Modify palette tool name with a custom end user label
+    Messages.ArrangeBorderNodesAction_actionDiagramText = CapellaMessages.ArrangeBorderNodesAction_actionDiagramText;
     Messages.ArrangeBorderNodesAction_actionText = CapellaMessages.ArrangeBorderNodesAction_actionText;
     Messages.ArrangeBorderNodesAction_commandLabel = CapellaMessages.ArrangeBorderNodesAction_commandLabel;
+    Messages.ArrangeBorderNodesAction_toolbarActionDiagramText = CapellaMessages.ArrangeBorderNodesAction_toolbarActionDiagramText;
     Messages.ArrangeBorderNodesAction_toolbarActionText = CapellaMessages.ArrangeBorderNodesAction_toolbarActionText;
+    Messages.ArrangeBorderNodesAction_toolTipDiagramText = CapellaMessages.ArrangeBorderNodesAction_toolTipDiagramText;
+    Messages.ArrangeBorderNodesAction_toolTipText = CapellaMessages.ArrangeBorderNodesAction_toolTipText;
 
     // Initialize preference values
     new DiagramProcessChainPathPreferenceInitializer();

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/messages.properties
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/activator/messages.properties
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright (c) 2016, 2020 THALES GLOBAL SERVICES.
+# Copyright (c) 2016, 2023 THALES GLOBAL SERVICES.
 # 
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License 2.0 which is available at
@@ -10,6 +10,11 @@
 # Contributors:
 #    Thales - initial API and implementation
 #===============================================================================
-ArrangeBorderNodesAction_actionText=Ports
-ArrangeBorderNodesAction_commandLabel=Arrange Connected Ports
-ArrangeBorderNodesAction_toolbarActionText=Arrange Connected Ports
+
+ArrangeBorderNodesAction_actionDiagramText=All Connected Ports
+ArrangeBorderNodesAction_actionText=Connected Ports
+ArrangeBorderNodesAction_commandLabel=Layout Connected Ports
+ArrangeBorderNodesAction_toolbarActionDiagramText=Layout All Connected Ports
+ArrangeBorderNodesAction_toolbarActionText=Layout Connected Ports
+ArrangeBorderNodesAction_toolTipDiagramText=Layout all the connected ports of the diagram.
+ArrangeBorderNodesAction_toolTipText=Layout the connected ports of the selected elements.

--- a/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
+++ b/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform
@@ -21,7 +21,7 @@ location GMF-Notation-1.13.1 "https://download.eclipse.org/modeling/gmp/gmf-nota
     org.eclipse.gmf.runtime.notation.sdk.feature.group lazy
 }
 
-location GMF-Runtime-1.16 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202309010720/" {
+location GMF-Runtime-1.16 "https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/interim/I202312121900/" {
     org.eclipse.gmf.runtime.sdk.feature.group lazy
     org.eclipse.gmf.runtime.thirdparty.feature.group lazy
 }
@@ -62,11 +62,14 @@ location Mylyn-3.26 "https://download.eclipse.org/mylyn/releases/3.26/" {
 	org.eclipse.mylyn.help.ui [3.26.0,3.27.0)
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/2023-03/" {
+location Orbit-2023-03 "https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/" {
+	org.slf4j.api
 	ch.qos.logback.slf4j
+    ch.qos.logback.classic
+    ch.qos.logback.core
 }
 
-location sirius "https://download.eclipse.org/sirius/updates/stable/7.3.0-S20230929-065140/2023-03" {
+location sirius "https://download.eclipse.org/sirius/updates/stable/7.4.0-S20240102-123506/2023-03" {
 	org.eclipse.sirius.doc.feature.feature.group
 	org.eclipse.sirius.doc.feature.source.feature.group
 	org.eclipse.sirius.runtime.source.feature.group


### PR DESCRIPTION
This PR depends on https://github.com/eclipse-sirius/sirius-desktop/pull/142 and must therefore be merged after updating a TP that points to a version of Sirius that incorporates the commits of https://github.com/eclipse-sirius/sirius-desktop/pull/142.