### PR TITLE
#2717 Fix NPE in Semantic Browser.

### DIFF
--- a/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/view/SemanticBrowserView.java
+++ b/core/plugins/org.polarsys.capella.core.ui.semantic.browser/src/org/polarsys/capella/core/ui/semantic/browser/view/SemanticBrowserView.java
@@ -841,7 +841,9 @@ public abstract class SemanticBrowserView extends ViewPart implements ISemanticB
         .getBoolean(CapellaBrowserPreferences.PREFS_DISABLE_SEMANTIC_BROWSER_SYNC_ON_STARTUP);
 
     if (isListeningOnStartup && null != memento) {
-      isListeningOnStartup = memento.getInteger(LISTENING_TO_WORKBENCH_PAGE_SELECTION_EVENTS) == 1;
+      Integer listeningValue = memento.getInteger(LISTENING_TO_WORKBENCH_PAGE_SELECTION_EVENTS);
+      // From old workbench or linux or macos, null may be provided.
+      isListeningOnStartup = listeningValue != null && listeningValue == 1;
     }
     if (isListeningOnStartup) {
       activateListeningToPageSelectionEvents();


### PR DESCRIPTION
#2717  On linux and macos, memento of Semantic Browser may not have all properties.
This leads the view to crash.